### PR TITLE
Fix server crash on stop

### DIFF
--- a/src/bin/calaos_server/main.cpp
+++ b/src/bin/calaos_server/main.cpp
@@ -122,6 +122,10 @@ int main (int argc, char **argv)
 
     srand(time(NULL));
 
+    //Ensure calling order of destructors
+    ListeRule::Instance();
+    ListeRoom::Instance();
+
     //init ecore system
     eina_init();
     ecore_init();


### PR DESCRIPTION
Prevent wrong order of static members deletion.
As Input/Ouput signal is connected to ListeRule instance, ListeRoom
instance must be destroyed *before* ListeRule instance.
Otherwise it could cause memory fault.