### PR TITLE
Removed all using namespace directives

### DIFF
--- a/src/bin/calaos_home/ApplicationMain.cpp
+++ b/src/bin/calaos_home/ApplicationMain.cpp
@@ -30,7 +30,7 @@
 #include "ScreenSuspendView.h"
 #include "Prefix.h"
 
-string ApplicationMain::theme = "";
+std::string ApplicationMain::theme = "";
 
 static void _window_resize_cb(void *data, Evas *e, Evas_Object *obj, void *event_info)
 {
@@ -71,25 +71,25 @@ ApplicationMain::ApplicationMain(int argc, char **argv)
 
     //Init efl core
     if (!eina_init())
-        throw (runtime_error("Unable to init Eina"));
+        throw (std::runtime_error("Unable to init Eina"));
     if (!ecore_init())
-        throw (runtime_error("Unable to init Ecore"));
+        throw (std::runtime_error("Unable to init Ecore"));
     if (!ecore_con_init())
-        throw (runtime_error("Unable to init Ecore-Con"));
+        throw (std::runtime_error("Unable to init Ecore-Con"));
     if (!ecore_con_url_init())
-        throw (runtime_error("Unable to init Ecore-Con-Url"));
+        throw (std::runtime_error("Unable to init Ecore-Con-Url"));
     if (!evas_init())
-        throw (runtime_error("Unable to init Evas"));
+        throw (std::runtime_error("Unable to init Evas"));
     if (!ecore_evas_init())
-        throw (runtime_error("Unable to init Ecore-Evas"));
+        throw (std::runtime_error("Unable to init Ecore-Evas"));
     if (!edje_init())
-        throw (runtime_error("Unable to init Edje"));
+        throw (std::runtime_error("Unable to init Edje"));
 
     edje_frametime_set(1.0 / 60.0);
     edje_scale_set(1.0);
 
     if (!elm_init(argc, argv))
-        throw (runtime_error("Unable to init Elementary"));
+        throw (std::runtime_error("Unable to init Elementary"));
 
     //Load Calaos specific ELM extensions
     elm_theme_extension_add(NULL, ApplicationMain::getTheme());
@@ -137,12 +137,12 @@ ApplicationMain::ApplicationMain(int argc, char **argv)
     layout = elm_layout_add(window);
     if (!elm_layout_file_set(layout, ApplicationMain::getTheme(), EDJE_GROUP_MAIN_LAYOUT))
     {
-        string e = "Unable to find group \"";
+        std::string e = "Unable to find group \"";
         e += EDJE_GROUP_MAIN_LAYOUT;
         e += "\" in theme \"";
         e += ApplicationMain::getTheme();
         e += "\"";
-        throw (runtime_error(e));
+        throw (std::runtime_error(e));
     }
 
     //create the screen suspend object and put it on the canvas
@@ -163,7 +163,7 @@ ApplicationMain::ApplicationMain(int argc, char **argv)
     {
         controller = new ApplicationController(evas, layout);
     }
-    catch(exception const& e)
+    catch(std::exception const& e)
     {
         cCritical() <<  "Can't create ApplicationController";
         throw;

--- a/src/bin/calaos_home/ApplicationMain.h
+++ b/src/bin/calaos_home/ApplicationMain.h
@@ -35,7 +35,6 @@
 
 #include "ScenarioModel.h"
 
-using namespace Utils;
 
 #define EDJE_GROUP_MAIN_LAYOUT  "calaos/main/layout"
 
@@ -55,7 +54,7 @@ private:
     //The main application controller
     ApplicationController *controller;
 
-    static string theme;
+    static std::string theme;
 
     ApplicationMain(int argc, char **argv);
 public:
@@ -77,12 +76,12 @@ public:
     }
 
     //type is 0 for UTF-8 text, 1 is for keeping evas textblock markup instead
-    void ShowKeyboard(string subtitle, ActivityKeyboardCb callback, bool multiline, string oldtext = "", int type = 0)
+    void ShowKeyboard(std::string subtitle, ActivityKeyboardCb callback, bool multiline, std::string oldtext = "", int type = 0)
     {
         if (controller) controller->ShowKeyboard(subtitle, callback, multiline, oldtext, type);
     }
 
-    void ShowWebBrowser(string url = "")
+    void ShowWebBrowser(std::string url = "")
     {
         if (controller) controller->ShowWebBrowser(url);
     }

--- a/src/bin/calaos_home/CalaosCameraView.cpp
+++ b/src/bin/calaos_home/CalaosCameraView.cpp
@@ -21,18 +21,18 @@ Eina_Bool _url_data_cb(void *data, int type, void *event_info)
         EINA_LIST_FOREACH(headers, l, str)
         {
             if (!str) continue;
-            string s((char *)str);
+            std::string s((char *)str);
 
-            vector<string> tokens;
+            std::vector<std::string> tokens;
             Utils::replace_str(s, "\n", "");
             Utils::replace_str(s, "\r", "");
             Utils::split(s, tokens, ":", 2);
 
-            string key = tokens[0];
+            std::string key = tokens[0];
             Utils::trim_left(key, " ");
             Utils::trim_right(key, " ");
 
-            string val = tokens[1];
+            std::string val = tokens[1];
             Utils::trim_left(val, " ");
             Utils::trim_right(val, " ");
 
@@ -131,7 +131,7 @@ void CalaosCameraView::SmartClipUnset()
     evas_object_clip_unset(clip);
 }
 
-void CalaosCameraView::setCameraUrl(const string &url)
+void CalaosCameraView::setCameraUrl(const std::string &url)
 {
     cameraUrl = url;
 }
@@ -196,7 +196,7 @@ void CalaosCameraView::processData()
         }
 
         //get boundary
-        boundary = string((char *)&buffer[0], end);
+        boundary = std::string((char *)&buffer[0], end);
 
         cDebugDom("camera") << "Found boundary \"" << boundary << "\"";
 
@@ -216,7 +216,7 @@ void CalaosCameraView::processData()
 
             if (len > 15)
             {
-                string s((char *)&buffer[i], len);
+                std::string s((char *)&buffer[i], len);
                 if (Utils::strStartsWith(s, "Content-Length", Utils::CaseInsensitive))
                 {
                     Utils::from_string(s.substr(15), nextContentLength);

--- a/src/bin/calaos_home/CalaosCameraView.h
+++ b/src/bin/calaos_home/CalaosCameraView.h
@@ -7,7 +7,6 @@
 #include <Ecore_Con.h>
 #include <Params.h>
 
-using namespace std;
 
 class CalaosCameraView: public EvasSmart
 {
@@ -15,20 +14,20 @@ private:
     Evas_Object *clip = nullptr;
     Evas_Object *camImage = nullptr;
 
-    string cameraUrl;
+    std::string cameraUrl;
 
     Ecore_Con_Url *ecurl = nullptr;
 
     Ecore_Event_Handler *handler_data = nullptr;
     Ecore_Event_Handler *handler_complete = nullptr;
 
-    vector<unsigned char> buffer;
+    std::vector<unsigned char> buffer;
     Params headers;
 
     bool formatDetected;
     bool single_frame;
     bool format_error;
-    string boundary;
+    std::string boundary;
     long int nextContentLength;
     long int nextDataStart;
     long int scanpos;
@@ -44,7 +43,7 @@ public:
     CalaosCameraView(Evas *evas);
     virtual ~CalaosCameraView();
 
-    void setCameraUrl(const string &url);
+    void setCameraUrl(const std::string &url);
 
     void play();
     void stop();

--- a/src/bin/calaos_home/CalaosConnection.cpp
+++ b/src/bin/calaos_home/CalaosConnection.cpp
@@ -20,9 +20,9 @@
  ******************************************************************************/
 #include "CalaosConnection.h"
 
-string CalaosConnection::calaosServerIp = string();
+std::string CalaosConnection::calaosServerIp = std::string();
 
-CalaosCmd::CalaosCmd(CommandDone_cb cb, void *d, CalaosConnection *p, const string &id):
+CalaosCmd::CalaosCmd(CommandDone_cb cb, void *d, CalaosConnection *p, const std::string &id):
     callback(cb),
     user_data(d),
     msgid(id),
@@ -35,7 +35,7 @@ CalaosCmd::CalaosCmd(CommandDone_cb cb, void *d, CalaosConnection *p, const stri
     });
 }
 
-CalaosConnection::CalaosConnection(string h):
+CalaosConnection::CalaosConnection(std::string h):
     con_state(CALAOS_CON_NONE),
     host(h),
     timeout(NULL)
@@ -60,7 +60,7 @@ CalaosConnection::~CalaosConnection()
     delete wsocket;
 }
 
-void CalaosConnection::getCredentials(string &username, string &password)
+void CalaosConnection::getCredentials(std::string &username, std::string &password)
 {
     //Get username/password
     username = Utils::get_config_option("calaos_user");
@@ -81,8 +81,8 @@ void CalaosConnection::onConnected()
         con_state = CALAOS_CON_LOGIN;
 
         //Get username/password
-        string username;
-        string password;
+        std::string username;
+        std::string password;
         getCredentials(username, password);
 
         json_t *jlogin = json_pack("{s:s, s:s}",
@@ -110,7 +110,7 @@ void CalaosConnection::onDisconnected()
     cCriticalDom("network.connection") << "Connection closed !";
 }
 
-void CalaosConnection::sendJson(const string &msg_type, json_t *jdata, const string &client_id)
+void CalaosConnection::sendJson(const std::string &msg_type, json_t *jdata, const std::string &client_id)
 {
     json_t *jroot = json_object();
     json_object_set_new(jroot, "msg", json_string(msg_type.c_str()));
@@ -122,7 +122,7 @@ void CalaosConnection::sendJson(const string &msg_type, json_t *jdata, const str
     wsocket->sendTextMessage(jansson_to_string(jroot));
 }
 
-void CalaosConnection::onMessageReceived(const string &data)
+void CalaosConnection::onMessageReceived(const std::string &data)
 {
     Params jsonRoot;
     Params jsonData;
@@ -187,7 +187,7 @@ void CalaosConnection::onMessageReceived(const string &data)
     {
         Params eventData;
         jansson_decode_object(json_object_get(jdata, "data"), eventData);
-        string ev = jsonData["type_str"];
+        std::string ev = jsonData["type_str"];
 
         if (ev == "io_added")
             notify_io_new.emit(ev, eventData);
@@ -257,16 +257,16 @@ void CalaosConnection::timeoutSend(CalaosCmd *cmd)
     }
 }
 
-void CalaosConnection::sendCommand(const string &msg, const Params &param)
+void CalaosConnection::sendCommand(const std::string &msg, const Params &param)
 {
     sendJson(msg, param.toJson());
 }
 
-void CalaosConnection::sendCommand(const string &msg, const Params &param,
+void CalaosConnection::sendCommand(const std::string &msg, const Params &param,
                                    CommandDone_cb callback,
                                    void *data)
 {
-    string clientid = Utils::to_string(rand() & 0xffff);
+    std::string clientid = Utils::to_string(rand() & 0xffff);
     while (commands.find(clientid) != commands.end())
         clientid = Utils::to_string(rand() & 0xffff);
 
@@ -275,11 +275,11 @@ void CalaosConnection::sendCommand(const string &msg, const Params &param,
     sendJson(msg, param.toJson(), clientid);
 }
 
-void CalaosConnection::sendCommand(const string &msg, json_t *jdata,
+void CalaosConnection::sendCommand(const std::string &msg, json_t *jdata,
                                    CommandDone_cb callback,
                                    void *data)
 {
-    string clientid = Utils::to_string(rand() & 0xffff);
+    std::string clientid = Utils::to_string(rand() & 0xffff);
     while (commands.find(clientid) != commands.end())
         clientid = Utils::to_string(rand() & 0xffff);
 

--- a/src/bin/calaos_home/CalaosConnection.h
+++ b/src/bin/calaos_home/CalaosConnection.h
@@ -30,7 +30,6 @@
 #include "Jansson_Addition.h"
 #include "WebSocketClient.h"
 
-using namespace Utils;
 
 #define TIMEOUT_CONNECT         60.0
 #define TIMEOUT_SEND            60.0
@@ -42,13 +41,13 @@ class CalaosConnection;
 class CalaosCmd
 {
 public:
-    CalaosCmd(CommandDone_cb cb, void *d, CalaosConnection *p, const string &id);
+    CalaosCmd(CommandDone_cb cb, void *d, CalaosConnection *p, const std::string &id);
     CalaosCmd(const CalaosCmd &other) = delete;
     ~CalaosCmd() { delete timeout; }
 
     CommandDone_cb callback = [](json_t*, void*){ /* no callback */ };
     void *user_data = nullptr;
-    string msgid;
+    std::string msgid;
 
 private:
     EcoreTimer *timeout = nullptr;
@@ -62,11 +61,11 @@ private:
 
     int con_state;
 
-    string host;
+    std::string host;
 
     EcoreTimer *timeout;
 
-    unordered_map<string, CalaosCmd *> commands;
+    std::unordered_map<std::string, CalaosCmd *> commands;
 
     WebSocketClient *wsocket;
 
@@ -76,20 +75,20 @@ private:
 
     void onConnected();
     void onDisconnected();
-    void onMessageReceived(const string &msg);
+    void onMessageReceived(const std::string &msg);
 
-    static string calaosServerIp;
+    static std::string calaosServerIp;
 
 public:
-    CalaosConnection(string host);
+    CalaosConnection(std::string host);
     ~CalaosConnection();
 
-    void sendJson(const string &msg_type, json_t *jdata, const string &client_id = string());
-    void sendCommand(const string &msg, const Params &param);
-    void sendCommand(const string &msg, const Params &param,
+    void sendJson(const std::string &msg_type, json_t *jdata, const std::string &client_id = std::string());
+    void sendCommand(const std::string &msg, const Params &param);
+    void sendCommand(const std::string &msg, const Params &param,
                      CommandDone_cb callback,
                      void *data = nullptr);
-    void sendCommand(const string &msg, json_t *jdata,
+    void sendCommand(const std::string &msg, json_t *jdata,
                      CommandDone_cb callback,
                      void *data = nullptr);
 
@@ -99,28 +98,28 @@ public:
     sigc::signal<void> connection_ok;
 
     //const string &msg_type, json_t *data, const string &client_id
-    sigc::signal<void, const string &, json_t *, const string &> messageReceived;
+    sigc::signal<void, const std::string &, json_t *, const std::string &> messageReceived;
 
     /* Events signals */
 
     //RoomModel signals
-    sigc::signal<void, const string &, const Params &> notify_io_change;
-    sigc::signal<void, const string &, const Params &> notify_io_new;
-    sigc::signal<void, const string &, const Params &> notify_io_delete;
-    sigc::signal<void, const string &, const Params &> notify_room_change;
-    sigc::signal<void, const string &, const Params &> notify_room_new;
-    sigc::signal<void, const string &, const Params &> notify_room_delete;
+    sigc::signal<void, const std::string &, const Params &> notify_io_change;
+    sigc::signal<void, const std::string &, const Params &> notify_io_new;
+    sigc::signal<void, const std::string &, const Params &> notify_io_delete;
+    sigc::signal<void, const std::string &, const Params &> notify_room_change;
+    sigc::signal<void, const std::string &, const Params &> notify_room_new;
+    sigc::signal<void, const std::string &, const Params &> notify_room_delete;
 
     //AudioModel signals
-    sigc::signal<void, const string &, const Params &> notify_audio_change;
+    sigc::signal<void, const std::string &, const Params &> notify_audio_change;
 
     //ScenarioModel signals
-    sigc::signal<void, const string &, const Params &> notify_scenario_add;
-    sigc::signal<void, const string &, const Params &> notify_scenario_del;
-    sigc::signal<void, const string &, const Params &> notify_scenario_change;
+    sigc::signal<void, const std::string &, const Params &> notify_scenario_add;
+    sigc::signal<void, const std::string &, const Params &> notify_scenario_del;
+    sigc::signal<void, const std::string &, const Params &> notify_scenario_change;
 
-    static void getCredentials(string &user, string &pass);
-    static string getCalaosServerIp() { return calaosServerIp; }
+    static void getCredentials(std::string &user, std::string &pass);
+    static std::string getCalaosServerIp() { return calaosServerIp; }
 };
 
 #endif // CALAOSCONNECTION_H

--- a/src/bin/calaos_home/CalaosDiscover.cpp
+++ b/src/bin/calaos_home/CalaosDiscover.cpp
@@ -68,7 +68,7 @@ void CalaosDiscover::timerDiscover()
 {
     cDebugDom("network") << "try to discover server...";
 
-    string packet = "CALAOS_DISCOVER";
+    std::string packet = "CALAOS_DISCOVER";
     if (!ecore_con_server_send(econ_sender, packet.c_str(), packet.length()))
     {
         econ_sender = ecore_con_server_connect(ECORE_CON_REMOTE_BROADCAST, "0.0.0.0", BCAST_UDP_PORT, this);
@@ -80,7 +80,7 @@ void CalaosDiscover::dataGet(Ecore_Con_Server *server, void *data, int size)
 {
     if (server != econ) return;
 
-    string msg((char *)data, size);
+    std::string msg((char *)data, size);
 
     cDebugDom("network") << "some data arrived msg: \"" << msg << "\"";
 

--- a/src/bin/calaos_home/CalaosDiscover.h
+++ b/src/bin/calaos_home/CalaosDiscover.h
@@ -30,7 +30,6 @@
 #include <EcoreTimer.h>
 #include <CalaosConnection.h>
 
-using namespace Utils;
 
 class CalaosDiscover: public sigc::trackable
 {
@@ -39,7 +38,7 @@ public:
     void dataGet(Ecore_Con_Server *server, void *data, int size);
 
 private:
-    string address;
+    std::string address;
     Ecore_Con_Server *econ;
     Ecore_Con_Server *econ_sender;
 
@@ -58,8 +57,8 @@ public:
     CalaosDiscover();
     ~CalaosDiscover();
 
-    sigc::signal<void, string> server_found;
-    sigc::signal<void, string> login_error;
+    sigc::signal<void, std::string> server_found;
+    sigc::signal<void, std::string> login_error;
 };
 
 #endif // CALAOSDISCOVER_H

--- a/src/bin/calaos_home/CommonUtils.cpp
+++ b/src/bin/calaos_home/CommonUtils.cpp
@@ -21,7 +21,6 @@
 #include "CommonUtils.h"
 #include <Elementary.h>
 
-using namespace Utils;
 
 Evas_Object *Utils::createPaddingTable(Evas *evas, Evas_Object *parent, int w, int h, int padding_top_bottom, int padding_side)
 {

--- a/src/bin/calaos_home/CommonUtils.h
+++ b/src/bin/calaos_home/CommonUtils.h
@@ -21,8 +21,8 @@
 #ifndef COMMONUTILS_H
 #define COMMONUTILS_H
 
-#include <Evas.h>
 #include <Utils.h>
+#include <Evas.h>
 
 namespace Utils
 {

--- a/src/bin/calaos_home/EdjeObject.cpp
+++ b/src/bin/calaos_home/EdjeObject.cpp
@@ -25,7 +25,7 @@ static void _edje_del(void *data, Evas *e , Evas_Object *obj, void *event_info);
 static void _edje_show(void *data, Evas *e , Evas_Object *obj, void *event_info);
 static void _edje_hide(void *data, Evas *e , Evas_Object *obj, void *event_info);
 
-EdjeObject::EdjeObject(string &_theme, Evas *_evas):
+EdjeObject::EdjeObject(std::string &_theme, Evas *_evas):
     theme(_theme),
     evas(_evas),
     autodelete(false)
@@ -64,10 +64,10 @@ EdjeObject::EdjeObject(const char *_theme, Evas *_evas):
 EdjeObject::~EdjeObject()
 {
     //deletes all swallowed objs
-    for_each(swallow_eobjs.begin(), swallow_eobjs.end(), Delete());
-    for_each(swallow_objs.begin(), swallow_objs.end(), DeleteEvasObject());
+    for_each(swallow_eobjs.begin(), swallow_eobjs.end(), Utils::Delete());
+    for_each(swallow_objs.begin(), swallow_objs.end(), Utils::DeleteEvasObject());
 
-    vector<EdjeCallbackData *>::iterator iter = callbacks.begin();
+    std::vector<EdjeCallbackData *>::iterator iter = callbacks.begin();
 
     for (;callbacks.size() > 0 && iter != callbacks.end();iter++)
     {
@@ -92,7 +92,7 @@ EdjeObject::~EdjeObject()
     DELETE_NULL_FUNC(evas_object_del, edje)
 }
 
-bool EdjeObject::LoadEdje(string c)
+bool EdjeObject::LoadEdje(std::string c)
 {
     CHECK_EDJE_RETURN(false)
 
@@ -100,7 +100,7 @@ bool EdjeObject::LoadEdje(string c)
     if (edje_object_file_set(edje, theme.c_str(), collection.c_str()) == 0)
     {
         int err = edje_object_load_error_get(edje);
-        string serr = "EdjeObject::LoadEdje(" + theme + ", " + collection + ") - ";
+        std::string serr = "EdjeObject::LoadEdje(" + theme + ", " + collection + ") - ";
         switch (err)
         {
         case EDJE_LOAD_ERROR_NONE: serr += "No Error."; break;
@@ -116,7 +116,7 @@ bool EdjeObject::LoadEdje(string c)
         case EDJE_LOAD_ERROR_RECURSIVE_REFERENCE: serr += "Recursive reference"; break;
         }
 
-        throw (runtime_error(serr));
+        throw (std::runtime_error(serr));
 
         return false;
     }
@@ -131,18 +131,18 @@ void EdjeObject::getGeometry(int *x, int *y, int *w, int *h)
             evas_object_geometry_get(edje, x, y, w, h);
 }
 
-string EdjeObject::getPartText(string part)
+std::string EdjeObject::getPartText(std::string part)
 {
     CHECK_EDJE_RETURN("")
 
             const char *txt = edje_object_part_text_get(edje, part.c_str());
     if (txt)
-        return string(txt);
+        return std::string(txt);
 
     return "";
 }
 
-void EdjeObject::Swallow(EdjeObject *obj, string part, bool delete_on_del)
+void EdjeObject::Swallow(EdjeObject *obj, std::string part, bool delete_on_del)
 {
     CHECK_EDJE_RETURN();
     edje_object_part_swallow(edje, part.c_str(), obj->getEvasObject());
@@ -151,7 +151,7 @@ void EdjeObject::Swallow(EdjeObject *obj, string part, bool delete_on_del)
         swallow_eobjs.push_back(obj);
 }
 
-void EdjeObject::Swallow(Evas_Object *obj, string part, bool delete_on_del)
+void EdjeObject::Swallow(Evas_Object *obj, std::string part, bool delete_on_del)
 {
     CHECK_EDJE_RETURN();
     edje_object_part_swallow(edje, part.c_str(), obj);
@@ -160,7 +160,7 @@ void EdjeObject::Swallow(Evas_Object *obj, string part, bool delete_on_del)
         swallow_objs.push_back(obj);
 }
 
-sigc::connection *EdjeObject::addCallback(string source, string signal, EdjeCallBack slot_cb, void *user_data)
+sigc::connection *EdjeObject::addCallback(std::string source, std::string signal, EdjeCallBack slot_cb, void *user_data)
 {
     CHECK_EDJE_RETURN(NULL)
 
@@ -182,7 +182,7 @@ void EdjeObject::delCallback(sigc::connection *connection)
 {
     CHECK_EDJE_RETURN()
 
-            vector<EdjeCallbackData *>::iterator iter = callbacks.begin();
+    std::vector<EdjeCallbackData *>::iterator iter = callbacks.begin();
 
     for (;iter != callbacks.end();iter++)
     {
@@ -201,7 +201,7 @@ void EdjeObject::delCallback(sigc::connection *connection)
 
 void EdjeObject::_evasObjectDeleted()
 {
-    for_each(callbacks.begin(), callbacks.end(), Delete());
+  for_each(callbacks.begin(), callbacks.end(), Utils::Delete());
 
     //Remove del callback here, because we NULL the edje pointer after that
     evas_object_event_callback_del_full(edje, EVAS_CALLBACK_DEL, _edje_del, this);

--- a/src/bin/calaos_home/EdjeObject.h
+++ b/src/bin/calaos_home/EdjeObject.h
@@ -27,8 +27,7 @@
 #include <Utils.h>
 #include <CommonUtils.h>
 
-using namespace Utils;
-
+//
 /* Edje signal callback
    Prototype is callback(void *data, Evas_Object *edje_object, string emission, string source)
 */
@@ -40,8 +39,8 @@ typedef struct _EdjeCallbackData: public sigc::trackable
     EdjeCallBackSignal signal_cb;
     sigc::connection connection;
     void *user_data;
-    string signal;
-    string source;
+    std::string signal;
+    std::string source;
 } EdjeCallbackData;
 
 #define CHECK_EDJE_RETURN(...) \
@@ -59,30 +58,30 @@ public:
     void _evasObjectHide();
 
 protected:
-    string theme; //Edje theme filename
-    string collection; //Edje collection group
+    std::string theme; //Edje theme filename
+    std::string collection; //Edje collection group
 
     Evas *evas;
     Evas_Object *edje; //The edje object
 
-    vector<EdjeCallbackData *> callbacks;
+    std::vector<EdjeCallbackData *> callbacks;
 
     bool autodelete; //autodelete EdjeObject if Evas_Object is deleted. Be carefull with this
 
-    list<Evas_Object *> swallow_objs;
-    list<EdjeObject *> swallow_eobjs;
+    std::list<Evas_Object *> swallow_objs;
+    std::list<EdjeObject *> swallow_eobjs;
 
     virtual void objectDeleted() { }
     virtual void objectShown() { }
     virtual void objectHidden() { }
 
 public:
-    EdjeObject(string &_theme, Evas *_evas);
+    EdjeObject(std::string &_theme, Evas *_evas);
     EdjeObject(const char *_theme, Evas *_evas);
     virtual ~EdjeObject();
 
     //load the edje file
-    bool LoadEdje(string collection);
+    bool LoadEdje(std::string collection);
 
     virtual void Show() { CHECK_EDJE_RETURN() evas_object_show(edje); }
     virtual void Hide() { CHECK_EDJE_RETURN() evas_object_hide(edje); }
@@ -96,27 +95,27 @@ public:
     void setLayer(int i) { CHECK_EDJE_RETURN() evas_object_layer_set(edje, i); }
     int getLayer() { CHECK_EDJE_RETURN(0) return evas_object_layer_get(edje); }
 
-    void EmitSignal(string signal, string source) { CHECK_EDJE_RETURN() edje_object_signal_emit(edje, signal.c_str(), source.c_str()); }
+    void EmitSignal(std::string signal, std::string source) { CHECK_EDJE_RETURN() edje_object_signal_emit(edje, signal.c_str(), source.c_str()); }
 
-    void setPartText(string part, string text) { CHECK_EDJE_RETURN() edje_object_part_text_set(edje, part.c_str(), text.c_str()); }
-    string getPartText(string part);
+    void setPartText(std::string part, std::string text) { CHECK_EDJE_RETURN() edje_object_part_text_set(edje, part.c_str(), text.c_str()); }
+    std::string getPartText(std::string part);
 
-    void setDragValue(string part, double x, double y) { CHECK_EDJE_RETURN() edje_object_part_drag_value_set(edje, part.c_str(), x, y); }
-    void getDragValue(string part, double *x, double *y) { CHECK_EDJE_RETURN() edje_object_part_drag_value_get(edje, part.c_str(), x, y); }
+    void setDragValue(std::string part, double x, double y) { CHECK_EDJE_RETURN() edje_object_part_drag_value_set(edje, part.c_str(), x, y); }
+    void getDragValue(std::string part, double *x, double *y) { CHECK_EDJE_RETURN() edje_object_part_drag_value_get(edje, part.c_str(), x, y); }
 
-    void Swallow(EdjeObject *obj, string part, bool delete_on_del = false);
-    void Swallow(Evas_Object *obj, string part, bool delete_on_del = false);
+    void Swallow(EdjeObject *obj, std::string part, bool delete_on_del = false);
+    void Swallow(Evas_Object *obj, std::string part, bool delete_on_del = false);
 
     Evas_Object *getEvasObject() { CHECK_EDJE_RETURN(NULL) return edje; }
 
-    void setTheme(string &_theme) { theme = _theme; }
+    void setTheme(std::string &_theme) { theme = _theme; }
 
-    string getCollection() { return collection; }
+    std::string getCollection() { return collection; }
 
     void setAutoDelete(bool autodel) { autodelete = autodel; }
     bool getAutoDelete() { return autodelete; }
 
-    sigc::connection *addCallback(string source, string signal, EdjeCallBack slot_cb, void *user_data = NULL);
+    sigc::connection *addCallback(std::string source, std::string signal, EdjeCallBack slot_cb, void *user_data = NULL);
     void delCallback(sigc::connection *connection);
 
     /* Object was deleted */

--- a/src/bin/calaos_home/EvasSmart.cpp
+++ b/src/bin/calaos_home/EvasSmart.cpp
@@ -19,7 +19,6 @@
  **
  ******************************************************************************/
 #include <EvasSmart.h>
-using namespace std;
 
 static void _smart_add(Evas_Object *o);
 static void _smart_del(Evas_Object *o);
@@ -34,7 +33,7 @@ static void _smart_calculate(Evas_Object * o);
 static void _smart_member_add(Evas_Object * o, Evas_Object *child);
 static void _smart_member_del(Evas_Object * o, Evas_Object *child);
 
-EvasSmart::EvasSmart(Evas *evas, string evas_smart_type):
+EvasSmart::EvasSmart(Evas *evas, std::string evas_smart_type):
     evas_object(NULL),
     smart_object(NULL),
     member_count(0)
@@ -45,14 +44,14 @@ EvasSmart::EvasSmart(Evas *evas, string evas_smart_type):
     evas_object_smart_data_set(evas_object, this);
 }
 
-Evas_Smart *EvasSmart::EvasSmartClassCreate(string evas_smart_type)
+Evas_Smart *EvasSmart::EvasSmartClassCreate(std::string evas_smart_type)
 {
-    static std::map<string, Evas_Smart *> SmartObjects;
-    static std::map<string, Evas_Smart_Class> SmartClasses;
+    static std::map<std::string, Evas_Smart *> SmartObjects;
+    static std::map<std::string, Evas_Smart_Class> SmartClasses;
 
     //try to find the smart class
     //if not found create a new one
-    map<string, Evas_Smart *>::iterator fter = SmartObjects.find(evas_smart_type);
+    std::map<std::string, Evas_Smart *>::iterator fter = SmartObjects.find(evas_smart_type);
     if (fter != SmartObjects.end())
         return SmartObjects[evas_smart_type];
 

--- a/src/bin/calaos_home/Modules.cpp
+++ b/src/bin/calaos_home/Modules.cpp
@@ -56,7 +56,7 @@ void ModuleManager::SearchModules()
         EINA_LIST_FOREACH(subdir, l, data)
         {
             fname = (char *)data;
-            string p;
+            std::string p;
 
             p = search_paths[i];
 
@@ -108,13 +108,13 @@ void ModuleManager::SearchModules()
                     continue;
                 }
 
-                string module_name;
-                vector<string> tok;
+                std::string module_name;
+                std::vector<std::string> tok;
                 Utils::split(p, tok, "/");
                 if (tok.size() > 2)
                     module_name = tok[tok.size() - 2];
 
-                string themepath = Prefix::Instance().dataDirectoryGet();
+                std::string themepath = Prefix::Instance().dataDirectoryGet();
                 themepath += "/widgets/" + module_name;
 
                 ModuleDef mdef;
@@ -144,17 +144,17 @@ void ModuleManager::SearchModules()
     }
 }
 
-bool ModuleManager::createModuleInstance(Evas *evas, ModuleDef &type, ModuleDef &mdef, string id)
+bool ModuleManager::createModuleInstance(Evas *evas, ModuleDef &type, ModuleDef &mdef, std::string id)
 {
     if (!type.handle || !type.api) return false;
 
-    string module_name;
-    vector<string> tok;
+    std::string module_name;
+    std::vector<std::string> tok;
     Utils::split(type.mod_fname, tok, "/");
     if (tok.size() > 2)
         module_name = tok[tok.size() - 2];
 
-    string themepath = Prefix::Instance().dataDirectoryGet();
+    std::string themepath = Prefix::Instance().dataDirectoryGet();
     themepath += "/widgets/" + module_name;
 
     CalaosModuleBase *cmod = type.api->create_object(evas, id.c_str(), themepath.c_str());
@@ -192,7 +192,7 @@ void ModuleManager::DeleteInstance(ModuleDef &mod)
 
     if (!mod.inst) return;
 
-    vector<ModuleDef>::iterator it = mods_inst.begin();
+    std::vector<ModuleDef>::iterator it = mods_inst.begin();
     for (int i = 0;i < instanceSize();i++, it++)
     {
         if (mod.inst == mods_inst[i].inst)
@@ -225,9 +225,9 @@ CalaosModuleBase *ModuleManager::getModuleInstance(ModuleDef &mod)
     return NULL;
 }
 
-vector<ModuleDef> ModuleManager::getModuleInstances(string mod_fname)
+std::vector<ModuleDef> ModuleManager::getModuleInstances(std::string mod_fname)
 {
-    vector<ModuleDef> mods;
+    std::vector<ModuleDef> mods;
 
     for (int i = 0;i < instanceSize();i++)
     {

--- a/src/bin/calaos_home/Modules.h
+++ b/src/bin/calaos_home/Modules.h
@@ -28,7 +28,6 @@
 #include <Ecore_File.h>
 #include <CalaosModule.h>
 
-using namespace std;
 
 class ModuleDef
 {
@@ -39,14 +38,14 @@ public:
         api(NULL), inst(NULL), handle(NULL)
     {}
 
-    string mod_name; // module name as returned by module->getName()
-    string mod_author; // module name as returned by module->getName()
-    string mod_desc; // module description as returned by module->getDescription()
-    string mod_version; // module version as returned by module->getVersion()
-    string mod_icon; // module icon, this is the filename + path of an edje file containing the module icon
+    std::string mod_name; // module name as returned by module->getName()
+    std::string mod_author; // module name as returned by module->getName()
+    std::string mod_desc; // module description as returned by module->getDescription()
+    std::string mod_version; // module version as returned by module->getVersion()
+    std::string mod_icon; // module icon, this is the filename + path of an edje file containing the module icon
     // The group "icon" is loaded from the edje file. If nothing is found, it take the
     // default icon from the main theme.
-    string mod_fname; //module filename
+    std::string mod_fname; //module filename
 
     CalaosModuleApi *api;
 
@@ -62,13 +61,13 @@ private:
     ~ModuleManager();
 
     //search paths
-    vector<string> search_paths;
+    std::vector<std::string> search_paths;
 
     //all running modules are stored here
-    vector<ModuleDef> mods_inst;
+    std::vector<ModuleDef> mods_inst;
 
     //all loadable modules are listed here
-    vector<ModuleDef> modules;
+    std::vector<ModuleDef> modules;
 
 public:
     static ModuleManager &Instance()
@@ -78,16 +77,16 @@ public:
         return mmanager;
     }
 
-    void addPath(string path) { search_paths.push_back(path); }
+    void addPath(std::string path) { search_paths.push_back(path); }
 
     // Search for loadable modules in paths
     void SearchModules();
 
     // Get all available modules
-    vector<ModuleDef> getAvailableModules() { return modules; }
+    std::vector<ModuleDef> getAvailableModules() { return modules; }
 
     // Create a new instance of mod_fname
-    bool createModuleInstance(Evas *evas, ModuleDef &type, ModuleDef &mdef, string id);
+    bool createModuleInstance(Evas *evas, ModuleDef &type, ModuleDef &mdef, std::string id);
 
     // Delete a module instance
     void DeleteInstance(ModuleDef &mod);
@@ -96,7 +95,7 @@ public:
     CalaosModuleBase *getModuleInstance(ModuleDef &mod);
 
     // Get all instance for a specific module type
-    vector<ModuleDef> getModuleInstances(string mod_fname);
+    std::vector<ModuleDef> getModuleInstances(std::string mod_fname);
 
     //total number of modules instance
     int instanceSize() { return mods_inst.size(); }

--- a/src/bin/calaos_home/WebSocketClient.h
+++ b/src/bin/calaos_home/WebSocketClient.h
@@ -33,29 +33,29 @@ public:
     WebSocketClient();
     virtual ~WebSocketClient();
 
-    sigc::signal<void, const string &> textMessageReceived;
-    sigc::signal<void, const string &> binaryMessageReceived;
+    sigc::signal<void, const std::string &> textMessageReceived;
+    sigc::signal<void, const std::string &> binaryMessageReceived;
     sigc::signal<void> websocketDisconnected;
     sigc::signal<void> websocketConnected;
 
-    void openConnection(string url);
+    void openConnection(std::string url);
 
-    void sendPing(const string &data);
-    void sendCloseFrame(uint16_t code = WebSocketFrame::CloseCodeNormal, const string &reason = string(), bool forceClose = false);
+    void sendPing(const std::string &data);
+    void sendCloseFrame(uint16_t code = WebSocketFrame::CloseCodeNormal, const std::string &reason = std::string(), bool forceClose = false);
 
-    void sendTextMessage(const string &data);
-    void sendBinaryMessage(const string &data);
+    void sendTextMessage(const std::string &data);
+    void sendBinaryMessage(const std::string &data);
 
 private:
     enum { WSConnecting, WSOpened, WSClosing, WSClosed };
     int status = WSClosed;
 
-    string wsUrl;
+    std::string wsUrl;
 
-    string recv_buffer;
+    std::string recv_buffer;
     WebSocketFrame currentFrame;
 
-    string currentData;
+    std::string currentData;
     int currentOpcode;
 
     bool isfragmented = false;
@@ -74,15 +74,15 @@ private:
 
     bool checkCloseStatusCode(uint16_t code);
 
-    void sendFrameData(const string &data, bool isbinary);
+    void sendFrameData(const std::string &data, bool isbinary);
 
     Ecore_Con_Server *ecoreServer = nullptr;
 
-    bool gotNewDataHandshake(const string &data);
-    void gotNewData(const string &data);
+    bool gotNewDataHandshake(const std::string &data);
+    void gotNewData(const std::string &data);
 
     void CloseConnection();
-    void sendToServer(string res);
+    void sendToServer(std::string res);
 
     Ecore_Event_Handler *handler_add;
     Ecore_Event_Handler *handler_data;
@@ -96,20 +96,20 @@ private:
     friend Eina_Bool WebSocketClient_con_error(void *data, int type, void *event);
     friend Eina_Bool WebSocketClient_con_data_written(void *data, int type, void *event);
 
-    string handshakeHeader;
-    string sec_key;
+    std::string handshakeHeader;
+    std::string sec_key;
 
     http_parser_settings parser_settings;
     http_parser *parser;
 
     bool parse_done = false;
-    unordered_map<string, string> request_headers;
+    std::unordered_map<std::string, std::string> request_headers;
 
     //for parsing purposes
     bool has_field = false, has_value = false;
-    string hfield, hvalue;
-    string bodymessage;
-    string parse_url;
+    std::string hfield, hvalue;
+    std::string bodymessage;
+    std::string parse_url;
 
     friend int _parser_begin(http_parser *parser);
     friend int _parser_header_field(http_parser *parser, const char *at, size_t length);

--- a/src/bin/calaos_home/controllers/ActivityAudioListController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityAudioListController.cpp
@@ -71,7 +71,7 @@ void ActivityAudioListController::updatePageView()
 {
     ActivityAudioListView *audioView = dynamic_cast<ActivityAudioListView *>(view);
 
-    list<AudioPlayer *>::iterator it = CalaosModel::Instance().getAudio()->players.begin();
+    std::list<AudioPlayer *>::iterator it = CalaosModel::Instance().getAudio()->players.begin();
     int i = 0;
 
     for (int j = 0;j < page * 3;j++)
@@ -137,7 +137,7 @@ void ActivityAudioListController::clickRight()
     parentController->setButtonMode("mode,back");
 }
 
-void ActivityAudioListController::doneCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void ActivityAudioListController::doneCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     updatePageView();
 }
@@ -149,7 +149,7 @@ void ActivityAudioListController::playerSelectCallback(AudioPlayer *player)
     parentController->setButtonMode("mode,audio_detail");
 }
 
-bool ActivityAudioListController::handleButtonClick(string button)
+bool ActivityAudioListController::handleButtonClick(std::string button)
 {
     if (button == "button.audio.back")
     {

--- a/src/bin/calaos_home/controllers/ActivityAudioListController.h
+++ b/src/bin/calaos_home/controllers/ActivityAudioListController.h
@@ -27,7 +27,6 @@
 #include "ActivityAudioListView.h"
 #include "AudioModel.h"
 
-using namespace Utils;
 
 class ActivityMediaController;
 
@@ -49,14 +48,14 @@ private:
 
     void load_done();
 
-    void doneCallback(void *data, Evas_Object *edje_object, string emission, string source);
+    void doneCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source);
     void playerSelectCallback(AudioPlayer *player);
 
 public:
     ActivityAudioListController(Evas *evas, Evas_Object *parent, ActivityMediaController *parentController);
     ~ActivityAudioListController();
 
-    virtual bool handleButtonClick(string button);
+    virtual bool handleButtonClick(std::string button);
 };
 
 #endif // ACTIVITYAUDIOLISTCONTROLLER_H

--- a/src/bin/calaos_home/controllers/ActivityCameraListController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityCameraListController.cpp
@@ -74,7 +74,7 @@ void ActivityCameraListController::updatePageView()
 {
     ActivityCameraListView *cameraView = dynamic_cast<ActivityCameraListView *>(view);
 
-    list<Camera *>::iterator it = CalaosModel::Instance().getCamera()->cameras.begin();
+    std::list<Camera *>::iterator it = CalaosModel::Instance().getCamera()->cameras.begin();
     int i = 0;
 
     for (int j = 0;j < page * 4;j++)
@@ -116,10 +116,10 @@ void ActivityCameraListController::updateScenarios()
 {
     ActivityCameraListView *cameraView = dynamic_cast<ActivityCameraListView *>(view);
 
-    const list<IOBase *> &scenarios = CalaosModel::Instance().getHome()->getCacheScenariosPref();
-    list<IOBase *> _page;
+    const std::list<IOBase *> &scenarios = CalaosModel::Instance().getHome()->getCacheScenariosPref();
+    std::list<IOBase *> _page;
 
-    list<IOBase *>::const_iterator it = scenarios.begin();
+    std::list<IOBase *>::const_iterator it = scenarios.begin();
     for (int i = 0;it != scenarios.end();it++, i++)
     {
         IOBase *io = *it;
@@ -165,12 +165,12 @@ void ActivityCameraListController::clickRight()
     cameraView->EmitSignal("hide,left", "calaos");
 }
 
-void ActivityCameraListController::doneCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void ActivityCameraListController::doneCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     updatePageView();
 }
 
-void ActivityCameraListController::cameraSelectCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void ActivityCameraListController::cameraSelectCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     if (emission.substr(0, 7) == "select,")
         emission = emission.erase(0, 7);
@@ -180,7 +180,7 @@ void ActivityCameraListController::cameraSelectCallback(void *data, Evas_Object 
     if ((page * 4 + position - 1) >= (int)CalaosModel::Instance().getCamera()->cameras.size())
         return;
 
-    list<Camera *>::iterator it = CalaosModel::Instance().getCamera()->cameras.begin();
+    std::list<Camera *>::iterator it = CalaosModel::Instance().getCamera()->cameras.begin();
     for (int j = 0;j < page * 4 + position - 1;j++)
         it++;
 

--- a/src/bin/calaos_home/controllers/ActivityCameraListController.h
+++ b/src/bin/calaos_home/controllers/ActivityCameraListController.h
@@ -28,7 +28,6 @@
 #include "CalaosModel.h"
 #include "ActivityCameraSelectController.h"
 
-using namespace Utils;
 
 class ActivityMediaController;
 
@@ -50,8 +49,8 @@ private:
 
     void load_done();
 
-    void doneCallback(void *data, Evas_Object *edje_object, string emission, string source);
-    void cameraSelectCallback(void *data, Evas_Object *edje_object, string emission, string source);
+    void doneCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void cameraSelectCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source);
 
 public:
     ActivityCameraListController(Evas *evas, Evas_Object *parent, ActivityMediaController *parentController);

--- a/src/bin/calaos_home/controllers/ActivityCameraSelectController.h
+++ b/src/bin/calaos_home/controllers/ActivityCameraSelectController.h
@@ -27,7 +27,6 @@
 #include "ActivityCameraSelectView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityCameraSelectController: public ActivityController
 {

--- a/src/bin/calaos_home/controllers/ActivityConfigClockController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityConfigClockController.cpp
@@ -18,9 +18,8 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
-#include "ActivityConfigClockController.h"
-
 #include "ApplicationMain.h"
+#include "ActivityConfigClockController.h"
 
 ActivityConfigClockController::ActivityConfigClockController(Evas *e, Evas_Object *p, ActivityConfigController *pc):
     ActivityController(e, p, ActivityViewFactory::ACTIVITY_VIEW_CONFIG_CLOCK),

--- a/src/bin/calaos_home/controllers/ActivityConfigClockController.h
+++ b/src/bin/calaos_home/controllers/ActivityConfigClockController.h
@@ -28,7 +28,6 @@
 #include "CalaosModel.h"
 #include "ActivityConfigController.h"
 
-using namespace Utils;
 
 class ActivityConfigClockController: public ActivityController
 {

--- a/src/bin/calaos_home/controllers/ActivityConfigController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityConfigController.cpp
@@ -18,11 +18,11 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
+#include "ApplicationMain.h"
 #include "ActivityConfigController.h"
 #include "ActivityConfigClockController.h"
 #include "ActivityConfigPasswordController.h"
 #include "ActivityConfigScreensaverController.h"
-#include "ApplicationMain.h"
 
 ActivityConfigController::ActivityConfigController(Evas *e, Evas_Object *p):
     ActivityController(e, p, ActivityViewFactory::ACTIVITY_VIEW_CONFIG)
@@ -49,7 +49,7 @@ void ActivityConfigController::createView()
     configView->addView(mainMenuController->getView());
 }
 
-void ActivityConfigController::menuIconClick(string icon)
+void ActivityConfigController::menuIconClick(std::string icon)
 {
     if (icon == "clock")
     {
@@ -71,7 +71,7 @@ void ActivityConfigController::menuIconClick(string icon)
     }
 }
 
-void ActivityConfigController::buttonClick(string button)
+void ActivityConfigController::buttonClick(std::string button)
 {
     ActivityConfigView *configView = dynamic_cast<ActivityConfigView *>(view);
 
@@ -114,7 +114,7 @@ void ActivityConfigController::controllerFinished(ActivityController *controller
     DELETE_NULL(controller);
 }
 
-void ActivityConfigController::setButtonMode(string mode)
+void ActivityConfigController::setButtonMode(std::string mode)
 {
     ActivityConfigView *configView = dynamic_cast<ActivityConfigView *>(view);
     configView->EmitSignal(mode, "calaos");

--- a/src/bin/calaos_home/controllers/ActivityConfigController.h
+++ b/src/bin/calaos_home/controllers/ActivityConfigController.h
@@ -29,7 +29,6 @@
 
 #include "ActivityConfigMenuController.h"
 
-using namespace Utils;
 
 class ActivityConfigController: public ActivityController
 {
@@ -38,8 +37,8 @@ private:
 
     virtual void createView();
 
-    void menuIconClick(string icon);
-    void buttonClick(string button);
+    void menuIconClick(std::string icon);
+    void buttonClick(std::string button);
 
     void controllerFinished(ActivityController *controller);
 
@@ -49,7 +48,7 @@ public:
 
     void addSubController(ActivityController *controller);
 
-    void setButtonMode(string mode);
+    void setButtonMode(std::string mode);
 };
 
 #endif // ACTIVITYCONFIGCONTROLLER_H

--- a/src/bin/calaos_home/controllers/ActivityConfigMenuController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityConfigMenuController.cpp
@@ -36,6 +36,6 @@ void ActivityConfigMenuController::createView()
     ActivityController::createView();
 
     ActivityConfigMenuView *configMenuView = dynamic_cast<ActivityConfigMenuView *>(view);
-    configMenuView->menu_item_clicked.connect(sigc::mem_fun(menu_icon_click, &sigc::signal<void, string>::emit));
+    configMenuView->menu_item_clicked.connect(sigc::mem_fun(menu_icon_click, &sigc::signal<void, std::string>::emit));
 }
 

--- a/src/bin/calaos_home/controllers/ActivityConfigMenuController.h
+++ b/src/bin/calaos_home/controllers/ActivityConfigMenuController.h
@@ -27,7 +27,6 @@
 #include "ActivityConfigMenuView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityConfigMenuController: public ActivityController
 {
@@ -38,7 +37,7 @@ public:
     ActivityConfigMenuController(Evas *evas, Evas_Object *parent);
     ~ActivityConfigMenuController();
 
-    sigc::signal<void, string> menu_icon_click;
+    sigc::signal<void, std::string> menu_icon_click;
 };
 
 #endif // ACTIVITYCONFIGMENUCONTROLLER_H

--- a/src/bin/calaos_home/controllers/ActivityConfigPasswordController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityConfigPasswordController.cpp
@@ -18,9 +18,9 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
+#include "ApplicationMain.h"
 #include "ActivityConfigPasswordController.h"
 
-#include "ApplicationMain.h"
 
 ActivityConfigPasswordController::ActivityConfigPasswordController(Evas *e, Evas_Object *p):
     ActivityController(e, p, ActivityViewFactory::ACTIVITY_VIEW_CONFIG_PASSWORD)

--- a/src/bin/calaos_home/controllers/ActivityConfigPasswordController.h
+++ b/src/bin/calaos_home/controllers/ActivityConfigPasswordController.h
@@ -26,7 +26,6 @@
 #include "ActivityController.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityConfigPasswordController: public ActivityController
 {

--- a/src/bin/calaos_home/controllers/ActivityConfigScreensaverController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityConfigScreensaverController.cpp
@@ -18,9 +18,8 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
-#include "ActivityConfigScreensaverController.h"
-
 #include "ApplicationMain.h"
+#include "ActivityConfigScreensaverController.h"
 
 ActivityConfigScreensaverController::ActivityConfigScreensaverController(Evas *e, Evas_Object *p):
     ActivityController(e, p, ActivityViewFactory::ACTIVITY_VIEW_CONFIG_SCREENSAVER)

--- a/src/bin/calaos_home/controllers/ActivityConfigScreensaverController.h
+++ b/src/bin/calaos_home/controllers/ActivityConfigScreensaverController.h
@@ -26,7 +26,6 @@
 #include "ActivityController.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityConfigScreensaverController: public ActivityController
 {

--- a/src/bin/calaos_home/controllers/ActivityController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityController.cpp
@@ -48,7 +48,7 @@ void ActivityController::createView()
     {
         view = ActivityViewFactory::CreateView(evas, parent, viewType);
     }
-    catch (exception const& e)
+    catch (std::exception const& e)
     {
         cCritical() <<  "Can't create view !";
         throw;

--- a/src/bin/calaos_home/controllers/ActivityController.h
+++ b/src/bin/calaos_home/controllers/ActivityController.h
@@ -33,7 +33,6 @@
 
 #include "ActivityView.h"
 
-using namespace Utils;
 
 class ActivityController: public sigc::trackable
 {
@@ -57,7 +56,7 @@ public:
     sigc::signal<void> wants_quit;
     sigc::signal<void, ActivityController *> view_deleted;
 
-    virtual bool handleButtonClick(string button) { return false; }
+    virtual bool handleButtonClick(std::string button) { return false; }
 
 };
 

--- a/src/bin/calaos_home/controllers/ActivityEditScenarioController.h
+++ b/src/bin/calaos_home/controllers/ActivityEditScenarioController.h
@@ -27,7 +27,6 @@
 #include "ActivityEditScenarioView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityEditScenarioController: public ActivityController
 {

--- a/src/bin/calaos_home/controllers/ActivityHomeController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityHomeController.cpp
@@ -90,7 +90,7 @@ void ActivityHomeController::clickRoomRight()
 void ActivityHomeController::updatePageView()
 {
     ActivityHomeView *homeView = dynamic_cast<ActivityHomeView *>(view);
-    list<Room *>::iterator it = CalaosModel::Instance().getHome()->rooms_type.begin();
+    std::list<Room *>::iterator it = CalaosModel::Instance().getHome()->rooms_type.begin();
     int i = 0;
 
     for (int j = 0;j < page * 6;j++)
@@ -148,13 +148,13 @@ void ActivityHomeController::updateScenarios()
 {
     ActivityHomeView *homeView = dynamic_cast<ActivityHomeView *>(view);
 
-    const list<IOBase *> &scenarios = CalaosModel::Instance().getHome()->getCacheScenariosPref();
-    list<IOBase *> _page;
+    const std::list<IOBase *> &scenarios = CalaosModel::Instance().getHome()->getCacheScenariosPref();
+    std::list<IOBase *> _page;
 
     //Add the status page first
     homeView->addStatusPage();
 
-    list<IOBase *>::const_iterator it = scenarios.begin();
+    std::list<IOBase *>::const_iterator it = scenarios.begin();
     for (int i = 0;it != scenarios.end();it++, i++)
     {
         IOBase *io = *it;
@@ -183,8 +183,8 @@ void ActivityHomeController::scenarioReload(Scenario *sc)
     ActivityHomeView *homeView = dynamic_cast<ActivityHomeView *>(view);
     if (!homeView) return;
 
-    const list<IOBase *> &scenarios = CalaosModel::Instance().getHome()->getCacheScenariosPref();
-    list<IOBase *> _page;
+    const std::list<IOBase *> &scenarios = CalaosModel::Instance().getHome()->getCacheScenariosPref();
+    std::list<IOBase *> _page;
 
     int currentpage = homeView->getCurrentPage();
 
@@ -196,7 +196,7 @@ void ActivityHomeController::scenarioReload(Scenario *sc)
         homeView->removePage(1);
     }
 
-    list<IOBase *>::const_iterator it = scenarios.begin();
+    std::list<IOBase *>::const_iterator it = scenarios.begin();
     for (int i = 0;it != scenarios.end();it++, i++)
     {
         IOBase *io = *it;
@@ -225,7 +225,7 @@ void ActivityHomeController::clickRoom(int selected_room)
 {
     ActivityHomeView *homeView = dynamic_cast<ActivityHomeView *>(view);
 
-    list<Room *>::iterator it = CalaosModel::Instance().getHome()->rooms_type.begin();
+    std::list<Room *>::iterator it = CalaosModel::Instance().getHome()->rooms_type.begin();
 
     for (int j = 0;j < page * 6 + selected_room &&
          it != CalaosModel::Instance().getHome()->rooms_type.end();j++)
@@ -246,7 +246,7 @@ void ActivityHomeController::lights_changed(int count)
 {
     ActivityHomeView *homeView = dynamic_cast<ActivityHomeView *>(view);
     if (!homeView) return;
-    string t;
+    std::string t;
 
     if (count <= 0)
         t = _("No lights on");
@@ -262,7 +262,7 @@ void ActivityHomeController::shutter_changed(int count)
 {
     ActivityHomeView *homeView = dynamic_cast<ActivityHomeView *>(view);
     if (!homeView) return;
-    string t;
+    std::string t;
 
     if (count <= 0)
         t = _("No shutter open");

--- a/src/bin/calaos_home/controllers/ActivityHomeController.h
+++ b/src/bin/calaos_home/controllers/ActivityHomeController.h
@@ -27,7 +27,6 @@
 #include "ActivityHomeView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityHomeController: public ActivityController
 {

--- a/src/bin/calaos_home/controllers/ActivityKeyboardController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityKeyboardController.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "ActivityKeyboardController.h"
 
-ActivityKeyboardController::ActivityKeyboardController(Evas *e, Evas_Object *p, string _subtitle, ActivityKeyboardCb _cb, bool _multiline, int t):
+ActivityKeyboardController::ActivityKeyboardController(Evas *e, Evas_Object *p, std::string _subtitle, ActivityKeyboardCb _cb, bool _multiline, int t):
     ActivityController(e, p, ActivityViewFactory::ACTIVITY_VIEW_KEYBOARD),
     multiline(_multiline),
     subtitle(_subtitle),
@@ -45,7 +45,7 @@ void ActivityKeyboardController::createView()
     keyboardView->validPressed.connect(sigc::mem_fun(*this, &ActivityKeyboardController::validButtonPressed));
 }
 
-void ActivityKeyboardController::validButtonPressed(string text)
+void ActivityKeyboardController::validButtonPressed(std::string text)
 {
     ActivityKeyboardSig sig;
     sig.connect(callback);
@@ -62,7 +62,7 @@ void ActivityKeyboardController::validButtonPressed(string text)
     wants_quit.emit();
 }
 
-void ActivityKeyboardController::setText(string t)
+void ActivityKeyboardController::setText(std::string t)
 {
     if (!view) return;
 

--- a/src/bin/calaos_home/controllers/ActivityKeyboardController.h
+++ b/src/bin/calaos_home/controllers/ActivityKeyboardController.h
@@ -27,28 +27,27 @@
 #include "ActivityKeyboardView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
-typedef sigc::slot<void, string> ActivityKeyboardCb;
-typedef sigc::signal<void, string> ActivityKeyboardSig;
+typedef sigc::slot<void, std::string> ActivityKeyboardCb;
+typedef sigc::signal<void, std::string> ActivityKeyboardSig;
 
 class ActivityKeyboardController: public ActivityController
 {
 private:
     bool multiline;
-    string subtitle;
+    std::string subtitle;
     ActivityKeyboardCb callback;
     int type; //0 to get a UTF-8 string and 1 to keep evas textblock markup instead
 
     virtual void createView();
 
-    void validButtonPressed(string text);
+    void validButtonPressed(std::string text);
 
 public:
-    ActivityKeyboardController(Evas *evas, Evas_Object *parent, string subtitle, ActivityKeyboardCb callback, bool multiline, int type);
+    ActivityKeyboardController(Evas *evas, Evas_Object *parent, std::string subtitle, ActivityKeyboardCb callback, bool multiline, int type);
     ~ActivityKeyboardController();
 
-    void setText(string t);
+    void setText(std::string t);
 };
 
 #endif // ActivityKeyboardController_H

--- a/src/bin/calaos_home/controllers/ActivityMediaController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityMediaController.cpp
@@ -18,12 +18,12 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
+#include "ApplicationMain.h"
 #include "ActivityMediaController.h"
 
 #include "ActivityCameraListController.h"
 #include "ActivityAudioListController.h"
 
-#include "ApplicationMain.h"
 
 ActivityMediaController::ActivityMediaController(Evas *e, Evas_Object *p):
     ActivityController(e, p, ActivityViewFactory::ACTIVITY_VIEW_MEDIA)
@@ -50,7 +50,7 @@ void ActivityMediaController::createView()
     mediaView->addView(mainMenuController->getView());
 }
 
-void ActivityMediaController::menuIconClick(string icon)
+void ActivityMediaController::menuIconClick(std::string icon)
 {
     if (icon == "eskiss")
     {
@@ -74,7 +74,7 @@ void ActivityMediaController::menuIconClick(string icon)
     }
 }
 
-void ActivityMediaController::buttonClick(string button)
+void ActivityMediaController::buttonClick(std::string button)
 {
     ActivityMediaView *mediaView = dynamic_cast<ActivityMediaView *>(view);
 
@@ -117,7 +117,7 @@ void ActivityMediaController::controllerFinished(ActivityController *controller)
     DELETE_NULL(controller);
 }
 
-void ActivityMediaController::setButtonMode(string mode)
+void ActivityMediaController::setButtonMode(std::string mode)
 {
     ActivityMediaView *mediaView = dynamic_cast<ActivityMediaView *>(view);
     mediaView->EmitSignal(mode, "calaos");

--- a/src/bin/calaos_home/controllers/ActivityMediaController.h
+++ b/src/bin/calaos_home/controllers/ActivityMediaController.h
@@ -29,7 +29,6 @@
 
 #include "ActivityMediaMenuController.h"
 
-using namespace Utils;
 
 class ActivityMediaController: public ActivityController
 {
@@ -38,8 +37,8 @@ private:
 
     virtual void createView();
 
-    void menuIconClick(string icon);
-    void buttonClick(string button);
+    void menuIconClick(std::string icon);
+    void buttonClick(std::string button);
 
     void controllerFinished(ActivityController *controller);
 
@@ -49,7 +48,7 @@ public:
 
     void addSubController(ActivityController *controller);
 
-    void setButtonMode(string mode);
+    void setButtonMode(std::string mode);
 };
 
 #endif // ACTIVITYMEDIACONTROLLER_H

--- a/src/bin/calaos_home/controllers/ActivityMediaMenuController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityMediaMenuController.cpp
@@ -36,5 +36,5 @@ void ActivityMediaMenuController::createView()
     ActivityController::createView();
 
     ActivityMediaMenuView *mediaMenuView = dynamic_cast<ActivityMediaMenuView *>(view);
-    mediaMenuView->menu_item_clicked.connect(sigc::mem_fun(menu_icon_click, &sigc::signal<void, string>::emit));
+    mediaMenuView->menu_item_clicked.connect(sigc::mem_fun(menu_icon_click, &sigc::signal<void, std::string>::emit));
 }

--- a/src/bin/calaos_home/controllers/ActivityMediaMenuController.h
+++ b/src/bin/calaos_home/controllers/ActivityMediaMenuController.h
@@ -27,7 +27,6 @@
 #include "ActivityMediaMenuView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityMediaMenuController: public ActivityController
 {
@@ -38,7 +37,7 @@ public:
     ActivityMediaMenuController(Evas *evas, Evas_Object *parent);
     ~ActivityMediaMenuController();
 
-    sigc::signal<void, string> menu_icon_click;
+    sigc::signal<void, std::string> menu_icon_click;
 };
 
 #endif // ACTIVITYMEDIAMENUCONTROLLER_H

--- a/src/bin/calaos_home/controllers/ActivityScenariosController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityScenariosController.cpp
@@ -18,8 +18,8 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
-#include "ActivityScenariosController.h"
 #include "ApplicationMain.h"
+#include "ActivityScenariosController.h"
 
 ActivityScenariosController::ActivityScenariosController(Evas *e, Evas_Object *p):
     ActivityController(e, p, ActivityViewFactory::ACTIVITY_VIEW_SCENARIOS)

--- a/src/bin/calaos_home/controllers/ActivityScenariosController.h
+++ b/src/bin/calaos_home/controllers/ActivityScenariosController.h
@@ -27,7 +27,6 @@
 #include "ActivityScenariosView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityScenariosController: public ActivityController
 {

--- a/src/bin/calaos_home/controllers/ActivityScheduleScenarioController.h
+++ b/src/bin/calaos_home/controllers/ActivityScheduleScenarioController.h
@@ -27,7 +27,6 @@
 #include "ActivityScheduleScenarioView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityScheduleScenarioController: public ActivityController
 {

--- a/src/bin/calaos_home/controllers/ActivityWebController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityWebController.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "ActivityWebController.h"
 
-ActivityWebController::ActivityWebController(Evas *e, Evas_Object *p, string _url):
+ActivityWebController::ActivityWebController(Evas *e, Evas_Object *p, std::string _url):
     ActivityController(e, p, ActivityViewFactory::ACTIVITY_VIEW_WEB)
 {
 }

--- a/src/bin/calaos_home/controllers/ActivityWebController.h
+++ b/src/bin/calaos_home/controllers/ActivityWebController.h
@@ -27,7 +27,6 @@
 #include "ActivityWebView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityWebController: public ActivityController
 {
@@ -35,7 +34,7 @@ private:
     virtual void createView();
 
 public:
-    ActivityWebController(Evas *evas, Evas_Object *parent, string url = "");
+    ActivityWebController(Evas *evas, Evas_Object *parent, std::string url = "");
     ~ActivityWebController();
 };
 

--- a/src/bin/calaos_home/controllers/ActivityWidgetsController.cpp
+++ b/src/bin/calaos_home/controllers/ActivityWidgetsController.cpp
@@ -72,7 +72,7 @@ int ActivityWidgetsController::getWidgetCount()
     return wview->size();
 }
 
-bool ActivityWidgetsController::AddWidget(ModuleDef &mtype, int x, int y, int w, int h, string id)
+bool ActivityWidgetsController::AddWidget(ModuleDef &mtype, int x, int y, int w, int h, std::string id)
 {
     ActivityWidgetsView *wview = dynamic_cast<ActivityWidgetsView *>(view);
     if (!wview) return false;

--- a/src/bin/calaos_home/controllers/ActivityWidgetsController.h
+++ b/src/bin/calaos_home/controllers/ActivityWidgetsController.h
@@ -27,7 +27,6 @@
 #include "ActivityWidgetsView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityWidgetsController: public ActivityController
 {
@@ -43,7 +42,7 @@ public:
 
     int getWidgetCount();
 
-    bool AddWidget(ModuleDef &mtype, int x, int y, int w = 0, int h = 0, string id = "");
+    bool AddWidget(ModuleDef &mtype, int x, int y, int w = 0, int h = 0, std::string id = "");
 };
 
 #endif // ACTIVITYWIDGETSCONTROLLER_H

--- a/src/bin/calaos_home/controllers/ApplicationController.cpp
+++ b/src/bin/calaos_home/controllers/ApplicationController.cpp
@@ -18,8 +18,8 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
-#include "ApplicationController.h"
 #include "ApplicationMain.h"
+#include "ApplicationController.h"
 #include "Modules.h"
 #include "GenlistItemWidget.h"
 #include "ScreenManager.h"
@@ -47,7 +47,7 @@ ApplicationController::ApplicationController(Evas *_e, Evas_Object *_l):
         {
             mouseCursor->LoadEdje("calaos/cursor");
         }
-        catch(exception const& e)
+        catch(std::exception const& e)
         {
             cCritical() <<  "ApplicationController: Can't load mouse cursor";
             throw;
@@ -204,7 +204,7 @@ void ApplicationController::onMenuConfigClick()
     }
 }
 
-void ApplicationController::ShowKeyboard(string subtitle, ActivityKeyboardCb callback, bool multiline, string oldtext, int type)
+void ApplicationController::ShowKeyboard(std::string subtitle, ActivityKeyboardCb callback, bool multiline, std::string oldtext, int type)
 {
     if (!keyboardController)
     {
@@ -220,7 +220,7 @@ void ApplicationController::ShowKeyboard(string subtitle, ActivityKeyboardCb cal
     }
 }
 
-void ApplicationController::ShowWebBrowser(string url)
+void ApplicationController::ShowWebBrowser(std::string url)
 {
     if (!webController)
     {
@@ -332,7 +332,7 @@ void ApplicationController::onMenuAddWidgetClick()
     elm_object_style_set(popup, "calaos");
     evas_object_size_hint_min_set(popup, 300, 240);
 
-    vector<ModuleDef> mods = ModuleManager::Instance().getAvailableModules();
+    std::vector<ModuleDef> mods = ModuleManager::Instance().getAvailableModules();
 
     for (uint i = 0;i < mods.size();i++)
     {
@@ -341,7 +341,7 @@ void ApplicationController::onMenuAddWidgetClick()
         item->Append(glist);
         item->item_selected.connect([this,i,popup](void *)
         {
-            vector<ModuleDef> m = ModuleManager::Instance().getAvailableModules();
+            std::vector<ModuleDef> m = ModuleManager::Instance().getAvailableModules();
             widgetsController->AddWidget(m[i], 200, 200);
             elm_ctxpopup_dismiss(popup);
             menuView->CloseLinkMenu();
@@ -374,7 +374,7 @@ void ApplicationController::home_loaded()
     //cout << CalaosModel::Instance().toString() << endl;
 }
 
-void ApplicationController::login_failed(string host)
+void ApplicationController::login_failed(std::string host)
 {
     //TODO: Do something with that information
 }

--- a/src/bin/calaos_home/controllers/ApplicationController.h
+++ b/src/bin/calaos_home/controllers/ApplicationController.h
@@ -21,11 +21,11 @@
 #ifndef APPLICATIONCONTROLLER_H
 #define APPLICATIONCONTROLLER_H
 
+#include "EdjeObject.h"
 #include <Utils.h>
 
 #include <Evas.h>
 #include <Elementary.h>
-#include "EdjeObject.h"
 
 #include "MainMenuView.h"
 #include "MainContentView.h"
@@ -43,7 +43,6 @@
 #include "ActivityEditScenarioController.h"
 #include "ActivityScheduleScenarioController.h"
 
-using namespace Utils;
 
 class EAPI ApplicationController: public sigc::trackable
 {
@@ -80,7 +79,7 @@ private:
 
     /* CalaosModel signals */
     void home_loaded();
-    void login_failed(string host);
+    void login_failed(std::string host);
 
     void activityQuit();
     void activityKeyboardQuit();
@@ -95,8 +94,8 @@ public:
     ApplicationController(Evas *evas, Evas_Object *layout);
     ~ApplicationController();
 
-    void ShowKeyboard(string subtitle, ActivityKeyboardCb callback, bool multiline, string oldtext = "", int type = 0);
-    void ShowWebBrowser(string url);
+    void ShowKeyboard(std::string subtitle, ActivityKeyboardCb callback, bool multiline, std::string oldtext = "", int type = 0);
+    void ShowWebBrowser(std::string url);
 
     void ShowScenarioEditor(Scenario *scenario);
     void ShowScenarioSchedule(Scenario *scenario);

--- a/src/bin/calaos_home/main.cpp
+++ b/src/bin/calaos_home/main.cpp
@@ -29,26 +29,25 @@
 #include "Prefix.h"
 #include "ApplicationMain.h"
 
-using namespace Utils;
 
 static void echoVersion(char **argv)
 {
-    cout << "Calaos Version: \n\t" PACKAGE_STRING << endl;
+    std::cout << "Calaos Version: \n\t" PACKAGE_STRING << std::endl;
 }
 
 static void echoUsage(char **argv)
 {
-    cout << "Calaos Home - http://www.calaos.fr" << endl;
+    std::cout << "Calaos Home - http://www.calaos.fr" << std::endl;
     echoVersion(argv);
-    cout << _("Usage:\n\t") << argv[0] << _(" [options]") << endl;
-    cout << endl << _("\tOptions:\n");
-    cout << _("\t-h, --help\tDisplay this help.\n");
-    cout << _("\t--config <path>\tSet <path> as the directory for config files.\n");
-    cout << _("\t--cache <path>\tSet <path> as the directory for cache files.\n");
-    cout << _("\t--theme <file.edj>\tUse the given edje file instead of the default.\n");
-    cout << _("\t--set-elm-config\tForce calaos_home to set the correct elementary config options for touchscreen usage.\n");
-    cout << _("\t-v, --version\tDisplay current version and exit.\n");
-    cout << endl;
+    std::cout << _("Usage:\n\t") << argv[0] << _(" [options]") << std::endl;
+    std::cout << std::endl << _("\tOptions:\n");
+    std::cout << _("\t-h, --help\tDisplay this help.\n");
+    std::cout << _("\t--config <path>\tSet <path> as the directory for config files.\n");
+    std::cout << _("\t--cache <path>\tSet <path> as the directory for cache files.\n");
+    std::cout << _("\t--theme <file.edj>\tUse the given edje file instead of the default.\n");
+    std::cout << _("\t--set-elm-config\tForce calaos_home to set the correct elementary config options for touchscreen usage.\n");
+    std::cout << _("\t-v, --version\tDisplay current version and exit.\n");
+    std::cout << std::endl;
 }
 
 int main(int argc, char **argv)
@@ -92,7 +91,7 @@ int main(int argc, char **argv)
     {
         ApplicationMain::Instance(argc, argv).Run(); //Start main app instance
     }
-    catch(exception const& e)
+    catch(std::exception const& e)
     {
         cCritical() <<  "An exception occured: " << e.what();
     }

--- a/src/bin/calaos_home/models/AudioModel.cpp
+++ b/src/bin/calaos_home/models/AudioModel.cpp
@@ -70,7 +70,7 @@ void AudioModel::load(json_t *data)
     load_done.emit();
 }
 
-AudioPlayer *AudioModel::getForId(string id)
+AudioPlayer *AudioModel::getForId(std::string id)
 {
     if (id == "")
         return nullptr;
@@ -108,12 +108,12 @@ void AudioPlayer::audio_state_get_cb(json_t *jdata, void *data)
     if (!jplayer) return;
 
     //volume
-    string vol = jansson_string_get(jplayer, "volume");
+    std::string vol = jansson_string_get(jplayer, "volume");
     from_string(vol, volume);
     player_volume_changed.emit();
 
     //status
-    string st = jansson_string_get(jplayer, "status");
+    std::string st = jansson_string_get(jplayer, "status");
     if (st == "playing") st = "play";
     params.Add("status", st);
     player_status_changed.emit();
@@ -122,19 +122,19 @@ void AudioPlayer::audio_state_get_cb(json_t *jdata, void *data)
     if (track && json_is_object(track))
     {
         jansson_decode_object(track, current_song_info);
-        string dur = jansson_string_get(track, "duration");
+        std::string dur = jansson_string_get(track, "duration");
         from_string(dur, duration);
         current_song_info.Add("duration", Utils::time2string_digit((long)duration));
         player_track_changed.emit();
     }
 
     //playlist size
-    string pls = jansson_string_get(jplayer, "playlist_size");
+    std::string pls = jansson_string_get(jplayer, "playlist_size");
     from_string(pls, playlist_size);
     player_playlist_changed.emit();
 }
 
-void AudioPlayer::notifyChange(const string &msgtype, const Params &evdata)
+void AudioPlayer::notifyChange(const std::string &msgtype, const Params &evdata)
 {
     if (evdata["player_id"] != params["id"]) return;
 
@@ -163,7 +163,7 @@ void AudioPlayer::notifyChange(const string &msgtype, const Params &evdata)
     }
     else if (msgtype == "audio_volume_changed")
     {
-        string v = evdata["volume"];
+        std::string v = evdata["volume"];
 
         if (v[0] == '+')
         {
@@ -194,7 +194,7 @@ void AudioPlayer::notifyChange(const string &msgtype, const Params &evdata)
                     { "id", params["id"] }};
         connection->sendCommand("audio", p, [=](json_t *jdata, void *)
         {
-            string sz = jansson_string_get(jdata, "playlist_size");
+            std::string sz = jansson_string_get(jdata, "playlist_size");
             if (sz.empty()) return;
 
             int nb_added = playlist_size;
@@ -232,7 +232,7 @@ void AudioPlayer::notifyChange(const string &msgtype, const Params &evdata)
         connection->sendCommand("audio", p, [=](json_t *jdata, void *)
         {
             //playlist size
-            string sz = jansson_string_get(jdata, "playlist_size");
+            std::string sz = jansson_string_get(jdata, "playlist_size");
             if (sz.empty()) return;
             from_string(sz, playlist_size);
             player_playlist_changed.emit();
@@ -250,7 +250,7 @@ void AudioPlayer::setVolume(int _volume)
     if (_volume < 0) _volume = 0;
     if (_volume > 100) _volume = 100;
 
-    string s = "volume " + Utils::to_string(_volume);
+    std::string s = "volume " + Utils::to_string(_volume);
 
     Params p = {{ "id", params["id"] },
                 { "value", s }};
@@ -306,7 +306,7 @@ void AudioPlayer::off()
     connection->sendCommand("set_state", p);
 }
 
-string AudioPlayer::getStatus()
+std::string AudioPlayer::getStatus()
 {
     return params["status"];
 }
@@ -348,7 +348,7 @@ void AudioPlayer::timerChangeTick()
     {
         time_inprocess = false;
 
-        string s = jansson_string_get(jdata, "time_elapsed");
+        std::string s = jansson_string_get(jdata, "time_elapsed");
         if (s.empty()) return;
         from_string(s, elapsed_time);
         params.Add("time", Utils::time2string_digit((long)elapsed_time));
@@ -358,7 +358,7 @@ void AudioPlayer::timerChangeTick()
 
 void AudioPlayer::setTime(double time)
 {
-    string cmd = "time " + Utils::to_string(time);
+    std::string cmd = "time " + Utils::to_string(time);
 
     Params p = {{ "id", params["id"] },
                 { "value", cmd }};
@@ -372,7 +372,7 @@ void AudioPlayer::audio_db_stats_get_cb(json_t *jdata, void *data)
 
 void AudioPlayer::playItem(int item)
 {
-    string cmd = "playlist " + Utils::to_string(item) + " play";
+    std::string cmd = "playlist " + Utils::to_string(item) + " play";
 
     Params p = {{ "id", params["id"] },
                 { "value", cmd }};
@@ -394,7 +394,7 @@ void AudioPlayer::getPlaylistItem(int item, PlayerInfo_cb callback)
 
 void AudioPlayer::removePlaylistItem(int item)
 {
-    string cmd = "playlist " + Utils::to_string(item) + " delete";
+    std::string cmd = "playlist " + Utils::to_string(item) + " delete";
 
     Params p = {{ "id", params["id"] },
                 { "value", cmd }};
@@ -522,7 +522,7 @@ void AudioPlayer::db_default_item_list_get_cb(json_t *jdata, void *data)
 
     size_t idx;
     json_t *value;
-    list<Params> infos;
+    std::list<Params> infos;
 
     json_array_foreach(json_object_get(jdata, "items"), idx, value)
     {
@@ -610,9 +610,9 @@ void AudioPlayer::getDBPlaylistTrackCount(int playlist_id, PlayerInfo_cb callbac
                             data);
 }
 
-void AudioPlayer::playlistDelete(string id)
+void AudioPlayer::playlistDelete(std::string id)
 {
-    string cmd = "database playlist delete playlist_id:" + Utils::to_string(id);
+    std::string cmd = "database playlist delete playlist_id:" + Utils::to_string(id);
 
     Params p = {{ "id", params["id"] },
                 { "value", cmd }};
@@ -626,7 +626,7 @@ void AudioPlayer::db_album_track_count_get_cb(json_t *jdata, void *data)
 
     size_t idx;
     json_t *value;
-    string count = jansson_string_get(jdata, "count");
+    std::string count = jansson_string_get(jdata, "count");
 
     json_array_foreach(json_object_get(jdata, "items"), idx, value)
     {
@@ -673,9 +673,9 @@ void AudioPlayer::getDBAlbumCoverItem(Params &item, PlayerInfo_cb callback, int 
 {
     if (!item.Exists("cover_url")) return;
 
-    string fname = Utils::getCacheFile(".cover_cache/album_") + item["cover_id"];
+    std::string fname = Utils::getCacheFile(".cover_cache/album_") + item["cover_id"];
 
-    string cmdsize;
+    std::string cmdsize;
     switch (size)
     {
     default:
@@ -700,7 +700,7 @@ void AudioPlayer::getDBAlbumCoverItem(Params &item, PlayerInfo_cb callback, int 
     data->callback = callback;
     data->item = item;
 
-    string cmd;
+    std::string cmd;
     cmd = Prefix::Instance().binDirectoryGet();
     cmd += "calaos_thumb " + item["cover_url"] + " " + fname + " " + cmdsize;
     data->thumb_exe = ecore_exe_run(cmd.c_str(), data);
@@ -735,14 +735,14 @@ IOBase *AudioPlayer::getAmplifier()
 {
     if (!params.Exists("amp_id")) return NULL;
 
-    map<string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(params["amp_id"]);
+    std::map<std::string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(params["amp_id"]);
     if (it == CalaosModel::Instance().getHome()->getCacheIO().end())
         return NULL;
 
     return (*it).second;
 }
 
-string AudioPlayer::getAmplifierStatus(string key)
+std::string AudioPlayer::getAmplifierStatus(std::string key)
 {
     IOBase *amp = getAmplifier();
     if (!amp) return "";
@@ -750,7 +750,7 @@ string AudioPlayer::getAmplifierStatus(string key)
     return amp->params[key];
 }
 
-string AudioPlayer::itemTypeToString(int type)
+std::string AudioPlayer::itemTypeToString(int type)
 {
     switch (type)
     {
@@ -767,7 +767,7 @@ string AudioPlayer::itemTypeToString(int type)
     }
 }
 
-int AudioPlayer::itemStringToType(string type)
+int AudioPlayer::itemStringToType(std::string type)
 {
     if (type == "track_id") return DB_ITEM_TRACK;
     else if (type == "album_id") return DB_ITEM_ALBUM;
@@ -780,9 +780,9 @@ int AudioPlayer::itemStringToType(string type)
     else return DB_ITEM_NONE;
 }
 
-void AudioPlayer::addItem(int type, string id)
+void AudioPlayer::addItem(int type, std::string id)
 {
-    string cmd = "playlist add ";
+    std::string cmd = "playlist add ";
     if (type == DB_ITEM_DIRECTURL)
         cmd += id;
     else
@@ -793,9 +793,9 @@ void AudioPlayer::addItem(int type, string id)
     connection->sendCommand("set_state", p);
 }
 
-void AudioPlayer::playItem(int type, string id)
+void AudioPlayer::playItem(int type, std::string id)
 {
-    string cmd = "playlist play ";
+    std::string cmd = "playlist play ";
     if (type == DB_ITEM_DIRECTURL)
         cmd += id;
     else
@@ -862,7 +862,7 @@ void AudioPlayer::getDBPlaylistItem(int item, PlayerInfo_cb callback)
                             data);
 }
 
-void AudioPlayer::getDBFolder(string folder_id, PlayerInfoList_cb callback)
+void AudioPlayer::getDBFolder(std::string folder_id, PlayerInfoList_cb callback)
 {
     PlayerInfoData *data = new PlayerInfoData();
     data->callback_list = callback;
@@ -877,7 +877,7 @@ void AudioPlayer::getDBFolder(string folder_id, PlayerInfoList_cb callback)
                             data);
 }
 
-void AudioPlayer::getDBSearch(string search, PlayerInfoList_cb callback)
+void AudioPlayer::getDBSearch(std::string search, PlayerInfoList_cb callback)
 {
     PlayerInfoData *data = new PlayerInfoData();
     data->callback_list = callback;
@@ -892,7 +892,7 @@ void AudioPlayer::getDBSearch(string search, PlayerInfoList_cb callback)
                             data);
 }
 
-void AudioPlayer::getDBTrackInfos(string track_id, PlayerInfo_cb callback)
+void AudioPlayer::getDBTrackInfos(std::string track_id, PlayerInfo_cb callback)
 {
     PlayerInfoData *data = new PlayerInfoData();
     data->callback = callback;
@@ -919,7 +919,7 @@ void AudioPlayer::getDBAllRadio(PlayerInfoList_cb callback)
                             data);
 }
 
-void AudioPlayer::getDBRadio(string radio_id, string subitem_id, PlayerInfoList_cb callback)
+void AudioPlayer::getDBRadio(std::string radio_id, std::string subitem_id, PlayerInfoList_cb callback)
 {
     PlayerInfoData *data = new PlayerInfoData();
     data->callback_list = callback;
@@ -935,7 +935,7 @@ void AudioPlayer::getDBRadio(string radio_id, string subitem_id, PlayerInfoList_
                             data);
 }
 
-void AudioPlayer::getDBRadioSearch(string radio_id, string subitem_id, string search, PlayerInfoList_cb callback)
+void AudioPlayer::getDBRadioSearch(std::string radio_id, std::string subitem_id, std::string search, PlayerInfoList_cb callback)
 {
     PlayerInfoData *data = new PlayerInfoData();
     data->callback_list = callback;

--- a/src/bin/calaos_home/models/AudioModel.h
+++ b/src/bin/calaos_home/models/AudioModel.h
@@ -25,12 +25,11 @@
 
 #include "CalaosConnection.h"
 
-using namespace Utils;
 
 typedef sigc::slot<void, Params &> PlayerInfo_cb;
 typedef sigc::signal<void, Params &> PlayerInfo_signal;
-typedef sigc::slot<void, list<Params> &> PlayerInfoList_cb;
-typedef sigc::signal<void, list<Params> &> PlayerInfoList_signal;
+typedef sigc::slot<void, std::list<Params> &> PlayerInfoList_cb;
+typedef sigc::signal<void, std::list<Params> &> PlayerInfoList_signal;
 
 class IOBase;
 
@@ -41,7 +40,7 @@ public:
     PlayerInfoList_cb callback_list;
 
     Params item;
-    string cover_fname;
+    std::string cover_fname;
     Ecore_Exe *thumb_exe;
 };
 
@@ -62,12 +61,12 @@ private:
 
     Params db_stats;
 
-    string itemTypeToString(int type);
-    int itemStringToType(string type);
+    std::string itemTypeToString(int type);
+    int itemStringToType(std::string type);
 
     void timerChangeTick();
 
-    void notifyChange(const string &msgtype, const Params &evdata);
+    void notifyChange(const std::string &msgtype, const Params &evdata);
 
     void audio_state_get_cb(json_t *jdata, void *data);
 
@@ -100,7 +99,7 @@ public:
     double getTimeElapsed() { return elapsed_time; }
     void setTime(double t);
 
-    string getStatus();
+    std::string getStatus();
 
     int getPlaylistSize() { return playlist_size; }
 
@@ -125,20 +124,20 @@ public:
     enum { DB_ITEM_NONE = 0, DB_ITEM_TRACK, DB_ITEM_ALBUM, DB_ITEM_ARTIST,
            DB_ITEM_GENRE, DB_ITEM_YEAR, DB_ITEM_PLAYLIST, DB_ITEM_FOLDER,
            DB_ITEM_RADIO, DB_ITEM_DIRECTURL };
-    void playItem(int type, string id);
-    void addItem(int type, string id);
+    void playItem(int type, std::string id);
+    void addItem(int type, std::string id);
 
     bool hasCover();
     void getCurrentCover(PlayerInfo_cb callback);
 
     //Amplifier
     IOBase *getAmplifier();
-    string getAmplifierStatus(string key);
+    std::string getAmplifierStatus(std::string key);
 
     //Database queries
     Params &getDBStats();
 
-    void playlistDelete(string id);
+    void playlistDelete(std::string id);
 
     void getDBAlbumItem(int item, PlayerInfo_cb callback);
     void getDBArtistItem(int item, PlayerInfo_cb callback);
@@ -158,12 +157,12 @@ public:
     void getDBArtistGenreItem(int item, int genre_id, PlayerInfo_cb callback);
     void getDBPlaylistTrackItem(int playlist_id, int item, PlayerInfo_cb callback);
 
-    void getDBFolder(string folder_id, PlayerInfoList_cb callback);
-    void getDBTrackInfos(string track_id, PlayerInfo_cb callback);
+    void getDBFolder(std::string folder_id, PlayerInfoList_cb callback);
+    void getDBTrackInfos(std::string track_id, PlayerInfo_cb callback);
     void getDBAllRadio(PlayerInfoList_cb callback);
-    void getDBRadio(string radio_id, string subitem_id, PlayerInfoList_cb callback);
-    void getDBRadioSearch(string radio_id, string subitem_id, string search, PlayerInfoList_cb callback);
-    void getDBSearch(string search, PlayerInfoList_cb callback);
+    void getDBRadio(std::string radio_id, std::string subitem_id, PlayerInfoList_cb callback);
+    void getDBRadioSearch(std::string radio_id, std::string subitem_id, std::string search, PlayerInfoList_cb callback);
+    void getDBSearch(std::string search, PlayerInfoList_cb callback);
 
     enum { AUDIO_COVER_SIZE_NONE = 0, AUDIO_COVER_SIZE_SMALL, AUDIO_COVER_SIZE_MEDIUM, AUDIO_COVER_SIZE_BIG };
     void getDBAlbumCoverItem(Params &item, PlayerInfo_cb callback, int size = AUDIO_COVER_SIZE_NONE);
@@ -196,9 +195,9 @@ public:
 
     void load(json_t *data);
 
-    AudioPlayer *getForId(string id);
+    AudioPlayer *getForId(std::string id);
 
-    list<AudioPlayer *> players;
+    std::list<AudioPlayer *> players;
 
     sigc::signal<void> load_done;
 

--- a/src/bin/calaos_home/models/CalaosModel.cpp
+++ b/src/bin/calaos_home/models/CalaosModel.cpp
@@ -45,7 +45,7 @@ CalaosModel::~CalaosModel()
     DELETE_NULL(connection);
 }
 
-void CalaosModel::discover_found(string address)
+void CalaosModel::discover_found(std::string address)
 {
     server_address = address;
 
@@ -79,7 +79,7 @@ void CalaosModel::discover_found(string address)
     scenario_model->load_done.connect(sigc::mem_fun(*this, &CalaosModel::load_done));
 }
 
-void CalaosModel::discover_error_login(string address)
+void CalaosModel::discover_error_login(std::string address)
 {
     /* this has to be redispatched to the gui and ask user for username/password */
     server_address = address;
@@ -145,56 +145,56 @@ void CalaosModel::load_home_done()
     scenario_model->load(room_model->getJsonHome());
 }
 
-string CalaosModel::toString()
+std::string CalaosModel::toString()
 {
-    stringstream s;
+    std::stringstream s;
 
     if (room_model)
     {
-        for (list<Room *>::iterator i = room_model->rooms.begin();i != room_model->rooms.end();i++)
+        for (std::list<Room *>::iterator i = room_model->rooms.begin();i != room_model->rooms.end();i++)
         {
             Room *room = *i;
-            s << "[" << room->type << " - " << room->name << "] - " << room->hits << endl;
+            s << "[" << room->type << " - " << room->name << "] - " << room->hits << std::endl;
 
-            for (list<IOBase *>::iterator j = room->ios.begin();j != room->ios.end();j++)
+            for (std::list<IOBase *>::iterator j = room->ios.begin();j != room->ios.end();j++)
             {
                 IOBase *io = *j;
 
-                s << "\t" << io->params["type"] << " - " << io->params["id"] << " - " << io->params["name"] << " - " << io->params["hits"] << endl;
+                s << "\t" << io->params["type"] << " - " << io->params["id"] << " - " << io->params["name"] << " - " << io->params["hits"] << std::endl;
             }
         }
     }
 
     if (camera_model)
     {
-        for (list<Camera *>::iterator i = camera_model->cameras.begin();i != camera_model->cameras.end();i++)
+        for (std::list<Camera *>::iterator i = camera_model->cameras.begin();i != camera_model->cameras.end();i++)
         {
             Camera *camera = *i;
 
-            s << "[Camera]" << endl << "\t";
-            s << camera->params["name"] << " - " << camera->params["jpeg_url"] << endl;
+            s << "[Camera]" << std::endl << "\t";
+            s << camera->params["name"] << " - " << camera->params["jpeg_url"] << std::endl;
         }
     }
 
     if (audio_model)
     {
-        for (list<AudioPlayer *>::iterator i = audio_model->players.begin();i != audio_model->players.end();i++)
+        for (std::list<AudioPlayer *>::iterator i = audio_model->players.begin();i != audio_model->players.end();i++)
         {
             AudioPlayer *audio = *i;
 
-            s << "[Audio]" << endl << "\t";
-            s << audio->params["name"] << " - " << audio->params["id"] << endl;
+            s << "[Audio]" << std::endl << "\t";
+            s << audio->params["name"] << " - " << audio->params["id"] << std::endl;
         }
     }
 
     if (scenario_model)
     {
-        for (list<Scenario *>::iterator i = scenario_model->scenarios.begin();i != scenario_model->scenarios.end();i++)
+        for (std::list<Scenario *>::iterator i = scenario_model->scenarios.begin();i != scenario_model->scenarios.end();i++)
         {
             Scenario *sc = *i;
 
-            s << "[Scenario]" << endl << "\t";
-            s << sc->ioScenario->params["name"] << " - " << sc->ioScenario->params["id"] << endl;
+            s << "[Scenario]" << std::endl << "\t";
+            s << sc->ioScenario->params["name"] << " - " << sc->ioScenario->params["id"] << std::endl;
         }
     }
 

--- a/src/bin/calaos_home/models/CalaosModel.h
+++ b/src/bin/calaos_home/models/CalaosModel.h
@@ -31,7 +31,6 @@
 #include "AudioModel.h"
 #include "ScenarioModel.h"
 
-using namespace Utils;
 
 class CalaosModel
 {
@@ -40,15 +39,15 @@ private:
 
     CalaosDiscover *discover;
     CalaosConnection *connection;
-    string server_address;
+    std::string server_address;
 
     RoomModel *room_model;
     CameraModel *camera_model;
     AudioModel *audio_model;
     ScenarioModel *scenario_model;
 
-    void discover_found(string address);
-    void discover_error_login(string address);
+    void discover_found(std::string address);
+    void discover_error_login(std::string address);
     void connection_ok();
     void lost_connection();
 
@@ -68,7 +67,7 @@ public:
 
     ~CalaosModel();
 
-    string toString();
+    std::string toString();
 
     RoomModel *getHome() { return room_model; }
     CameraModel *getCamera() { return camera_model; }
@@ -77,7 +76,7 @@ public:
 
     bool isLoaded() { return loaded; }
 
-    sigc::signal<void, string> login_failed;
+    sigc::signal<void, std::string> login_failed;
     sigc::signal<void> home_loaded;
 };
 

--- a/src/bin/calaos_home/models/CameraModel.cpp
+++ b/src/bin/calaos_home/models/CameraModel.cpp
@@ -64,7 +64,7 @@ Room *Camera::getRoom()
 {
     if (room) return room;
 
-    map<string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(params["id"]);
+    std::map<std::string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(params["id"]);
     if (it == CalaosModel::Instance().getHome()->getCacheIO().end())
         return NULL;
 
@@ -125,13 +125,13 @@ void Camera::ZoomOut()
 void Camera::Recall(int position)
 {
     Params p = {{ "id", params["id"] },
-                { "value", string("recall ") + Utils::to_string(position) }};
+                { "value", std::string("recall ") + Utils::to_string(position) }};
     connection->sendCommand("set_state", p);
 }
 
 void Camera::Save(int position)
 {
     Params p = {{ "id", params["id"] },
-                { "value", string("save ") + Utils::to_string(position) }};
+                { "value", std::string("save ") + Utils::to_string(position) }};
     connection->sendCommand("set_state", p);
 }

--- a/src/bin/calaos_home/models/CameraModel.h
+++ b/src/bin/calaos_home/models/CameraModel.h
@@ -26,7 +26,6 @@
 #include "CalaosConnection.h"
 #include "RoomModel.h"
 
-using namespace Utils;
 
 class Camera: public sigc::trackable
 {
@@ -69,7 +68,7 @@ public:
 
     void load(json_t *data);
 
-    list<Camera *> cameras;
+    std::list<Camera *> cameras;
 
     sigc::signal<void> load_done;
 };

--- a/src/bin/calaos_home/models/RoomModel.cpp
+++ b/src/bin/calaos_home/models/RoomModel.cpp
@@ -93,7 +93,7 @@ void Room::load(json_t *data)
 {
     name = jansson_string_get(data, "name", "<unkown room name>");
     type = jansson_string_get(data, "type", "<unkown type name>");
-    string h = jansson_string_get(data, "hits", "0");
+    std::string h = jansson_string_get(data, "hits", "0");
     Utils::from_string(h, hits);
 
     json_t *items = json_object_get(data, "items");
@@ -136,7 +136,7 @@ void Room::load_io_done(IOBase *io)
     if (io->params["chauffage_id"] != "")
         model->chauffageList.push_back(io);
 
-    string _type = io->params["gui_type"];
+    std::string _type = io->params["gui_type"];
 
     if (_type == "scenario")
         model->cacheScenarios.push_back(io);
@@ -163,7 +163,7 @@ void Room::load_io_done(IOBase *io)
     {
         int value = 100;
 
-        vector<string> tokens;
+        std::vector<std::string> tokens;
         split(io->params["state"], tokens);
         if (tokens.size() > 1)
             from_string(tokens[1], value);
@@ -201,7 +201,7 @@ void Room::load_io_done(IOBase *io)
 
             json_object_foreach(jdata, key, value)
             {
-                string svalue;
+                std::string svalue;
 
                 if (json_is_string(value))
                     svalue = json_string_value(value);
@@ -223,7 +223,7 @@ void Room::updateVisibleIO()
     visible_ios.clear();
     scenario_ios.clear();
 
-    list<IOBase *>::iterator it = ios.begin();
+    std::list<IOBase *>::iterator it = ios.begin();
     for (;it != ios.end();it++)
     {
         IOBase *io = *it;
@@ -264,10 +264,10 @@ void Room::updateVisibleIO()
     scenario_ios.sort(IOHitsCompare);
 }
 
-IOBase *RoomModel::getChauffageForType(string type)
+IOBase *RoomModel::getChauffageForType(std::string type)
 {
-    list<Room *> l;
-    list<Room *>::iterator it = rooms_type.begin();
+    std::list<Room *> l;
+    std::list<Room *>::iterator it = rooms_type.begin();
 
     for (;it != rooms_type.end();it++)
     {
@@ -291,7 +291,7 @@ IOBase *RoomModel::getChauffageForType(string type)
 
 IOBase *Room::getChauffage()
 {
-    list<IOBase *>::iterator it = visible_ios.begin();
+    std::list<IOBase *>::iterator it = visible_ios.begin();
     for (;it != visible_ios.end();it++)
     {
         IOBase *io = (*it);
@@ -306,7 +306,7 @@ void RoomModel::updateRoomType()
 {
     rooms_type.clear();
 
-    list<Room *>::iterator it, itr;
+    std::list<Room *>::iterator it, itr;
     for (it = rooms.begin(); it != rooms.end();it++)
     {
         Room *room = *it;
@@ -327,19 +327,19 @@ void RoomModel::updateRoomType()
     }
 }
 
-void IOBase::sendAction(string command)
+void IOBase::sendAction(std::string command)
 {
     Params p = {{ "id", params["id"] },
                 { "value", command }};
     connection->sendCommand("set_state", p);
 }
 
-void IOBase::sendUserCommand(const string &cmd, const Params &p, CommandDone_cb callback)
+void IOBase::sendUserCommand(const std::string &cmd, const Params &p, CommandDone_cb callback)
 {   
     connection->sendCommand(cmd, p, callback);
 }
 
-void IOBase::notifyChange(const string &msgtype, const Params &evdata)
+void IOBase::notifyChange(const std::string &msgtype, const Params &evdata)
 {
     if (params["gui_type"] == "time_range" &&
         msgtype == "timerange_changed")
@@ -378,7 +378,7 @@ void IOBase::notifyChange(const string &msgtype, const Params &evdata)
     {
         for (int i = 0;i < evdata.size();i++)
         {
-            string key, val;
+            std::string key, val;
             evdata.get_item(i, key, val);
             params.Add(key, val);
         }
@@ -437,7 +437,7 @@ void IOBase::checkCacheChange()
     {
         int value = 100;
 
-        vector<string> tokens;
+        std::vector<std::string> tokens;
         split(params["state"], tokens);
         if (tokens.size() > 1)
             from_string(tokens[1], value);
@@ -467,7 +467,7 @@ void IOBase::checkCacheChange()
     }
 }
 
-void Room::notifyChange(const string &msgtype, const Params &evdata)
+void Room::notifyChange(const std::string &msgtype, const Params &evdata)
 {
     VAR_UNUSED(msgtype);
 
@@ -476,7 +476,7 @@ void Room::notifyChange(const string &msgtype, const Params &evdata)
         evdata["room_type"] == type)
     {
         //an input is deleted from this room
-        map<string, IOBase *>::const_iterator it = model->getCacheIO().find(evdata["io_id_deleted"]);
+        std::map<std::string, IOBase *>::const_iterator it = model->getCacheIO().find(evdata["io_id_deleted"]);
         if (it != model->getCacheIO().end())
         {
             IOBase *io = it->second;
@@ -517,7 +517,7 @@ void RoomModel::notifyRoomChange()
     updateRoomType();
 }
 
-void Room::notifyIOAdd(const string &msgtype, const Params &evdata)
+void Room::notifyIOAdd(const std::string &msgtype, const Params &evdata)
 {
     json_t *jreq = nullptr;
 
@@ -562,7 +562,7 @@ void Room::loadNewIOFromNotif(const Params &ioparam)
 
     load_io_done(io);
 
-    string _type = io->params["gui_type"];
+    std::string _type = io->params["gui_type"];
     if (_type == "scenario")
     {
         //Sort cached scenarios again
@@ -577,13 +577,13 @@ void Room::loadNewIOFromNotif(const Params &ioparam)
     io_added.emit(io);
 }
 
-void Room::notifyIODel(const string &msgtype, const Params &evdata)
+void Room::notifyIODel(const std::string &msgtype, const Params &evdata)
 {
     if (evdata["room_name"] != name ||
         evdata["room_type"] != type)
         return; //not for us
 
-    list<IOBase *>::iterator it;
+    std::list<IOBase *>::iterator it;
     for (it = ios.begin(); it != ios.end();it++)
     {
         IOBase *io = (*it);
@@ -607,7 +607,7 @@ void Room::notifyIODel(const string &msgtype, const Params &evdata)
                 continue;
             }
 
-            list<IOBase *>::iterator cit;
+            std::list<IOBase *>::iterator cit;
             for (cit = model->chauffageList.begin();cit != model->chauffageList.end();cit++)
             {
                 if (*cit == io)
@@ -646,7 +646,7 @@ void Room::notifyIODel(const string &msgtype, const Params &evdata)
     }
 }
 
-void RoomModel::notifyRoomAdd(const string &msgtype, const Params &evdata)
+void RoomModel::notifyRoomAdd(const std::string &msgtype, const Params &evdata)
 {
     VAR_UNUSED(msgtype);
 
@@ -662,7 +662,7 @@ void RoomModel::notifyRoomAdd(const string &msgtype, const Params &evdata)
     room_added.emit(room);
 }
 
-void RoomModel::notifyRoomDel(const string &msgtype, const Params &evdata)
+void RoomModel::notifyRoomDel(const std::string &msgtype, const Params &evdata)
 {
     VAR_UNUSED(msgtype);
 
@@ -683,11 +683,11 @@ void RoomModel::notifyRoomDel(const string &msgtype, const Params &evdata)
     }
 }
 
-list<Room *> RoomModel::getRoomsForType(string type)
+std::list<Room *> RoomModel::getRoomsForType(std::string type)
 {
-    list<Room *> rtypes;
+    std::list<Room *> rtypes;
 
-    list<Room *>::iterator it, itr;
+    std::list<Room *>::iterator it, itr;
     for (it = rooms.begin(); it != rooms.end();it++)
     {
         Room *room = *it;
@@ -708,7 +708,7 @@ IOBase *RoomModel::getConsigneFromTemp(IOBase *temp)
     if (!temp || temp->params["gui_type"] != "temp" || temp->params["chauffage_id"] == "")
         return NULL;
 
-    list<IOBase *>::iterator it;
+    std::list<IOBase *>::iterator it;
     for (it = chauffageList.begin();it != chauffageList.end();it++)
     {
         IOBase *io = (*it);
@@ -726,7 +726,7 @@ IOBase *RoomModel::getTempFromConsigne(IOBase *consigne)
     if (!consigne || consigne->params["gui_type"] != "var_int" || consigne->params["chauffage_id"] == "")
         return NULL;
 
-    list<IOBase *>::iterator it;
+    std::list<IOBase *>::iterator it;
     for (it = chauffageList.begin();it != chauffageList.end();it++)
     {
         IOBase *io = (*it);
@@ -739,9 +739,9 @@ IOBase *RoomModel::getTempFromConsigne(IOBase *consigne)
     return NULL;
 }
 
-map<Room *, list<IOBase *> > RoomModel::getLightsOnForRooms()
+std::map<Room *, std::list<IOBase *> > RoomModel::getLightsOnForRooms()
 {
-    map<Room *, list<IOBase *> > lmap;
+    std::map<Room *, std::list<IOBase *> > lmap;
 
     RoomIOCache::iterator it = cacheLightsOn.begin();
     for (;it != cacheLightsOn.end();it++)
@@ -750,13 +750,13 @@ map<Room *, list<IOBase *> > RoomModel::getLightsOnForRooms()
 
         if (lmap.find(rio.room) == lmap.end())
         {
-            list<IOBase *> l;
+            std::list<IOBase *> l;
             l.push_back(rio.io);
             lmap[rio.room] = l;
         }
         else
         {
-            list<IOBase *> &l = lmap[rio.room];
+            std::list<IOBase *> &l = lmap[rio.room];
             l.push_back(rio.io);
         }
     }
@@ -764,9 +764,9 @@ map<Room *, list<IOBase *> > RoomModel::getLightsOnForRooms()
     return lmap;
 }
 
-map<Room *, list<IOBase *> > RoomModel::getShuttersUpForRooms()
+std::map<Room *, std::list<IOBase *> > RoomModel::getShuttersUpForRooms()
 {
-    map<Room *, list<IOBase *> > lmap;
+    std::map<Room *, std::list<IOBase *> > lmap;
 
     RoomIOCache::iterator it = cacheShuttersUp.begin();
     for (;it != cacheShuttersUp.end();it++)
@@ -775,13 +775,13 @@ map<Room *, list<IOBase *> > RoomModel::getShuttersUpForRooms()
 
         if (lmap.find(rio.room) == lmap.end())
         {
-            list<IOBase *> l;
+            std::list<IOBase *> l;
             l.push_back(rio.io);
             lmap[rio.room] = l;
         }
         else
         {
-            list<IOBase *> &l = lmap[rio.room];
+            std::list<IOBase *> &l = lmap[rio.room];
             l.push_back(rio.io);
         }
     }
@@ -789,7 +789,7 @@ map<Room *, list<IOBase *> > RoomModel::getShuttersUpForRooms()
     return lmap;
 }
 
-string IOBase::getIconForIO()
+std::string IOBase::getIconForIO()
 {
     if (params["gui_type"] == "light" ||
         params["gui_type"] == "light_dimmer" ||
@@ -824,7 +824,7 @@ string IOBase::getIconForIO()
 double IOBase::getDaliValueFromState()
 {
     double val = 0.0;
-    string state = params["state"];
+    std::string state = params["state"];
 
     if (Utils::is_of_type<double>(state))
     {
@@ -832,7 +832,7 @@ double IOBase::getDaliValueFromState()
     }
     else if (state.compare(0, 4, "set ") == 0)
     {
-        string s = state;
+        std::string s = state;
         s.erase(0, 4);
         from_string(s, val);
     }
@@ -850,7 +850,7 @@ double IOBase::getDaliValueFromState()
 
 int IOBase::getPercentVoletSmart()
 {
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     int percent;
 
     Utils::split(params["state"], tokens);
@@ -863,9 +863,9 @@ int IOBase::getPercentVoletSmart()
     return percent;
 }
 
-string IOBase::getStatusVoletSmart()
+std::string IOBase::getStatusVoletSmart()
 {
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     Utils::split(params["state"], tokens);
 
     if (tokens.size() > 0)
@@ -874,9 +874,9 @@ string IOBase::getStatusVoletSmart()
     return "";
 }
 
-vector<IOActionList> IOBase::getActionList()
+std::vector<IOActionList> IOBase::getActionList()
 {
-    vector<IOActionList> v;
+    std::vector<IOActionList> v;
 
     if (params["gui_type"] == "light")
     {
@@ -991,17 +991,17 @@ vector<IOActionList> IOBase::getActionList()
         v.push_back(IOActionList("power off", _("Power Off"), IOActionList::ACTION_SIMPLE));
         v.push_back(IOActionList("volume %1", _("Change volume"), _("Change volume to %1%"), IOActionList::ACTION_SLIDER));
 
-        cout << params.toString() << endl;
+        std::cout << params.toString() << std::endl;
 
-        map<int, string>::iterator it = amplifier_inputs.begin();
+        std::map<int, std::string>::iterator it = amplifier_inputs.begin();
 
         for (;it != amplifier_inputs.end();it++)
         {
             int source_id = (*it).first;
-            string input_name = (*it).second;
+            std::string input_name = (*it).second;
 
-            string src_action = "source " + Utils::to_string(source_id);
-            string src_actionname = _("Switch source to ") + Utils::to_string(input_name);
+            std::string src_action = "source " + Utils::to_string(source_id);
+            std::string src_actionname = _("Switch source to ") + Utils::to_string(input_name);
 
             v.push_back(IOActionList(src_action, src_actionname, IOActionList::ACTION_SIMPLE));
         }
@@ -1091,10 +1091,10 @@ IOActionList IOBase::getActionFromState()
     return ac;
 }
 
-IOActionList IOBase::getActionListFromAction(string action)
+IOActionList IOBase::getActionListFromAction(std::string action)
 {
     IOActionList ac;
-    vector<string> tokens;
+    std::vector<std::string> tokens;
 
     split(action, tokens);
     if (tokens.size() < 1) return ac;
@@ -1252,15 +1252,15 @@ IOActionList IOBase::getActionListFromAction(string action)
             int inputid;
             from_string(tokens[tokens.size() - 1], inputid);
 
-            map<int, string>::iterator it = amplifier_inputs.begin();
+            std::map<int, std::string>::iterator it = amplifier_inputs.begin();
 
             for (;it != amplifier_inputs.end();it++)
             {
                 int source_id = (*it).first;
-                string input_name = (*it).second;
+                std::string input_name = (*it).second;
 
-                string src_action = "source " + Utils::to_string(source_id);
-                string src_actionname = _("Switch source to ") + Utils::to_string(input_name);
+                std::string src_action = "source " + Utils::to_string(source_id);
+                std::string src_actionname = _("Switch source to ") + Utils::to_string(input_name);
 
                 if (inputid == source_id)
                 {
@@ -1274,9 +1274,9 @@ IOActionList IOBase::getActionListFromAction(string action)
     return ac;
 }
 
-string IOActionList::getComputedTitle(IOBase *io)
+std::string IOActionList::getComputedTitle(IOBase *io)
 {
-    string t = title_computed;
+    std::string t = title_computed;
 
     if (type == ACTION_SLIDER ||
         type == ACTION_NUMBER)
@@ -1291,9 +1291,9 @@ string IOActionList::getComputedTitle(IOBase *io)
     return t;
 }
 
-string IOActionList::getComputedAction(IOBase *io)
+std::string IOActionList::getComputedAction(IOBase *io)
 {
-    string ac = action;
+    std::string ac = action;
 
     if (type == ACTION_SIMPLE)
         return ac;
@@ -1355,14 +1355,14 @@ void IOBase::loadPlage_cb(json_t *jdata, void *data)
         if (p["day"] == "7") range_infos.range_sunday.push_back(tr);
     }
 
-    string m = jansson_string_get(jdata, "months");
+    std::string m = jansson_string_get(jdata, "months");
 
     //reverse to have a left to right months representation
     std::reverse(m.begin(), m.end());
 
     try
     {
-        bitset<12> mset(m);
+        std::bitset<12> mset(m);
         range_infos.range_months = mset;
     }
     catch(...)
@@ -1377,9 +1377,9 @@ void IOBase::loadPlage_cb(json_t *jdata, void *data)
     io_changed.emit(); //io has changed
 }
 
-vector<int> TimeRangeInfos::isScheduledDate(struct tm scDate)
+std::vector<int> TimeRangeInfos::isScheduledDate(struct tm scDate)
 {
-    vector<int> ret;
+    std::vector<int> ret;
 
     cDebugDom("scenario") << "Checking scenario for date ";
 
@@ -1387,7 +1387,7 @@ vector<int> TimeRangeInfos::isScheduledDate(struct tm scDate)
     if (!range_months.test(scDate.tm_mon))
         return ret;
 
-    auto checkRange = [=,&ret](const vector<TimeRange> &range)
+    auto checkRange = [=,&ret](const std::vector<TimeRange> &range)
     {
         cDebugDom("scenario") << "day: " << scDate.tm_wday << " range size: " << range.size();
         for (uint i = 0;i < range.size();i++)
@@ -1413,7 +1413,7 @@ vector<int> TimeRangeInfos::isScheduledDate(struct tm scDate)
     return ret;
 }
 
-vector<TimeRange> TimeRangeInfos::getRange(int day)
+std::vector<TimeRange> TimeRangeInfos::getRange(int day)
 {
     switch (day)
     {
@@ -1426,35 +1426,35 @@ vector<TimeRange> TimeRangeInfos::getRange(int day)
     case TimeRange::SUNDAY: return range_sunday; break;
     default: break;
     }
-    vector<TimeRange> v;
+    std::vector<TimeRange> v;
     return v;
 }
 
-string TimeRangeInfos::toString()
+std::string TimeRangeInfos::toString()
 {
-    stringstream str;
+    std::stringstream str;
 
-    str << "*** Monday ***" << endl;
+    str << "*** Monday ***" << std::endl;
     for (uint i = 0; i < range_monday.size();i++)
-        str << "\t" << range_monday[i].toString() << endl;
-    str << "*** Tuesday ***" << endl;
+        str << "\t" << range_monday[i].toString() << std::endl;
+    str << "*** Tuesday ***" << std::endl;
     for (uint i = 0; i < range_tuesday.size();i++)
-        str << "\t" << range_tuesday[i].toString() << endl;
-    str << "*** Wednesday ***" << endl;
+        str << "\t" << range_tuesday[i].toString() << std::endl;
+    str << "*** Wednesday ***" << std::endl;
     for (uint i = 0; i < range_wednesday.size();i++)
-        str << "\t" << range_wednesday[i].toString() << endl;
-    str << "*** Thursday ***" << endl;
+        str << "\t" << range_wednesday[i].toString() << std::endl;
+    str << "*** Thursday ***" << std::endl;
     for (uint i = 0; i < range_thursday.size();i++)
-        str << "\t" << range_thursday[i].toString() << endl;
-    str << "*** Friday ***" << endl;
+        str << "\t" << range_thursday[i].toString() << std::endl;
+    str << "*** Friday ***" << std::endl;
     for (uint i = 0; i < range_friday.size();i++)
-        str << "\t" << range_friday[i].toString() << endl;
-    str << "*** Saturday ***" << endl;
+        str << "\t" << range_friday[i].toString() << std::endl;
+    str << "*** Saturday ***" << std::endl;
     for (uint i = 0; i < range_saturday.size();i++)
-        str << "\t" << range_saturday[i].toString() << endl;
-    str << "*** Sunday ***" << endl;
+        str << "\t" << range_saturday[i].toString() << std::endl;
+    str << "*** Sunday ***" << std::endl;
     for (uint i = 0; i < range_sunday.size();i++)
-        str << "\t" << range_sunday[i].toString() << endl;
+        str << "\t" << range_sunday[i].toString() << std::endl;
 
     return str.str();
 }

--- a/src/bin/calaos_home/models/RoomModel.h
+++ b/src/bin/calaos_home/models/RoomModel.h
@@ -25,34 +25,31 @@
 #include "CalaosConnection.h"
 #include <TimeRange.h>
 
-using namespace Utils;
-
 class IOBase;
 class Room;
 
 bool IOHitsCompare(const IOBase *lhs, const IOBase *rhs);
 bool RoomHitsCompare(const Room *lhs, const Room *rhs);
 
-class IOBase;
 class IOActionList
 {
 public:
-    IOActionList(string a, string t, string t2, int ty): //title_computed must be computed with value first
+    IOActionList(std::string a, std::string t, std::string t2, int ty): //title_computed must be computed with value first
         action(a), title(t), title_computed(t2), dvalue(0.0), type(ty)
     {}
-    IOActionList(string a, string t, int ty): //same title and title_computed
+    IOActionList(std::string a, std::string t, int ty): //same title and title_computed
         action(a), title(t), title_computed(t), dvalue(0.0), type(ty)
     {}
     IOActionList():
         dvalue(0.0), type(ACTION_NONE)
     {}
 
-    string action;
-    string title;
-    string title_computed;
+    std::string action;
+    std::string title;
+    std::string title_computed;
 
     double dvalue;
-    string svalue;
+    std::string svalue;
 
     //for color type
     ColorValue colorval;
@@ -60,8 +57,8 @@ public:
     enum { ACTION_NONE = 0, ACTION_SIMPLE, ACTION_SLIDER, ACTION_COLOR, ACTION_TEXT, ACTION_NUMBER, ACTION_TIME_MS };
     int type;
 
-    string getComputedAction(IOBase *io);
-    string getComputedTitle(IOBase *io);
+    std::string getComputedAction(IOBase *io);
+    std::string getComputedTitle(IOBase *io);
 
     void copyValueFrom(IOActionList &ac)
     { dvalue = ac.dvalue; svalue = ac.svalue; colorval = ac.colorval; }
@@ -73,26 +70,25 @@ public:
     TimeRangeInfos()
     {}
 
-    vector<TimeRange> range_monday;
-    vector<TimeRange> range_tuesday;
-    vector<TimeRange> range_wednesday;
-    vector<TimeRange> range_thursday;
-    vector<TimeRange> range_friday;
-    vector<TimeRange> range_saturday;
-    vector<TimeRange> range_sunday;
+    std::vector<TimeRange> range_monday;
+    std::vector<TimeRange> range_tuesday;
+    std::vector<TimeRange> range_wednesday;
+    std::vector<TimeRange> range_thursday;
+    std::vector<TimeRange> range_friday;
+    std::vector<TimeRange> range_saturday;
+    std::vector<TimeRange> range_sunday;
 
-    vector<TimeRange> getRange(int day);
+    std::vector<TimeRange> getRange(int day);
 
     //months where InPlageHoraire is activated
     enum { JANUARY = 0, FEBRUARY, MARCH, APRIL, MAY, JUNE, JULY, AUGUST, SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER };
-    bitset<12> range_months;
+    std::bitset<12> range_months;
 
-    vector<int> isScheduledDate(tm scDate);
+    std::vector<int> isScheduledDate(tm scDate);
 
-    string toString();
+    std::string toString();
 };
 
-class Room;
 class IOBase: public sigc::trackable
 {
 private:
@@ -101,8 +97,8 @@ private:
 
     Room *room;
 
-    void sendAction_cb(bool success, vector<string> result, void *data);
-    void notifyChange(const string &msgtype, const Params &evdata);
+    void sendAction_cb(bool success, std::vector<std::string> result, void *data);
+    void notifyChange(const std::string &msgtype, const Params &evdata);
 
     void checkCacheChange();
 
@@ -123,19 +119,19 @@ public:
 
     Params params;
 
-    void sendAction(string command);
-    void sendUserCommand(const string &cmd, const Params &p, CommandDone_cb callback);
+    void sendAction(std::string command);
+    void sendUserCommand(const std::string &cmd, const Params &p, CommandDone_cb callback);
     Room *getRoom() { return room; }
 
     //Some utility functions
     double getDaliValueFromState();
     int getPercentVoletSmart();
-    string getStatusVoletSmart();
+    std::string getStatusVoletSmart();
 
-    string getIconForIO();
-    vector<IOActionList> getActionList();
+    std::string getIconForIO();
+    std::vector<IOActionList> getActionList();
     IOActionList getActionFromState();
-    IOActionList getActionListFromAction(string action); //action is from the scenario action
+    IOActionList getActionListFromAction(std::string action); //action is from the scenario action
 
     //InPlageHoraire functions
     void loadPlage(); //force a reload of the plage data
@@ -143,7 +139,7 @@ public:
     TimeRangeInfos range_infos;
 
     //AVReceiver specifiv functions
-    map<int, string> amplifier_inputs;
+    std::map<int, std::string> amplifier_inputs;
 
     //signals
     sigc::signal<void> io_changed;
@@ -159,9 +155,9 @@ private:
     CalaosConnection* connection;
     RoomModel *model;
 
-    void notifyChange(const string &msgtype, const Params &evdata);
-    void notifyIOAdd(const string &msgtype, const Params &evdata);
-    void notifyIODel(const string &msgtype, const Params &evdata);
+    void notifyChange(const std::string &msgtype, const Params &evdata);
+    void notifyIOAdd(const std::string &msgtype, const Params &evdata);
+    void notifyIODel(const std::string &msgtype, const Params &evdata);
 
     void updateVisibleIO();
 
@@ -185,13 +181,13 @@ public:
 
     void load(json_t *data);
 
-    string name;
-    string type;
+    std::string name;
+    std::string type;
     int hits;
 
-    list<IOBase *> ios;
-    list<IOBase *> visible_ios; //Contains only visible IO for a GUI
-    list<IOBase *> scenario_ios; //Contains all IO controlable in a scenario
+    std::list<IOBase *> ios;
+    std::list<IOBase *> visible_ios; //Contains only visible IO for a GUI
+    std::list<IOBase *> scenario_ios; //Contains all IO controlable in a scenario
 
     void load_io_done(IOBase *io);
     void load_io_notif_done(IOBase *io);
@@ -212,7 +208,7 @@ typedef struct _RoomLightsOn
     Room *room;
     IOBase *io;
 } RoomIO;
-typedef map<IOBase *, RoomIO> RoomIOCache;
+typedef std::map<IOBase *, RoomIO> RoomIOCache;
 
 class RoomModel: public sigc::trackable
 {
@@ -225,23 +221,23 @@ private:
 
     void updateChauffageIO(); //update association of chauffage IO
 
-    void notifyRoomAdd(const string &msgtype, const Params &evdata);
-    void notifyRoomDel(const string &msgtype, const Params &evdata);
+    void notifyRoomAdd(const std::string &msgtype, const Params &evdata);
+    void notifyRoomDel(const std::string &msgtype, const Params &evdata);
     void notifyRoomChange(); //notify hits change and sort rooms again if change happens
 
     /* Caches */
     friend class Room;
     friend class IOBase;
 
-    list<IOBase *> cacheScenarios;
-    list<IOBase *> cacheScenariosPref;
+    std::list<IOBase *> cacheScenarios;
+    std::list<IOBase *> cacheScenariosPref;
 
     RoomIOCache cacheLightsOn;
     RoomIOCache cacheShuttersUp;
 
-    map<string, IOBase *> cacheIOs;
+    std::map<std::string, IOBase *> cacheIOs;
 
-    list<IOBase *> chauffageList;
+    std::list<IOBase *> chauffageList;
 
     json_t *jsonHome = nullptr;
 
@@ -249,27 +245,27 @@ public:
     RoomModel(CalaosConnection *connection);
     ~RoomModel();
 
-    list<Room *> rooms; //All rooms sorted
-    list<Room *> rooms_type; //Only types sorted by hits
+    std::list<Room *> rooms; //All rooms sorted
+    std::list<Room *> rooms_type; //Only types sorted by hits
 
     void load();
     json_t *getJsonHome() { return jsonHome; }
 
-    const list<IOBase *> &getCacheScenarios() { return cacheScenarios; }
-    const list<IOBase *> &getCacheScenariosPref() { return cacheScenariosPref; }
+    const std::list<IOBase *> &getCacheScenarios() { return cacheScenarios; }
+    const std::list<IOBase *> &getCacheScenariosPref() { return cacheScenariosPref; }
     const RoomIOCache &getCacheLightsOn() { return cacheLightsOn; }
     const RoomIOCache &getCacheShuttersUp() { return cacheShuttersUp; }
-    const map<string, IOBase *> &getCacheIO() { return cacheIOs; }
+    const std::map<std::string, IOBase *> &getCacheIO() { return cacheIOs; }
 
-    map<Room *, list<IOBase *> > getLightsOnForRooms();
-    map<Room *, list<IOBase *> > getShuttersUpForRooms();
+    std::map<Room *, std::list<IOBase *> > getLightsOnForRooms();
+    std::map<Room *, std::list<IOBase *> > getShuttersUpForRooms();
 
-    list<Room *> getRoomsForType(string type);
+    std::list<Room *> getRoomsForType(std::string type);
 
     IOBase *getConsigneFromTemp(IOBase *temp);
     IOBase *getTempFromConsigne(IOBase *temp);
 
-    IOBase *getChauffageForType(string type);
+    IOBase *getChauffageForType(std::string type);
 
     sigc::signal<void> load_done;
 

--- a/src/bin/calaos_home/models/ScenarioModel.cpp
+++ b/src/bin/calaos_home/models/ScenarioModel.cpp
@@ -47,8 +47,8 @@ void ScenarioModel::scenario_list_cb(json_t *jdata, void *data)
 
     json_array_foreach(json_object_get(jdata, "scenarios"), idx, value)
     {
-        string id = jansson_string_get(value, "id");
-        map<string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(id);
+        std::string id = jansson_string_get(value, "id");
+        std::map<std::string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(id);
 
         if (it == CalaosModel::Instance().getHome()->getCacheIO().end())
         {
@@ -81,7 +81,7 @@ void Scenario::load(json_t *jdata)
 
     if (scenario_data.params["schedule"] != "false")
     {
-        map<string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(scenario_data.params["schedule"]);
+        std::map<std::string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(scenario_data.params["schedule"]);
         if (it != CalaosModel::Instance().getHome()->getCacheIO().end())
         {
             ioSchedule = (*it).second;
@@ -117,10 +117,10 @@ void Scenario::load(json_t *jdata)
 
         json_array_foreach(json_object_get(value, "actions"), idx_act, value_act)
         {
-            string id_out = jansson_string_get(value_act, "id");
-            string act = jansson_string_get(value_act, "action");
+            std::string id_out = jansson_string_get(value_act, "id");
+            std::string act = jansson_string_get(value_act, "action");
 
-            map<string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(id_out);
+            std::map<std::string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(id_out);
             if (it == CalaosModel::Instance().getHome()->getCacheIO().end())
             {
                 cErrorDom("scenario") << "Unknown action id \'" << id_out << "\' with action \'" << act << "\' !";
@@ -149,9 +149,9 @@ Room *Scenario::getRoom()
     return room;
 }
 
-string Scenario::getFirstCategory()
+std::string Scenario::getFirstCategory()
 {
-    vector<string> tok;
+    std::vector<std::string> tok;
     split(scenario_data.params["category"], tok, "-");
     if (tok.size() > 0)
         return tok[0];
@@ -292,7 +292,7 @@ void Scenario::createSchedule(sigc::slot<void, IOBase *> callback)
                                              { "id", ioScenario->params["id"] }},
                             [=](json_t *jdata, void *)
     {
-        string sched_id = jansson_string_get(jdata, "id");
+        std::string sched_id = jansson_string_get(jdata, "id");
 
         if (sched_id.empty())
         {
@@ -305,7 +305,7 @@ void Scenario::createSchedule(sigc::slot<void, IOBase *> callback)
         //We need to delay a bit because we have to wait for RoomModel to load the io id first
         timer = new EcoreTimer(0.05, [=]()
         {
-            map<string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(sched_id);
+            std::map<std::string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(sched_id);
 
             if (it == CalaosModel::Instance().getHome()->getCacheIO().end())
             {
@@ -352,22 +352,22 @@ void Scenario::setSchedules(TimeRangeInfos &tr)
     }
 
     cDebugDom("scenario") << "Saving Scenario schedule: ";
-    cout << tr.toString();
+    std::cout << tr.toString();
 
     json_t *jret = json_object();
 
     json_object_set_new(jret, "id", json_string(ioSchedule->params["id"].c_str()));
 
     //Send months
-    stringstream ssmonth;
+    std::stringstream ssmonth;
     ssmonth << tr.range_months;
-    string str = ssmonth.str();
+    std::string str = ssmonth.str();
     std::reverse(str.begin(), str.end());
 
     json_object_set_new(jret, "months", json_string(str.c_str()));
     json_t *jranges = json_array();
 
-    auto addRange = [=](const vector<TimeRange> &ranges, int day)
+    auto addRange = [=](const std::vector<TimeRange> &ranges, int day)
     {
         for (const TimeRange &t: ranges)
             json_array_append_new(jranges, t.toParams(day).toJson());
@@ -404,7 +404,7 @@ void ScenarioModel::deleteScenario(Scenario *sc)
     connection->sendCommand("autoscenario", {{ "type", "delete" }, { "id", sc->ioScenario->params["id"] }});
 }
 
-void ScenarioModel::notifyScenarioAdd(const string &msgtype, const Params &evdata)
+void ScenarioModel::notifyScenarioAdd(const std::string &msgtype, const Params &evdata)
 {
     cDebugDom("scenario") << "New scenario notif, start timer to load scenario data...";
 
@@ -412,12 +412,12 @@ void ScenarioModel::notifyScenarioAdd(const string &msgtype, const Params &evdat
     EcoreTimer::singleShot(0.5, sigc::bind(sigc::mem_fun(*this, &ScenarioModel::notifyScenarioAddDelayed), msgtype, evdata));
 }
 
-void ScenarioModel::notifyScenarioAddDelayed(const string &msgtype, const Params &evdata)
+void ScenarioModel::notifyScenarioAddDelayed(const std::string &msgtype, const Params &evdata)
 {
     VAR_UNUSED(msgtype);
     cDebugDom("scenario") << "New scenario, load data";
 
-    map<string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(evdata["id"]);
+    std::map<std::string, IOBase *>::const_iterator it = CalaosModel::Instance().getHome()->getCacheIO().find(evdata["id"]);
 
     if (it == CalaosModel::Instance().getHome()->getCacheIO().end())
     {
@@ -451,7 +451,7 @@ void ScenarioModel::notifyScenarioDel(Scenario *sc)
         return;
     }
 
-    list<Scenario *>::iterator it;
+    std::list<Scenario *>::iterator it;
     it = find(scenarios.begin(), scenarios.end(), sc);
 
     if (it == scenarios.end())
@@ -466,12 +466,12 @@ void ScenarioModel::notifyScenarioDel(Scenario *sc)
     scenarios.erase(it);
 }
 
-void ScenarioModel::notifyScenarioChange(const string &msgtype, const Params &evdata)
+void ScenarioModel::notifyScenarioChange(const std::string &msgtype, const Params &evdata)
 {
     VAR_UNUSED(msgtype);
     cDebug() << "scenario id: " << evdata["id"] << " changed, broadcasting signal";
 
-    list<Scenario *>::iterator it = scenarios.begin();
+    std::list<Scenario *>::iterator it = scenarios.begin();
     for (;it != scenarios.end();it++)
     {
         Scenario *sc = *it;
@@ -498,9 +498,9 @@ void ScenarioModel::notifyScenarioChange(const string &msgtype, const Params &ev
     }
 }
 
-list<ScenarioSchedule> ScenarioModel::getScenarioForDate(struct tm scDate)
+std::list<ScenarioSchedule> ScenarioModel::getScenarioForDate(struct tm scDate)
 {
-    list<ScenarioSchedule> retList;
+    std::list<ScenarioSchedule> retList;
 
     auto it = scenarios.begin();
     for (;it != scenarios.end();it++)
@@ -513,12 +513,12 @@ list<ScenarioSchedule> ScenarioModel::getScenarioForDate(struct tm scDate)
             continue;
 
         cDebugDom("scenario") << "Scenario schedule: ";
-        cout << sc->ioSchedule->range_infos.toString();
+        std::cout << sc->ioSchedule->range_infos.toString();
 
         auto checkScenario = [=,&retList](int day)
         {
             cDebugDom("scenario") << "Checking day: " << day;
-            vector<int> num;
+            std::vector<int> num;
             num = sc->ioSchedule->range_infos.isScheduledDate(scDate);
 
             for (uint i = 0;i < num.size();i++)
@@ -548,7 +548,7 @@ list<ScenarioSchedule> ScenarioModel::getScenarioForDate(struct tm scDate)
     {
         long timea = 0, timeb = 0;
 
-        vector<TimeRange> vtr = a.scenario->ioSchedule->range_infos.getRange(a.day);
+        std::vector<TimeRange> vtr = a.scenario->ioSchedule->range_infos.getRange(a.day);
         if (a.timeRangeNum >= 0 && a.timeRangeNum < (int)vtr.size())
             timea = vtr[a.timeRangeNum].getStartTimeSec();
 

--- a/src/bin/calaos_home/models/ScenarioModel.h
+++ b/src/bin/calaos_home/models/ScenarioModel.h
@@ -26,7 +26,6 @@
 #include "CalaosConnection.h"
 #include "RoomModel.h"
 
-using namespace Utils;
 
 class ScenarioAction
 {
@@ -35,9 +34,9 @@ public:
     {}
 
     IOBase *io;
-    string action;
+    std::string action;
 
-    string toString()
+    std::string toString()
     {
         if (!io) return "Empty action !";
         return io->params["id"] + " : " + action;
@@ -52,12 +51,12 @@ public:
         pause(1000)
     {}
 
-    vector<ScenarioAction> actions;
+    std::vector<ScenarioAction> actions;
     long int pause; //msec
 
-    string toString()
+    std::string toString()
     {
-        string t = "\t\t[STEP] - pause:" + Utils::to_string(pause);
+        std::string t = "\t\t[STEP] - pause:" + Utils::to_string(pause);
         for (uint i = 0;i < actions.size();i++)
             t += "\n\t\t\t" + actions[i].toString();
         return t;
@@ -76,7 +75,7 @@ public:
         params.Add("enabled", "true");
     }
 
-    string name;
+    std::string name;
     Room *room;
     bool visible;
 
@@ -84,7 +83,7 @@ public:
 
     static const int END_STEP = 0xFEDC1234;
 
-    vector<ScenarioStep> steps;
+    std::vector<ScenarioStep> steps;
     ScenarioStep step_end;
 
     bool empty;
@@ -92,9 +91,9 @@ public:
     json_t *createRequest();
     json_t *modifyRequest(IOBase *io);
 
-    string toString()
+    std::string toString()
     {
-        string t = "[SCENARIO DATA] - name:" + name + " visible:" + Utils::to_string(visible) +
+        std::string t = "[SCENARIO DATA] - name:" + name + " visible:" + Utils::to_string(visible) +
                    "\n" + params.toString();
         for (uint i = 0;i < steps.size();i++)
             t += "\n\t[Step " + Utils::to_string(i) + "]\n" + steps[i].toString();
@@ -123,7 +122,7 @@ public:
 
     ScenarioData scenario_data;
 
-    string getFirstCategory();
+    std::string getFirstCategory();
 
     bool isScheduled() { if (ioSchedule) return true; return false; }
     void createSchedule(sigc::slot<void, IOBase *> callback);
@@ -155,10 +154,10 @@ private:
 
     void scenario_list_cb(json_t *jdata, void *data);
 
-    void notifyScenarioAdd(const string &msgtype, const Params &evdata);
-    void notifyScenarioAddDelayed(const string &msgtype, const Params &evdata);
+    void notifyScenarioAdd(const std::string &msgtype, const Params &evdata);
+    void notifyScenarioAddDelayed(const std::string &msgtype, const Params &evdata);
     void notifyScenarioDel(Scenario *sc);
-    void notifyScenarioChange(const string &msgtype, const Params &evdata);
+    void notifyScenarioChange(const std::string &msgtype, const Params &evdata);
 
 public:
     ScenarioModel(CalaosConnection *connection);
@@ -169,9 +168,9 @@ public:
     void modifyScenario(Scenario *sc);
     void deleteScenario(Scenario *sc);
 
-    list<Scenario *> scenarios;
+    std::list<Scenario *> scenarios;
 
-    list<ScenarioSchedule> getScenarioForDate(struct tm scDate);
+    std::list<ScenarioSchedule> getScenarioForDate(struct tm scDate);
 
     sigc::signal<void> load_done;
     sigc::signal<void, Scenario *> scenario_new;

--- a/src/bin/calaos_home/models/ScreenManager.cpp
+++ b/src/bin/calaos_home/models/ScreenManager.cpp
@@ -34,7 +34,7 @@ ScreenManager::~ScreenManager()
 
 int ScreenManager::getTime()
 {
-    string time = Utils::get_config_option("dpms_standby");
+    std::string time = Utils::get_config_option("dpms_standby");
     int t;
     Utils::from_string(time, t);
 

--- a/src/bin/calaos_home/test_cam.cpp
+++ b/src/bin/calaos_home/test_cam.cpp
@@ -4,7 +4,6 @@
 #include "CalaosCameraView.h"
 #include <Ecore_Con.h>
 
-using namespace std;
 
 EAPI_MAIN int elm_main(int argc, char **argv)
 {

--- a/src/bin/calaos_home/views/ActivityAudioListView.cpp
+++ b/src/bin/calaos_home/views/ActivityAudioListView.cpp
@@ -122,7 +122,7 @@ void ActivityAudioListView::createRootBrowserPage()
     it_browser_root = elm_naviframe_item_push(pager_browser, NULL, NULL, NULL, browser_root->getEvasObject(), "calaos");
 }
 
-EdjeObject *ActivityAudioListView::createRootButton(string title, string subtitle, string total, int row, int col)
+EdjeObject *ActivityAudioListView::createRootButton(std::string title, std::string subtitle, std::string total, int row, int col)
 {
     EdjeObject *obj = new EdjeObject(theme, evas);
     obj->LoadEdje("calaos/audio/browser/button");
@@ -239,7 +239,7 @@ void ActivityAudioListView::setEditMode()
 
     Params &stats = player_current->getPlayer()->getDBStats();
 
-    string s = _("<small><blue>Media library : </blue>") +
+    std::string s = _("<small><blue>Media library : </blue>") +
                stats["albums"] + _(" albums with ") +
                stats["tracks"] + _(" tracks by ") +
                stats["artists"] + _(" artists.</small>");
@@ -557,7 +557,7 @@ void ActivityAudioListView::browserShowFolders(void *data, Evas_Object *_edje, s
     loadFolderList("");
 }
 
-void ActivityAudioListView::loadFolderList(string folder_id)
+void ActivityAudioListView::loadFolderList(std::string folder_id)
 {
     EmitSignal("browser,loading,start", "calaos");
 
@@ -565,9 +565,9 @@ void ActivityAudioListView::loadFolderList(string folder_id)
                                              sigc::mem_fun(*this, &ActivityAudioListView::itemListLoaded));
 }
 
-void ActivityAudioListView::itemListLoaded(list<Params> &infos)
+void ActivityAudioListView::itemListLoaded(std::list<Params> &infos)
 {
-    list<Params>::iterator it = infos.begin();
+    std::list<Params>::iterator it = infos.begin();
 
     CREATE_GENLIST_HELPER(glist);
 
@@ -605,7 +605,7 @@ void ActivityAudioListView::itemListLoaded(list<Params> &infos)
     EmitSignal("browser,loading,stop", "calaos");
 }
 
-void ActivityAudioListView::folderSelected(void *data, string folder_id)
+void ActivityAudioListView::folderSelected(void *data, std::string folder_id)
 {
     loadFolderList(folder_id);
 }
@@ -689,7 +689,7 @@ void ActivityAudioListView::browserShowRadios(void *data, Evas_Object *_edje, st
     player_current->getPlayer()->getDBAllRadio(sigc::mem_fun(*this, &ActivityAudioListView::itemRadioLoaded));
 }
 
-void ActivityAudioListView::radioSelected(void *data, string rid, string subitem_id)
+void ActivityAudioListView::radioSelected(void *data, std::string rid, std::string subitem_id)
 {
     EmitSignal("browser,loading,start", "calaos");
 
@@ -701,9 +701,9 @@ void ActivityAudioListView::radioSelected(void *data, string rid, string subitem
     player_current->getPlayer()->getDBRadio(rid, subitem_id, sigc::mem_fun(*this, &ActivityAudioListView::itemRadioLoaded));
 }
 
-void ActivityAudioListView::itemRadioLoaded(list<Params> &infos)
+void ActivityAudioListView::itemRadioLoaded(std::list<Params> &infos)
 {
-    list<Params>::iterator it = infos.begin();
+    std::list<Params>::iterator it = infos.begin();
 
     CREATE_GENLIST_HELPER(glist);
     elm_genlist_homogeneous_set(glist, false);
@@ -779,14 +779,14 @@ void ActivityAudioListView::itemRadioLoaded(list<Params> &infos)
     EmitSignal("browser,loading,stop", "calaos");
 }
 
-void ActivityAudioListView::searchRadioSelected(void *data, string radioid, string subitem_id)
+void ActivityAudioListView::searchRadioSelected(void *data, std::string radioid, std::string subitem_id)
 {
     ApplicationMain::Instance().ShowKeyboard(_("Search into radios"), sigc::bind(
                                                  sigc::mem_fun(*this, &ActivityAudioListView::searchRadioKeyboard_cb),
                                                  radioid, subitem_id), false);
 }
 
-void ActivityAudioListView::searchRadioKeyboard_cb(string text, string radioid, string subitem_id)
+void ActivityAudioListView::searchRadioKeyboard_cb(std::string text, std::string radioid, std::string subitem_id)
 {
     EmitSignal("browser,loading,start", "calaos");
 
@@ -800,7 +800,7 @@ void ActivityAudioListView::browserShowSearch(void *data, Evas_Object *_edje, st
                                              false);
 }
 
-void ActivityAudioListView::searchDBKeyboard_cb(string text)
+void ActivityAudioListView::searchDBKeyboard_cb(std::string text)
 {
     if (!player_current) return;
 

--- a/src/bin/calaos_home/views/ActivityAudioListView.h
+++ b/src/bin/calaos_home/views/ActivityAudioListView.h
@@ -28,7 +28,6 @@
 
 #include "ActivityAudioPlayerObject.h"
 
-using namespace Utils;
 
 #define CREATE_GENLIST_HELPER(glist) \
     Evas_Object *glist = elm_genlist_add(parent); \
@@ -42,7 +41,7 @@ using namespace Utils;
 class ActivityAudioListView: public ActivityView
 {
 private:
-    vector<ActivityPlayerObject> players;
+    std::vector<ActivityPlayerObject> players;
     ActivityPlayerObject *player_current;
 
     Evas_Object *gplaylist;
@@ -51,18 +50,18 @@ private:
     EdjeObject *browser_root;
     Elm_Object_Item *it_browser_root;
 
-    vector<EdjeObject *> browser_root_buttons;
+    std::vector<EdjeObject *> browser_root_buttons;
 
     bool in_edit_mode;
 
-    string radio_id;
+    std::string radio_id;
 
     void EdjeCallback(void *data, Evas_Object *_edje, std::string emission, std::string source);
 
     void playerSelected(ActivityPlayerObject *obj);
 
     void createRootBrowserPage();
-    EdjeObject *createRootButton(string title, string subtitle, string total, int row, int col);
+    EdjeObject *createRootButton(std::string title, std::string subtitle, std::string total, int row, int col);
 
     void browserShowAlbums(void *data, Evas_Object *_edje, std::string emission, std::string source);
     void browserShowArtists(void *data, Evas_Object *_edje, std::string emission, std::string source);
@@ -81,11 +80,11 @@ private:
     void yearSelected(void *data);
     void genreSelected(void *data);
     void playlistSelected(void *data);
-    void folderSelected(void *data, string folder_id);
-    void radioSelected(void *data, string radio_id, string subitem_id);
-    void searchRadioSelected(void *data, string radio_id, string subitem_id);
-    void searchRadioKeyboard_cb(string text, string radio_id, string subitem_id);
-    void searchDBKeyboard_cb(string text);
+    void folderSelected(void *data, std::string folder_id);
+    void radioSelected(void *data, std::string radio_id, std::string subitem_id);
+    void searchRadioSelected(void *data, std::string radio_id, std::string subitem_id);
+    void searchRadioKeyboard_cb(std::string text, std::string radio_id, std::string subitem_id);
+    void searchDBKeyboard_cb(std::string text);
 
     void browserShowAlbumTracks(Params &infos, int album_id, Params album_infos);
     void browserShowArtistAlbum(Params &infos, Params artist_infos);
@@ -93,9 +92,9 @@ private:
     void browserShowGenreArtist(Params &infos, Params genre_infos);
     void browserShowPlaylistTracks(Params &infos, Params pl_infos);
 
-    void loadFolderList(string folder_id);
-    void itemListLoaded(list<Params> &infos);
-    void itemRadioLoaded(list<Params> &infos);
+    void loadFolderList(std::string folder_id);
+    void itemListLoaded(std::list<Params> &infos);
+    void itemRadioLoaded(std::list<Params> &infos);
 
 public:
     ActivityAudioListView(Evas *evas, Evas_Object *parent);
@@ -120,7 +119,7 @@ public:
     void unsetEditMode();
     bool isEditMode() { return in_edit_mode; } // return true if in edit mode
 
-    virtual string getTitle() { return "Musique"; }
+    virtual std::string getTitle() { return "Musique"; }
 
     sigc::signal<void> button_left_click;
     sigc::signal<void> button_right_click;

--- a/src/bin/calaos_home/views/ActivityAudioPlayerObject.cpp
+++ b/src/bin/calaos_home/views/ActivityAudioPlayerObject.cpp
@@ -87,7 +87,7 @@ void ActivityPlayerObject::resetPlayer()
     }
 }
 
-void ActivityPlayerObject::createEdjeObject(string &theme, Evas *e)
+void ActivityPlayerObject::createEdjeObject(std::string &theme, Evas *e)
 {
     EdjeObject *obj = new EdjeObject(theme, e);
     obj->LoadEdje("calaos/audio/player");
@@ -249,7 +249,7 @@ void ActivityPlayerObject::onTrackChange()
 {
     if (!player) return;
 
-    string artist, album, title, year, type, duration;
+    std::string artist, album, title, year, type, duration;
     artist = player->current_song_info["artist"];
     album = player->current_song_info["album"];
     title = player->current_song_info["title"];
@@ -306,7 +306,7 @@ void ActivityPlayerObject::coverGet_cb(Params &infos)
     downloader->Start();
 }
 
-void ActivityPlayerObject::coverDownload_cb(string status, void *data)
+void ActivityPlayerObject::coverDownload_cb(std::string status, void *data)
 {
     if (status == "failed" || status == "aborted")
     {
@@ -627,9 +627,9 @@ void ActivityPlayerObject::amplifierClick_cb(void *data, Evas_Object *_edje, std
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    map<int, string> inputs;
+    std::map<int, std::string> inputs;
     if (player->getAmplifier()) inputs = player->getAmplifier()->amplifier_inputs;
-    map<int, string>::iterator it = inputs.begin();
+    std::map<int, std::string>::iterator it = inputs.begin();
 
     GenlistItemBase *header = new GenlistItemSimpleHeader(evas, glist, "Source d'entrée");
     header->Append(glist);

--- a/src/bin/calaos_home/views/ActivityAudioPlayerObject.h
+++ b/src/bin/calaos_home/views/ActivityAudioPlayerObject.h
@@ -26,7 +26,6 @@
 #include "ActivityView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityPlayerObject
 {
@@ -44,7 +43,7 @@ private:
     Evas_Object *amp_panel;
     bool amp_volume;
 
-    string cover_fname;
+    std::string cover_fname;
 
     sigc::connection con_volume;
     sigc::connection con_status;
@@ -55,7 +54,7 @@ private:
     sigc::connection con_pl_trackdel;
     sigc::connection con_pl_trackmoved;
 
-    vector<sigc::connection *> small_player_connections;
+    std::vector<sigc::connection *> small_player_connections;
 
     void onVolumeChange();
     void onStatusChange();
@@ -84,7 +83,7 @@ private:
     void selectDetail_cb(void *data, Evas_Object *_edje, std::string emission, std::string source);
 
     void coverGet_cb(Params &infos);
-    void coverDownload_cb(string status, void *data);
+    void coverDownload_cb(std::string status, void *data);
 
     void amplifierChanged();
     void inputSourceSelected(void *data);
@@ -95,7 +94,7 @@ public:
     ActivityPlayerObject(Evas *e, Evas_Object *parent);
     ~ActivityPlayerObject();
 
-    void createEdjeObject(string &theme, Evas *evas);
+    void createEdjeObject(std::string &theme, Evas *evas);
     void resetPlayer();
 
     void setPlayer(AudioPlayer *p);

--- a/src/bin/calaos_home/views/ActivityCameraListView.cpp
+++ b/src/bin/calaos_home/views/ActivityCameraListView.cpp
@@ -68,10 +68,10 @@ void ActivityCameraListView::setCamera(Camera *camera, int position)
 
     Swallow(video->getSmartObject(), "camera.swallow." + Utils::to_string(position + 1));
 
-    string u, p;
+    std::string u, p;
     CalaosConnection::getCredentials(u, p);
 
-    string url = "http://";
+    std::string url = "http://";
     url += CalaosConnection::getCalaosServerIp() + ":5454/api";
     url += "?cn_user=" + u;
     url += "&cn_pass=" + p;
@@ -147,13 +147,13 @@ void ActivityCameraListView::EdjeCallback(void *data, Evas_Object *_edje, std::s
     }
 }
 
-void ActivityCameraListView::addScenarioPage(list<IOBase *> &scenarios_io)
+void ActivityCameraListView::addScenarioPage(std::list<IOBase *> &scenarios_io)
 {
     EdjeObject *container = new EdjeObject(theme, evas);
     container->LoadEdje("calaos/page/home/scenario");
     container->setAutoDelete(true);
 
-    list<IOBase *>::iterator it = scenarios_io.begin();
+    std::list<IOBase *>::iterator it = scenarios_io.begin();
     for (int i = 0;it != scenarios_io.end() && i < 6;it++, i++)
     {
         IOView *ioView = IOViewFactory::CreateIOView(evas, getEvasObject(), IOView::IO_SCENARIO_HOME);
@@ -163,7 +163,7 @@ void ActivityCameraListView::addScenarioPage(list<IOBase *> &scenarios_io)
 
         scenarios.push_back(ioView);
 
-        string _t = "element." + Utils::to_string(i + 1);
+        std::string _t = "element." + Utils::to_string(i + 1);
         container->Swallow(ioView, _t);
     }
 

--- a/src/bin/calaos_home/views/ActivityCameraListView.h
+++ b/src/bin/calaos_home/views/ActivityCameraListView.h
@@ -29,7 +29,6 @@
 
 #include <PagingView.h>
 
-using namespace Utils;
 
 class CalaosCameraView;
 class ActivityCameraListView;
@@ -51,9 +50,9 @@ public:
 class ActivityCameraListView: public ActivityView
 {
 private:
-    vector<ActivityCameraObject> cameras;
+    std::vector<ActivityCameraObject> cameras;
 
-    vector<IOView *> scenarios;
+    std::vector<IOView *> scenarios;
     PagingView *page_view;
 
     void EdjeCallback(void *data, Evas_Object *_edje, std::string emission, std::string source);
@@ -78,9 +77,9 @@ public:
     void ShowLoading();
     void HideLoading();
 
-    void addScenarioPage(list<IOBase *> &scenarios_io);
+    void addScenarioPage(std::list<IOBase *> &scenarios_io);
 
-    virtual string getTitle() { return "Vidéosurveillance"; }
+    virtual std::string getTitle() { return "Vidéosurveillance"; }
 
     virtual void EnableView();
     virtual void DisableView();

--- a/src/bin/calaos_home/views/ActivityCameraSelectView.cpp
+++ b/src/bin/calaos_home/views/ActivityCameraSelectView.cpp
@@ -51,9 +51,9 @@ void ActivityCameraSelectView::resetView()
 {
 }
 
-string ActivityCameraSelectView::getTitle()
+std::string ActivityCameraSelectView::getTitle()
 {
-    return string("Caméra: ") + camera->params["name"];
+    return std::string("Caméra: ") + camera->params["name"];
 }
 
 void ActivityCameraSelectView::ShowLoading()
@@ -91,10 +91,10 @@ void ActivityCameraSelectView::setCamera(Camera *cam)
 
     Swallow(camera_video->getSmartObject(), "camera.swallow");
 
-    string u, p;
+    std::string u, p;
     CalaosConnection::getCredentials(u, p);
 
-    string url = "http://";
+    std::string url = "http://";
     url += CalaosConnection::getCalaosServerIp() + ":5454/api";
     url += "?cn_user=" + u;
     url += "&cn_pass=" + p;
@@ -126,7 +126,7 @@ void ActivityCameraSelectView::setCamera(Camera *cam)
 
     setPartText("room_title.text", room->name);
 
-    list<IOBase *>::iterator it = room->visible_ios.begin();
+    std::list<IOBase *>::iterator it = room->visible_ios.begin();
     for (;it != room->visible_ios.end();it++)
     {
         IOViewFactory::CreateIOBaseElement(evas, list_item, *it, list_item, "left"/*, group_item*/);
@@ -221,7 +221,7 @@ void ActivityCameraSelectView::buttonSavePositionClick()
     header->Append(glist);
     for (int i = 0;i < 8;i++)
     {
-        string label = _("Position %1");
+        std::string label = _("Position %1");
         Utils::replace_str(label, "%1", Utils::to_string(i + 1));
         int *user_data = new int(i + 1);
         GenlistItemSimple *item  = new GenlistItemSimple(evas, glist, label, true, false, user_data);
@@ -251,7 +251,7 @@ void ActivityCameraSelectView::positionSelected(void *data)
 {
     int *user_data = reinterpret_cast<int *>(data);
     int position = *user_data;
-    string text = _("<center>Save to <light_blue>position #%1</light_blue></center>");
+    std::string text = _("<center>Save to <light_blue>position #%1</light_blue></center>");
     Utils::replace_str(text, "%1", Utils::to_string(position));
 
     camera->Save(position);

--- a/src/bin/calaos_home/views/ActivityCameraSelectView.h
+++ b/src/bin/calaos_home/views/ActivityCameraSelectView.h
@@ -27,7 +27,6 @@
 #include "ActivityView.h"
 #include "IOView.h"
 
-using namespace Utils;
 
 class CalaosCameraView;
 
@@ -58,7 +57,7 @@ public:
     void ShowLoading();
     void HideLoading();
 
-    virtual string getTitle();
+    virtual std::string getTitle();
 
     void setCamera(Camera *camera);
 };

--- a/src/bin/calaos_home/views/ActivityConfigClockView.h
+++ b/src/bin/calaos_home/views/ActivityConfigClockView.h
@@ -25,7 +25,6 @@
 
 #include "ActivityView.h"
 
-using namespace Utils;
 
 class ActivityConfigClockView: public ActivityView
 {
@@ -38,7 +37,7 @@ class ActivityConfigClockView: public ActivityView
 
                 virtual void resetView();
 
-                virtual string getTitle() { return _("Configure Clock and Date"); }
+                virtual std::string getTitle() { return _("Configure Clock and Date"); }
 };
 
 #endif // ActivityConfigClockView_H

--- a/src/bin/calaos_home/views/ActivityConfigMenuView.cpp
+++ b/src/bin/calaos_home/views/ActivityConfigMenuView.cpp
@@ -47,7 +47,7 @@ ActivityConfigMenuView::ActivityConfigMenuView(Evas *_e, Evas_Object *_parent):
     setPartText("tab1.uptime.label", _("System started since : "));
 
     long days = Utils::getUptime() / 60 / 60 / 24;
-    string uptime;
+    std::string uptime;
     uptime = to_string(days);
     if (days == 1)
         uptime += _(" day");
@@ -73,9 +73,9 @@ ActivityConfigMenuView::ActivityConfigMenuView(Evas *_e, Evas_Object *_parent):
 
     setPartText("tab1.hostname", hostname);
 
-    string local_ip = "";
+    std::string local_ip = "";
     // Get All interfaces
-    vector<string> intf = TCPSocket::getAllInterfaces();
+    std::vector<std::string> intf = TCPSocket::getAllInterfaces();
     if (intf.size() > 0)
     {
         for (unsigned int i = 0; i < intf.size(); i++)

--- a/src/bin/calaos_home/views/ActivityConfigMenuView.h
+++ b/src/bin/calaos_home/views/ActivityConfigMenuView.h
@@ -25,7 +25,6 @@
 
 #include "ActivityView.h"
 
-using namespace Utils;
 
 class ActivityConfigMenuView: public ActivityView
 {
@@ -39,9 +38,9 @@ public:
 
     virtual void resetView();
 
-    virtual string getTitle() { return _("Configuration center"); }
+    virtual std::string getTitle() { return _("Configuration center"); }
 
-    sigc::signal<void, string> menu_item_clicked;
+    sigc::signal<void, std::string> menu_item_clicked;
 };
 
 #endif // ACTIVITYCONFIGMENUVIEW_H

--- a/src/bin/calaos_home/views/ActivityConfigPasswordView.h
+++ b/src/bin/calaos_home/views/ActivityConfigPasswordView.h
@@ -25,7 +25,6 @@
 
 #include "ActivityView.h"
 
-using namespace Utils;
 
 class ActivityConfigPasswordView: public ActivityView
 {
@@ -38,7 +37,7 @@ class ActivityConfigPasswordView: public ActivityView
 
                 virtual void resetView();
 
-                virtual string getTitle() { return _("Configure Password"); }
+                virtual std::string getTitle() { return _("Configure Password"); }
 };
 
 #endif // ActivityConfigPasswordView_H

--- a/src/bin/calaos_home/views/ActivityConfigScreensaverView.cpp
+++ b/src/bin/calaos_home/views/ActivityConfigScreensaverView.cpp
@@ -55,7 +55,7 @@ ActivityConfigScreensaverView::ActivityConfigScreensaverView(Evas *_e, Evas_Obje
     slider->setAutoDelete(true);
 
     double slider_val;
-    string option_val;
+    std::string option_val;
     bool enabled = false;
 
     if (get_config_option("dpms_enable") == "true")
@@ -74,13 +74,13 @@ ActivityConfigScreensaverView::ActivityConfigScreensaverView(Evas *_e, Evas_Obje
     setPartText("module_screen_time_value", Utils::to_string((int)(slider_val)) + _(" minutes"));
 
     slider->addCallback("object", "*",
-                        [=](void *data, Evas_Object *edje_object, string emission, string source)
+                        [=](void *data, Evas_Object *edje_object, std::string emission, std::string source)
     {
         // Change value on screen when slider move
         if (emission == "slider,move")
         {
             double x;
-            string val;
+            std::string val;
 
             slider->getDragValue("slider", &x, NULL);
             val = Utils::to_string((int)(x * DPMS_STANDBY_MAX_VALUE)) +  _(" minutes");
@@ -113,7 +113,7 @@ ActivityConfigScreensaverView::ActivityConfigScreensaverView(Evas *_e, Evas_Obje
     slider->setDragValue("slider", slider_val / DPMS_STANDBY_MAX_VALUE, slider_val / DPMS_STANDBY_MAX_VALUE);
     Swallow(slider, "dpms_standby_slider.swallow", true);
 
-    addCallback("object", "*", [=](void *data, Evas_Object *edje_object, string emission, string source)
+    addCallback("object", "*", [=](void *data, Evas_Object *edje_object, std::string emission, std::string source)
     {
         if (emission == "screen,suspend,check")
         {

--- a/src/bin/calaos_home/views/ActivityConfigScreensaverView.h
+++ b/src/bin/calaos_home/views/ActivityConfigScreensaverView.h
@@ -25,7 +25,6 @@
 
 #include "ActivityView.h"
 
-using namespace Utils;
 
 class ActivityConfigScreensaverView: public ActivityView
 {
@@ -38,7 +37,7 @@ class ActivityConfigScreensaverView: public ActivityView
 
                 virtual void resetView();
 
-                virtual string getTitle() { return _("Configure Screen saver settings"); }
+                virtual std::string getTitle() { return _("Configure Screen saver settings"); }
 };
 
 #endif // ActivityConfigScreensaverView_H

--- a/src/bin/calaos_home/views/ActivityConfigView.h
+++ b/src/bin/calaos_home/views/ActivityConfigView.h
@@ -26,7 +26,6 @@
 #include "ActivityView.h"
 #include "MainContentView.h"
 
-using namespace Utils;
 
 class ActivityConfigView: public ActivityView
 {
@@ -45,7 +44,7 @@ public:
     BaseView *getTopView() { return contentView->getTopView(); }
     void removeTopView() { contentView->removeTopView(); }
 
-    sigc::signal<void, string> button_clicked;
+    sigc::signal<void, std::string> button_clicked;
 };
 
 #endif // ACTIVITYCONFIGVIEW_H

--- a/src/bin/calaos_home/views/ActivityEditScenarioView.cpp
+++ b/src/bin/calaos_home/views/ActivityEditScenarioView.cpp
@@ -99,7 +99,7 @@ void ActivityEditScenarioView::showStep(int step)
             pageName->object_deleted.connect(sigc::mem_fun(*this, &ActivityEditScenarioView::pageNameDeleted));
             pageName->addCallback("button.name", "pressed", sigc::mem_fun(*this, &ActivityEditScenarioView::pageNameEditName));
             pageName->addCallback("button.*selected", "pressed", sigc::mem_fun(*this, &ActivityEditScenarioView::pageNameVisiblePressed));
-            pageName->setPartText("name.text", string(_("Scenario name: ")) + "<blue>" + scenario_data.name + "</blue>");
+            pageName->setPartText("name.text", std::string(_("Scenario name: ")) + "<blue>" + scenario_data.name + "</blue>");
             updateVisibility();
 
             pageName->setPartText("title_step.2", _("<big>Scenario creation or modification</big><br><br><small><disabled>Use the following field to enter the name of your scenario and find it <br>quickly. Also, choose the visibility of you scenario.</disabled></small>"));
@@ -141,14 +141,14 @@ void ActivityEditScenarioView::updateVisibility()
     if (scenario_data.visible)
     {
         pageName->EmitSignal("visible.select", "calaos");
-        string r = "??";
+        std::string r = "??";
         if (scenario_data.room) r = scenario_data.room->name;
-        pageName->setPartText("visible.text", string(_("Displayed in the interface: ")) + "<blue>" + _("Displayed in") + " \"" + r + "\"</blue>");
+        pageName->setPartText("visible.text", std::string(_("Displayed in the interface: ")) + "<blue>" + _("Displayed in") + " \"" + r + "\"</blue>");
     }
     else
     {
         pageName->EmitSignal("visible.unselect", "calaos");
-        pageName->setPartText("visible.text", string(_("Displayed in the interface: ")) + "<blue>" + _("Don't display it.") + "</blue>");
+        pageName->setPartText("visible.text", std::string(_("Displayed in the interface: ")) + "<blue>" + _("Don't display it.") + "</blue>");
     }
 }
 
@@ -157,12 +157,12 @@ void ActivityEditScenarioView::updateCycling()
     if (scenario_data.params["cycle"] == "true")
     {
         pageActions->EmitSignal("cycle.select", "calaos");
-        pageActions->setPartText("cycle.text", string(_("Infinite loop: ")) + "<blue>" + _("Enabled") + "</blue>");
+        pageActions->setPartText("cycle.text", std::string(_("Infinite loop: ")) + "<blue>" + _("Enabled") + "</blue>");
     }
     else
     {
         pageActions->EmitSignal("cycle.unselect", "calaos");
-        pageActions->setPartText("cycle.text", string(_("Infinite loop: ")) + "<blue>" + _("Disabled") + "</blue>");
+        pageActions->setPartText("cycle.text", std::string(_("Infinite loop: ")) + "<blue>" + _("Disabled") + "</blue>");
     }
 }
 
@@ -176,11 +176,11 @@ void ActivityEditScenarioView::pageNameEditName(void *data, Evas_Object *_edje, 
                                              scenario_data.name);
 }
 
-void ActivityEditScenarioView::pageNameEditName_cb(string text)
+void ActivityEditScenarioView::pageNameEditName_cb(std::string text)
 {
     scenario_data.name = text;
     if (pageName)
-        pageName->setPartText("name.text", string(_("Scenario name")) + ": <blue>" + scenario_data.name + "</blue>");
+        pageName->setPartText("name.text", std::string(_("Scenario name")) + ": <blue>" + scenario_data.name + "</blue>");
 }
 
 void ActivityEditScenarioView::pageNameVisiblePressed(void *data, Evas_Object *_edje, std::string emission, std::string source)
@@ -194,7 +194,7 @@ void ActivityEditScenarioView::pageNameVisiblePressed(void *data, Evas_Object *_
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    string title_label = _("Display scenario<br><small><light_blue>Choose a room.</light_blue></small>");
+    std::string title_label = _("Display scenario<br><small><light_blue>Choose a room.</light_blue></small>");
     GenlistItemSimpleHeader *header = new GenlistItemSimpleHeader(evas, glist, title_label);
     header->Append(glist);
 
@@ -206,7 +206,7 @@ void ActivityEditScenarioView::pageNameVisiblePressed(void *data, Evas_Object *_
         item->setSelected(true);
     item->item_selected.connect(sigc::bind(sigc::mem_fun(*this, &ActivityEditScenarioView::itemRoomSelected), (Room *)NULL));
 
-    list<Room *>::iterator it = CalaosModel::Instance().getHome()->rooms.begin();
+    std::list<Room *>::iterator it = CalaosModel::Instance().getHome()->rooms.begin();
     for (;it != CalaosModel::Instance().getHome()->rooms.end();it++)
     {
         Room *room = *it;
@@ -279,7 +279,7 @@ void ActivityEditScenarioView::buttonPressed(void *data, Evas_Object *_edje, std
 
         current_wizstep++;
 
-        string _t = "set,step" + Utils::to_string(current_wizstep);
+        std::string _t = "set,step" + Utils::to_string(current_wizstep);
         EmitSignal(_t, "calaos");
 
         showStep(current_wizstep);
@@ -292,7 +292,7 @@ void ActivityEditScenarioView::buttonPressed(void *data, Evas_Object *_edje, std
 
         current_wizstep--;
 
-        string _t = "set,step" + Utils::to_string(current_wizstep);
+        std::string _t = "set,step" + Utils::to_string(current_wizstep);
         EmitSignal(_t, "calaos");
 
         elm_naviframe_item_pop(pager_step);
@@ -323,14 +323,14 @@ void ActivityEditScenarioView::loadPageActions()
     elm_object_style_set(actions_list, "calaos");
     evas_object_show(actions_list);
 
-    list<Room *>::iterator it = CalaosModel::Instance().getHome()->rooms.begin();
+    std::list<Room *>::iterator it = CalaosModel::Instance().getHome()->rooms.begin();
     for (;it != CalaosModel::Instance().getHome()->rooms.end();it++)
     {
         Room *r = *it;
         IOGenlistRoomGroupIcon *room = new IOGenlistRoomGroupIcon(evas, home_list, r, "");
         room->Append(home_list);
 
-        list<IOBase *>::iterator itio = r->scenario_ios.begin();
+        std::list<IOBase *>::iterator itio = r->scenario_ios.begin();
         for (;itio != r->scenario_ios.end();itio++)
         {
             IOBase *io = *itio;
@@ -348,7 +348,7 @@ void ActivityEditScenarioView::loadPageActions()
 
 void ActivityEditScenarioView::actionAddPressed(IOBase *io)
 {
-    map<Room *, GenlistItemBase *>::iterator it;
+    std::map<Room *, GenlistItemBase *>::iterator it;
     it = room_table.find(io->getRoom());
 
     ScenarioAction sa;
@@ -413,7 +413,7 @@ void ActivityEditScenarioView::loadActionsStep()
     if (edje_object_part_exists(pageActions->getEvasObject(), "button.step"))
     {
         Evas_Object *button = edje_object_part_external_object_get(pageActions->getEvasObject(), "button.step");
-        string _t = (current_step == ScenarioData::END_STEP)? _("Final step") : string(_("Step")) + " " + Utils::to_string(current_step + 1);
+        std::string _t = (current_step == ScenarioData::END_STEP)? _("Final step") : std::string(_("Step")) + " " + Utils::to_string(current_step + 1);
         elm_object_text_set(button, _t.c_str());
     }
 
@@ -486,7 +486,7 @@ void ActivityEditScenarioView::buttonStepPressed(void *data, Evas_Object *_edje,
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    string title_label = string(_("Scenario step")) + "<br><small><light_blue>" + string(_("Scenario progress")) + "</light_blue></small>";
+    std::string title_label = std::string(_("Scenario step")) + "<br><small><light_blue>" + std::string(_("Scenario progress")) + "</light_blue></small>";
     GenlistItemBase *header = new GenlistItemSimpleHeader(evas, glist, title_label);
     header->Append(glist);
 
@@ -495,7 +495,7 @@ void ActivityEditScenarioView::buttonStepPressed(void *data, Evas_Object *_edje,
     {
         ScenarioStep &step = scenario_data.steps[i];
 
-        GenlistItemSimple *item = new GenlistItemSimple(evas, parent, string(_("Step")) + " " + Utils::to_string(i + 1), true, false, NULL, "check");
+        GenlistItemSimple *item = new GenlistItemSimple(evas, parent, std::string(_("Step")) + " " + Utils::to_string(i + 1), true, false, NULL, "check");
         item->Append(glist, header);
         if ((int)i == current_step)
         {
@@ -504,7 +504,7 @@ void ActivityEditScenarioView::buttonStepPressed(void *data, Evas_Object *_edje,
         }
         item->item_selected.connect(sigc::bind(sigc::mem_fun(*this, &ActivityEditScenarioView::stepSelect), i));
 
-        string _t = _("Pause: ") + time2string(step.pause / 1000, step.pause % 1000);
+        std::string _t = _("Pause: ") + time2string(step.pause / 1000, step.pause % 1000);
         GenlistItemSimple *item_pause = new GenlistItemSimple(evas, parent, _t, true, false, NULL, "disclosure");
         item_pause->Append(glist, header);
         item_pause->item_selected.connect(sigc::bind(sigc::mem_fun(*this, &ActivityEditScenarioView::stepPauseChange), i, item_pause));
@@ -555,7 +555,7 @@ void ActivityEditScenarioView::stepPauseChange(void *data, int step, GenlistItem
     page->setAutoDelete(true);
     page->addCallback("button.back", "pressed", sigc::mem_fun(*this, &ActivityEditScenarioView::buttonPauseBackClick));
     page->addCallback("button.valid", "pressed", sigc::bind(sigc::mem_fun(*this, &ActivityEditScenarioView::buttonPauseValidTimeClick), step, item));
-    string t = "<b>" + string(_("Choose time")) + "</b><br><light_blue><small>" + string(_("Pause time before next step")) + "</small></light_blue>";
+    std::string t = "<b>" + std::string(_("Choose time")) + "</b><br><light_blue><small>" + std::string(_("Pause time before next step")) + "</small></light_blue>";
     page->setPartText("text", t);
 
     if (edje_object_part_exists(page->getEvasObject(), "button.back"))
@@ -616,19 +616,19 @@ void ActivityEditScenarioView::stepPauseChange(void *data, int step, GenlistItem
     elm_naviframe_item_push(pager_step_popup, NULL, NULL, NULL, page->getEvasObject(), "calaos");
 }
 
-void ActivityEditScenarioView::buttonPauseBackClick(void *data, Evas_Object *edje_object, string emission, string source)
+void ActivityEditScenarioView::buttonPauseBackClick(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     elm_naviframe_item_pop(pager_step_popup);
 }
 
-void ActivityEditScenarioView::buttonPauseValidTimeClick(void *data, Evas_Object *edje_object, string emission, string source, int step, GenlistItemSimple *item)
+void ActivityEditScenarioView::buttonPauseValidTimeClick(void *data, Evas_Object *edje_object, std::string emission, std::string source, int step, GenlistItemSimple *item)
 {
     scenario_data.steps[step].pause = elm_spinner_value_get(spin_hours) * 60.0 * 60.0 * 1000.0 +
                                       elm_spinner_value_get(spin_min) * 60.0 * 1000.0 +
                                       elm_spinner_value_get(spin_sec) * 1000.0 +
                                       elm_spinner_value_get(spin_ms);
 
-    string _t = _("Pause: ") + time2string(scenario_data.steps[step].pause / 1000, scenario_data.steps[step].pause % 1000);
+    std::string _t = _("Pause: ") + time2string(scenario_data.steps[step].pause / 1000, scenario_data.steps[step].pause % 1000);
     item->setLabelText(_t);
     elm_naviframe_item_pop(pager_step_popup);
 }
@@ -653,7 +653,7 @@ void ActivityEditScenarioView::buttonStepDelPressed(void *data, Evas_Object *_ed
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    string title_label = string(_("Confirmation")) + "<br><small><light_blue>" + string(_("Are you sure to delete this step?")) + "</light_blue></small>";
+    std::string title_label = std::string(_("Confirmation")) + "<br><small><light_blue>" + std::string(_("Are you sure to delete this step?")) + "</light_blue></small>";
     GenlistItemBase *header = new GenlistItemSimpleHeader(evas, glist, title_label);
     header->Append(glist);
 

--- a/src/bin/calaos_home/views/ActivityEditScenarioView.h
+++ b/src/bin/calaos_home/views/ActivityEditScenarioView.h
@@ -27,7 +27,6 @@
 #include "GenlistItemBase.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class GenlistItemSimple;
 class GenlistItemScenarioAction;
@@ -46,7 +45,7 @@ private:
 
     ScenarioData scenario_data;
 
-    list<IOBase *> cache_ios; //show all controlable ios
+    std::list<IOBase *> cache_ios; //show all controlable ios
 
     Evas_Object *popup, *step_popup;
 
@@ -55,7 +54,7 @@ private:
     Evas_Object *spin_sec;
     Evas_Object *spin_ms;
 
-    map<Room *, GenlistItemBase *> room_table;
+    std::map<Room *, GenlistItemBase *> room_table;
 
     void buttonPressed(void *data, Evas_Object *_edje, std::string emission, std::string source);
     void showStep(int step);
@@ -63,10 +62,10 @@ private:
     void pageActionsDeleted();
     void loadPageActions();
     void loadActionsStep();
-    string getIconForIO(IOBase *io);
+    std::string getIconForIO(IOBase *io);
 
     void pageNameEditName(void *data, Evas_Object *_edje, std::string emission, std::string source);
-    void pageNameEditName_cb(string text);
+    void pageNameEditName_cb(std::string text);
 
     void pageNameVisiblePressed(void *data, Evas_Object *_edje, std::string emission, std::string source);
     void pageActionsCyclePressed(void *data, Evas_Object *_edje, std::string emission, std::string source);
@@ -83,8 +82,8 @@ private:
 
     void stepSelect(void *data, int step);
     void stepPauseChange(void *data, int step, GenlistItemSimple *item);
-    void buttonPauseBackClick(void *data, Evas_Object *edje_object, string emission, string source);
-    void buttonPauseValidTimeClick(void *data, Evas_Object *edje_object, string emission, string source, int step, GenlistItemSimple *item);
+    void buttonPauseBackClick(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void buttonPauseValidTimeClick(void *data, Evas_Object *edje_object, std::string emission, std::string source, int step, GenlistItemSimple *item);
 
     void deleteStepValid(void *data);
     void deleteStepCancel(void *data);

--- a/src/bin/calaos_home/views/ActivityHomeView.cpp
+++ b/src/bin/calaos_home/views/ActivityHomeView.cpp
@@ -108,14 +108,14 @@ void ActivityHomeView::objectHidden()
     EmitSignal("hide,left", "calaos");
 }
 
-void ActivityHomeView::setRoom(string type, int position, IOBase *chauffage)
+void ActivityHomeView::setRoom(std::string type, int position, IOBase *chauffage)
 {
     if (rooms[position])
         delete rooms[position];
 
     EmitSignal("reset,rooms", "calaos");
 
-    string t = type;
+    std::string t = type;
 
     if (type == "salon") t = "lounge";
     if (type == "chambre") t = "bedroom";
@@ -131,14 +131,14 @@ void ActivityHomeView::setRoom(string type, int position, IOBase *chauffage)
     if (type == "couloir") t = "corridor";
 
     rooms[position] = new EdjeObject(ApplicationMain::getTheme(), evas);
-    string group = "calaos/room/";
+    std::string group = "calaos/room/";
 
     if (!rooms[position]->LoadEdje(group + t))
     {
         //room not found, load default
         if (!rooms[position]->LoadEdje("calaos/room/various"))
         {
-            throw(runtime_error("ActivityHomeView::setRoom(): Can't load edje !"));
+            throw(std::runtime_error("ActivityHomeView::setRoom(): Can't load edje !"));
         }
     }
 
@@ -164,7 +164,7 @@ void ActivityHomeView::setRoom(string type, int position, IOBase *chauffage)
         updateChauffage(position);
     }
 
-    EmitSignal(string("enable,room,") + Utils::to_string(position + 1), "calaos"); //this enable mouse click on unused rooms
+    EmitSignal(std::string("enable,room,") + Utils::to_string(position + 1), "calaos"); //this enable mouse click on unused rooms
 }
 
 void ActivityHomeView::updateChauffage(int pos)
@@ -172,7 +172,7 @@ void ActivityHomeView::updateChauffage(int pos)
     if (pos < 0 || pos >= 6 || !rooms[pos])
         return;
 
-    string t = chauffages[pos]->params["state"];
+    std::string t = chauffages[pos]->params["state"];
     rooms[pos]->setPartText("chauffage.temp.small", t + " °C");
 
     IOBase *consigne = CalaosModel::Instance().getHome()->getConsigneFromTemp(chauffages[pos]);
@@ -194,7 +194,7 @@ void ActivityHomeView::delChauffage(int pos)
 void ActivityHomeView::hideRoom(int position)
 {
     rooms[position]->EmitSignal("hide", "calaos");
-    EmitSignal(string("disable,room,") + Utils::to_string(position + 1), "calaos"); //this disable mouse click on unused rooms
+    EmitSignal(std::string("disable,room,") + Utils::to_string(position + 1), "calaos"); //this disable mouse click on unused rooms
 }
 
 void ActivityHomeView::resetRooms()
@@ -344,13 +344,13 @@ void ActivityHomeView::ButtonLightsInfoCb(void *data, Evas_Object *_edje, std::s
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    map<Room *, list<IOBase *> > lights = CalaosModel::Instance().getHome()->getLightsOnForRooms();
-    map<Room *, list<IOBase *> >::iterator it = lights.begin();
+    std::map<Room *, std::list<IOBase *> > lights = CalaosModel::Instance().getHome()->getLightsOnForRooms();
+    std::map<Room *, std::list<IOBase *> >::iterator it = lights.begin();
     for (;it != lights.end();it++)
     {
         Room *room = (*it).first;
-        list<IOBase *> &ios = (*it).second;
-        list<IOBase *>::iterator it_io;
+        std::list<IOBase *> &ios = (*it).second;
+        std::list<IOBase *>::iterator it_io;
 
         //Create group header
         GenlistItemBase *group_item = new IOGenlistRoomGroup(evas, parent, room, "");
@@ -398,13 +398,13 @@ void ActivityHomeView::ButtonShuttersInfoCb(void *data, Evas_Object *_edje, std:
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    map<Room *, list<IOBase *> > shutters = CalaosModel::Instance().getHome()->getShuttersUpForRooms();
-    map<Room *, list<IOBase *> >::iterator it = shutters.begin();
+    std::map<Room *, std::list<IOBase *> > shutters = CalaosModel::Instance().getHome()->getShuttersUpForRooms();
+    std::map<Room *, std::list<IOBase *> >::iterator it = shutters.begin();
     for (;it != shutters.end();it++)
     {
         Room *room = (*it).first;
-        list<IOBase *> &ios = (*it).second;
-        list<IOBase *>::iterator it_io;
+        std::list<IOBase *> &ios = (*it).second;
+        std::list<IOBase *>::iterator it_io;
 
         //Create group header
         GenlistItemBase *group_item = new IOGenlistRoomGroup(evas, parent, room, "");
@@ -429,12 +429,12 @@ void ActivityHomeView::ButtonShuttersInfoCb(void *data, Evas_Object *_edje, std:
     evas_object_show(popup);
 }
 
-void ActivityHomeView::setLightsOnText(string txt)
+void ActivityHomeView::setLightsOnText(std::string txt)
 {
     pageStatus->setPartText("light.text", txt);
 }
 
-void ActivityHomeView::setShuttersUpText(string txt)
+void ActivityHomeView::setShuttersUpText(std::string txt)
 {
     pageStatus->setPartText("shutter.text", txt);
 }
@@ -468,13 +468,13 @@ void ActivityHomeView::addStatusPage()
     page_view->addPage(pageStatus->getEvasObject());
 }
 
-void ActivityHomeView::addScenarioPage(list<IOBase *> &scenarios_io)
+void ActivityHomeView::addScenarioPage(std::list<IOBase *> &scenarios_io)
 {
     EdjeObject *container = new EdjeObject(theme, evas);
     container->LoadEdje("calaos/page/home/scenario");
     container->setAutoDelete(true);
 
-    list<IOBase *>::iterator it = scenarios_io.begin();
+    std::list<IOBase *>::iterator it = scenarios_io.begin();
     for (int i = 0;it != scenarios_io.end() && i < 6;it++, i++)
     {
         IOView *ioView = IOViewFactory::CreateIOView(evas, getEvasObject(), IOView::IO_SCENARIO_HOME);
@@ -482,7 +482,7 @@ void ActivityHomeView::addScenarioPage(list<IOBase *> &scenarios_io)
         ioView->Show();
         ioView->initView();
 
-        string _t = "element." + Utils::to_string(i + 1);
+        std::string _t = "element." + Utils::to_string(i + 1);
         container->Swallow(ioView, _t, true);
     }
 
@@ -538,7 +538,7 @@ void ActivityHomeView::changeCurrentRoomDetail(Room *room)
     elm_genlist_clear(list_left);
     elm_genlist_clear(list_right);
 
-    list<IOBase *>::iterator it = room->visible_ios.begin();
+    std::list<IOBase *>::iterator it = room->visible_ios.begin();
     for (int i = 0;it != room->visible_ios.end();it++, i++)
     {
         if (i % 2)
@@ -560,11 +560,11 @@ static void _del_list_data_cb(void *data, Evas_Object *obj, void *item)
 void ActivityHomeView::setCurrentRoomDetail(Room *room)
 {
     //Update top room list from current room type
-    list<Room *> list_room_type = CalaosModel::Instance().getHome()->getRoomsForType(room->type);
+    std::list<Room *> list_room_type = CalaosModel::Instance().getHome()->getRoomsForType(room->type);
 
     Elm_Object_Item *item = NULL;
 
-    list<Room *>::iterator it = list_room_type.begin();
+    std::list<Room *>::iterator it = list_room_type.begin();
     for (;it != list_room_type.end();it++)
     {
         Room *r = *it;

--- a/src/bin/calaos_home/views/ActivityHomeView.h
+++ b/src/bin/calaos_home/views/ActivityHomeView.h
@@ -29,7 +29,6 @@
 #include <IOView.h>
 #include <PagingView.h>
 
-using namespace Utils;
 
 class ActivityHomeView;
 class HomeRoomClickData
@@ -45,12 +44,12 @@ protected:
     virtual void objectShown();
     virtual void objectHidden();
 
-    vector<HomeRoomClickData *> dataRoomCallbacks;
+    std::vector<HomeRoomClickData *> dataRoomCallbacks;
 
-    vector<IOBase *> chauffages;
-    vector<sigc::connection> chauff_change_con;
-    vector<sigc::connection> chauff_del_con;
-    vector<EdjeObject *> rooms;
+    std::vector<IOBase *> chauffages;
+    std::vector<sigc::connection> chauff_change_con;
+    std::vector<sigc::connection> chauff_del_con;
+    std::vector<EdjeObject *> rooms;
 
     Evas_Object *list_top;
     Evas_Object *list_left;
@@ -86,11 +85,11 @@ public:
     ActivityHomeView(Evas *evas, Evas_Object *parent);
     ~ActivityHomeView();
 
-    void setRoom(string type, int position, IOBase *chauffage);
+    void setRoom(std::string type, int position, IOBase *chauffage);
     void hideRoom(int position);
 
     void addStatusPage();
-    void addScenarioPage(list<IOBase *> &ios);
+    void addScenarioPage(std::list<IOBase *> &ios);
     void removePage(int p);
     int getPageCount();
     int getCurrentPage();
@@ -107,8 +106,8 @@ public:
 
     virtual void resetView();
 
-    void setLightsOnText(string txt);
-    void setShuttersUpText(string txt);
+    void setLightsOnText(std::string txt);
+    void setShuttersUpText(std::string txt);
 
     void clearLists();
     void setCurrentRoomDetail(Room *room);

--- a/src/bin/calaos_home/views/ActivityKeyboardView.cpp
+++ b/src/bin/calaos_home/views/ActivityKeyboardView.cpp
@@ -62,7 +62,7 @@ void ActivityKeyboardView::setMultiline(bool multiline)
         elm_object_style_set(textblock, "calaos");
 }
 
-void ActivityKeyboardView::setSubtitle(string subtitle)
+void ActivityKeyboardView::setSubtitle(std::string subtitle)
 {
     setPartText("module.subtitle", subtitle);
 }
@@ -75,11 +75,11 @@ void ActivityKeyboardView::clearTextCb(void *data, Evas_Object *_edje, std::stri
 
 void ActivityKeyboardView::validInputCb(void *data, Evas_Object *_edje, std::string emission, std::string source)
 {
-    string val = elm_entry_entry_get(textblock);
+    std::string val = elm_entry_entry_get(textblock);
     validPressed.emit(val);
 }
 
-void ActivityKeyboardView::setText(string t)
+void ActivityKeyboardView::setText(std::string t)
 {
     elm_entry_entry_set(textblock, t.c_str());
 }

--- a/src/bin/calaos_home/views/ActivityKeyboardView.h
+++ b/src/bin/calaos_home/views/ActivityKeyboardView.h
@@ -26,7 +26,6 @@
 #include "ActivityView.h"
 #include "KeyboardView.h"
 
-using namespace Utils;
 
 class ActivityKeyboardView: public ActivityView
 {
@@ -44,11 +43,11 @@ public:
     virtual void resetView();
 
     void setMultiline(bool multiline);
-    void setSubtitle(string subtitle);
-    void setText(string t);
+    void setSubtitle(std::string subtitle);
+    void setText(std::string t);
 
     sigc::signal<void> clearText;
-    sigc::signal<void, string> validPressed;
+    sigc::signal<void, std::string> validPressed;
 };
 
 #endif // ActivityKeyboardView_H

--- a/src/bin/calaos_home/views/ActivityMediaMenuView.cpp
+++ b/src/bin/calaos_home/views/ActivityMediaMenuView.cpp
@@ -48,11 +48,11 @@ ActivityMediaMenuView::ActivityMediaMenuView(Evas *_e, Evas_Object *_parent):
 
 ActivityMediaMenuView::~ActivityMediaMenuView()
 {
-    for_each(items.begin(), items.end(), Delete());
+    for_each(items.begin(), items.end(), Utils::Delete());
     items.clear();
 }
 
-void ActivityMediaMenuView::addIcon(int position, string type)
+void ActivityMediaMenuView::addIcon(int position, std::string type)
 {
     if (Utils::get_config_option("enable_media_" + type) != "false")
     {
@@ -85,7 +85,7 @@ void ActivityMediaMenuView::addIcon(int position, string type)
             obj->setPartText("item_description", _("Play with physics !"));
         }
         obj->addCallback("menu", "click," + type, sigc::mem_fun(*this, &ActivityMediaMenuView::ItemCallback));
-        Swallow(obj, string("icon.") + Utils::to_string(position));
+        Swallow(obj, std::string("icon.") + Utils::to_string(position));
         obj->EmitSignal("show", "calaos");
         obj->Show();
         items.push_back(obj);
@@ -93,7 +93,7 @@ void ActivityMediaMenuView::addIcon(int position, string type)
     }
 }
 
-void ActivityMediaMenuView::ItemCallback(void *data, Evas_Object *_edje, string emission, string source)
+void ActivityMediaMenuView::ItemCallback(void *data, Evas_Object *_edje, std::string emission, std::string source)
 {
     if (source != "menu") return;
 

--- a/src/bin/calaos_home/views/ActivityMediaMenuView.h
+++ b/src/bin/calaos_home/views/ActivityMediaMenuView.h
@@ -25,16 +25,15 @@
 
 #include "ActivityView.h"
 
-using namespace Utils;
 
 class ActivityMediaMenuView: public ActivityView
 {
 private:
-    list<EdjeObject *> items;
+    std::list<EdjeObject *> items;
 
-    void addIcon(int position, string type);
+    void addIcon(int position, std::string type);
 
-    void ItemCallback(void *data, Evas_Object *edje, string emission, string source);
+    void ItemCallback(void *data, Evas_Object *edje, std::string emission, std::string source);
 
 public:
     ActivityMediaMenuView(Evas *evas, Evas_Object *parent);
@@ -42,9 +41,9 @@ public:
 
     virtual void resetView();
 
-    virtual string getTitle() { return "Multimédia"; }
+    virtual std::string getTitle() { return "Multimédia"; }
 
-    sigc::signal<void, string> menu_item_clicked;
+    sigc::signal<void, std::string> menu_item_clicked;
 };
 
 #endif // ACTIVITYMEDIAMENUVIEW_H

--- a/src/bin/calaos_home/views/ActivityMediaView.h
+++ b/src/bin/calaos_home/views/ActivityMediaView.h
@@ -26,7 +26,6 @@
 #include "ActivityView.h"
 #include "MainContentView.h"
 
-using namespace Utils;
 
 class ActivityMediaView: public ActivityView
 {
@@ -45,7 +44,7 @@ public:
     BaseView *getTopView() { return contentView->getTopView(); }
     void removeTopView() { contentView->removeTopView(); }
 
-    sigc::signal<void, string> button_clicked;
+    sigc::signal<void, std::string> button_clicked;
 };
 
 #endif // ACTIVITYMEDIAVIEW_H

--- a/src/bin/calaos_home/views/ActivityScenariosView.cpp
+++ b/src/bin/calaos_home/views/ActivityScenariosView.cpp
@@ -204,7 +204,7 @@ void ActivityScenariosView::loadScenarioList()
     }
 
     //populate the scenario list
-    list<Scenario *>::iterator it = CalaosModel::Instance().getScenario()->scenarios.begin();
+    std::list<Scenario *>::iterator it = CalaosModel::Instance().getScenario()->scenarios.begin();
     for (;it != CalaosModel::Instance().getScenario()->scenarios.end();it++)
     {
         Scenario *sc = *it;
@@ -266,7 +266,7 @@ void ActivityScenariosView::reloadCalendar()
 {
     elm_genlist_clear(schedule_list);
 
-    string weekday;
+    std::string weekday;
     switch (currDate.tm_wday)
     {
     case 0: weekday = _("Sunday"); break;
@@ -279,7 +279,7 @@ void ActivityScenariosView::reloadCalendar()
     default: break;
     }
 
-    string month;
+    std::string month;
     switch (currDate.tm_mon)
     {
     case 0: month = _("January"); break;
@@ -297,14 +297,14 @@ void ActivityScenariosView::reloadCalendar()
     default: break;
     }
 
-    string label = _("On <blue>%1, %2 %3, %4</blue>");
+    std::string label = _("On <blue>%1, %2 %3, %4</blue>");
     Utils::replace_str(label, "%1", weekday);
     Utils::replace_str(label, "%2", month);
     Utils::replace_str(label, "%3", Utils::to_string(currDate.tm_mday));
     Utils::replace_str(label, "%4", Utils::to_string(currDate.tm_year + 1900));
     setPartText("schedule.date", label);
 
-    list<ScenarioSchedule> lst = CalaosModel::Instance().getScenario()->getScenarioForDate(currDate);
+    std::list<ScenarioSchedule> lst = CalaosModel::Instance().getScenario()->getScenarioForDate(currDate);
     for (auto i = lst.begin();i != lst.end();i++)
     {
         ScenarioSchedule sc = *i;

--- a/src/bin/calaos_home/views/ActivityScenariosView.h
+++ b/src/bin/calaos_home/views/ActivityScenariosView.h
@@ -26,7 +26,6 @@
 #include "ActivityView.h"
 #include "CalaosModel.h"
 
-using namespace Utils;
 
 class ActivityScenariosView: public ActivityView
 {

--- a/src/bin/calaos_home/views/ActivityScheduleScenarioView.cpp
+++ b/src/bin/calaos_home/views/ActivityScheduleScenarioView.cpp
@@ -225,7 +225,7 @@ void ActivityScheduleScenarioView::showTimeRangePopup()
     evas_object_show(popup);
 }
 
-void ActivityScheduleScenarioView::createTimeSelectTypeList(void *data, Evas_Object *edje_object, string emission, string source)
+void ActivityScheduleScenarioView::createTimeSelectTypeList(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     if ((editState == EDIT_START_TIME || editState == EDIT_START_TIME_OFFSET) && cycle)
     {
@@ -259,7 +259,7 @@ void ActivityScheduleScenarioView::createTimeSelectTypeList(void *data, Evas_Obj
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    string title_label;
+    std::string title_label;
     GenlistItemSimpleHeader *header = NULL;
     if (editState == EDIT_START_TYPE)
     {
@@ -342,7 +342,7 @@ void ActivityScheduleScenarioView::selectTimeType(void *data)
         evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
         evas_object_show(glist);
 
-        string title_label = _("<b>Offset time</b><br><light_blue><small>You can choose to shift the sun time</small></light_blue>");
+        std::string title_label = _("<b>Offset time</b><br><light_blue><small>You can choose to shift the sun time</small></light_blue>");
         GenlistItemSimpleHeader *header = new GenlistItemSimpleHeader(evas, glist, title_label, "navigation_back");
         header->Append(glist);
         header->setButtonLabel("button.back", _("Beginning"));
@@ -449,7 +449,7 @@ void ActivityScheduleScenarioView::showTimeSelection(void *data)
         page->addCallback("button.valid", "pressed", sigc::mem_fun(*this, &ActivityScheduleScenarioView::createTimeSelectTypeList));
     else
         page->addCallback("button.valid", "pressed", sigc::mem_fun(*this, &ActivityScheduleScenarioView::showWeekSelection));
-    string t;
+    std::string t;
     if (editState == EDIT_START_TIME)
         t = _("<b>Choose a schedule</b><br><light_blue><small>Start time of scenario</small></light_blue>");
     else if (editState == EDIT_END_TIME)
@@ -519,7 +519,7 @@ void ActivityScheduleScenarioView::showTimeSelection(void *data)
     elm_naviframe_item_push(pager_popup, NULL, NULL, NULL, page->getEvasObject(), "calaos");
 }
 
-void ActivityScheduleScenarioView::showWeekSelection(void *data, Evas_Object *edje_object, string emission, string source)
+void ActivityScheduleScenarioView::showWeekSelection(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     if (cycle)
     {
@@ -558,7 +558,7 @@ void ActivityScheduleScenarioView::showWeekSelection(void *data, Evas_Object *ed
     elm_genlist_multi_select_set(glist, true);
     evas_object_show(glist);
 
-    string title_label = _("Days of the week<br><small><light_blue>Days of the week when scenario is executed.</light_blue></small>");
+    std::string title_label = _("Days of the week<br><small><light_blue>Days of the week when scenario is executed.</light_blue></small>");
     GenlistItemSimpleHeader *header = new GenlistItemSimpleHeader(evas, glist, title_label, "navigation");
     header->Append(glist);
 
@@ -574,7 +574,7 @@ void ActivityScheduleScenarioView::showWeekSelection(void *data, Evas_Object *ed
 
     for (int i = 0;i < 8;i++)
     {
-        string label;
+        std::string label;
         switch (i)
         {
         case 0: label = _("Everyday"); break;
@@ -608,7 +608,7 @@ void ActivityScheduleScenarioView::showWeekSelection(void *data, Evas_Object *ed
     elm_naviframe_item_push(pager_popup, NULL, NULL, NULL, table, "calaos");
 }
 
-void ActivityScheduleScenarioView::headerWeekButtonClick(string bt)
+void ActivityScheduleScenarioView::headerWeekButtonClick(std::string bt)
 {
     if (bt == "button.back")
     {
@@ -646,14 +646,14 @@ void ActivityScheduleScenarioView::headerWeekButtonClick(string bt)
     }
 }
 
-void ActivityScheduleScenarioView::buttonBackClick(void *data, Evas_Object *edje_object, string emission, string source)
+void ActivityScheduleScenarioView::buttonBackClick(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     editState = editStatesHist.top();
     editStatesHist.pop();
     elm_naviframe_item_pop(pager_popup);
 }
 
-void ActivityScheduleScenarioView::buttonHeaderBackClick(string button)
+void ActivityScheduleScenarioView::buttonHeaderBackClick(std::string button)
 {
     editState = editStatesHist.top();
     editStatesHist.pop();
@@ -675,8 +675,8 @@ void ActivityScheduleScenarioView::reloadTimeRanges()
 {
     elm_genlist_clear(schedule_list);
 
-    vector<TimeRange> trange_sorted;
-    auto sortTimeRange = [&trange_sorted](const vector<TimeRange> &range, int day)
+    std::vector<TimeRange> trange_sorted;
+    auto sortTimeRange = [&trange_sorted](const std::vector<TimeRange> &range, int day)
     {
         for (const TimeRange &t: range)
         {
@@ -727,7 +727,7 @@ void ActivityScheduleScenarioView::reloadTimeRanges()
             evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
             evas_object_show(glist);
 
-            string title_label = _("Confirmation");
+            std::string title_label = _("Confirmation");
             title_label += "<br><small><light_blue>";
             title_label += _("Are you sure to delete this schedule?");
             title_label +=  "</light_blue></small>";
@@ -788,7 +788,7 @@ void ActivityScheduleScenarioView::reloadTimeRanges()
 
 void ActivityScheduleScenarioView::deleteTimeRange(const TimeRange &range)
 {
-    auto delRange = [=](vector<TimeRange> &vrange)
+    auto delRange = [=](std::vector<TimeRange> &vrange)
     {
         auto it = std::find(vrange.begin(), vrange.end(), range);
         if (it != vrange.end())

--- a/src/bin/calaos_home/views/ActivityScheduleScenarioView.h
+++ b/src/bin/calaos_home/views/ActivityScheduleScenarioView.h
@@ -27,7 +27,6 @@
 #include "CalaosModel.h"
 #include "GenlistItemSimple.h"
 
-using namespace Utils;
 
 class ActivityScheduleScenarioView: public ActivityView
 {
@@ -38,8 +37,8 @@ private:
     Evas_Object *schedule_list, *month_list;
 
     GenlistItemSimple *item_all;
-    vector<GenlistItemSimple *> items_months;
-    vector<GenlistItemSimple *> items_periods;
+    std::vector<GenlistItemSimple *> items_months;
+    std::vector<GenlistItemSimple *> items_periods;
 
     Evas_Object *popup;
     Evas_Object *pager_popup;
@@ -52,7 +51,7 @@ private:
     Evas_Object *spin_end_min;
     Evas_Object *spin_end_sec;
 
-    vector<GenlistItemSimple *> week_days;
+    std::vector<GenlistItemSimple *> week_days;
 
     //store current data we are editing, also used to set default value
     TimeRange edit_range;
@@ -63,7 +62,7 @@ private:
            EDIT_WEEK};
     int editState;
 
-    stack<int> editStatesHist;
+    std::stack<int> editStatesHist;
 
     bool cycle;
 
@@ -73,19 +72,19 @@ private:
 
     void reloadTimeRanges();
 
-    void buttonValidEndClick(void *data, Evas_Object *edje_object, string emission, string source);
-    void buttonValidWeekClick(void *data, Evas_Object *edje_object, string emission, string source);
-    void buttonBackClick(void *data, Evas_Object *edje_object, string emission, string source);
-    void buttonHeaderBackClick(string button);
+    void buttonValidEndClick(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void buttonValidWeekClick(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void buttonBackClick(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void buttonHeaderBackClick(std::string button);
 
     void unselectWeekDays(void *data);
     void unselectAllWeekDays(void *data);
-    void headerWeekButtonClick(string bt);
+    void headerWeekButtonClick(std::string bt);
 
-    void createTimeSelectTypeList(void *data, Evas_Object *edje_object, string emission, string source);
+    void createTimeSelectTypeList(void *data, Evas_Object *edje_object, std::string emission, std::string source);
     void selectTimeType(void *data);
     void showTimeSelection(void *data);
-    void showWeekSelection(void *data, Evas_Object *edje_object, string emission, string source);
+    void showWeekSelection(void *data, Evas_Object *edje_object, std::string emission, std::string source);
 
     void deleteTimeRange(const TimeRange &range);
 

--- a/src/bin/calaos_home/views/ActivityView.cpp
+++ b/src/bin/calaos_home/views/ActivityView.cpp
@@ -56,7 +56,7 @@ ActivityView::ActivityView(Evas *_e, Evas_Object *_parent):
 {
 }
 
-ActivityView::ActivityView(Evas *_e, Evas_Object *_parent, string _collection):
+ActivityView::ActivityView(Evas *_e, Evas_Object *_parent, std::string _collection):
     BaseView(_e, _parent),
     box_buttons(NULL),
     button_quit(NULL)
@@ -65,7 +65,7 @@ ActivityView::ActivityView(Evas *_e, Evas_Object *_parent, string _collection):
     {
         LoadEdje(_collection);
     }
-    catch(exception const& e)
+    catch(std::exception const& e)
     {
         cCritical() <<  "ActivityView: Can't load edje";
         throw;
@@ -117,7 +117,7 @@ ActivityView *ActivityViewFactory::CreateView(Evas *evas, Evas_Object *parent, i
         case ACTIVITY_VIEW_NONE: break;
         }
     }
-    catch (exception const& e)
+    catch (std::exception const& e)
     {
         cCritical() <<  "ActivityViewFactory: Can't create viewType:" << viewTypeString(viewType);
         throw;
@@ -132,7 +132,7 @@ ActivityView *ActivityViewFactory::CreateView(Evas *evas, Evas_Object *parent, i
     return view;
 }
 
-string ActivityViewFactory::viewTypeString(int viewType)
+std::string ActivityViewFactory::viewTypeString(int viewType)
 {
     switch (viewType)
     {

--- a/src/bin/calaos_home/views/ActivityView.h
+++ b/src/bin/calaos_home/views/ActivityView.h
@@ -25,7 +25,6 @@
 
 #include "BaseView.h"
 
-using namespace Utils;
 
 class ActivityView: public BaseView
 {
@@ -38,7 +37,7 @@ protected:
 
 public:
     ActivityView(Evas *evas, Evas_Object *parent);
-    ActivityView(Evas *evas, Evas_Object *parent, string collection);
+    ActivityView(Evas *evas, Evas_Object *parent, std::string collection);
     virtual ~ActivityView();
 
     virtual void resetView() = 0;
@@ -52,7 +51,7 @@ public:
 class ActivityViewFactory
 {
 private:
-    static string viewTypeString(int viewType);
+    static std::string viewTypeString(int viewType);
 
 public:
     enum { ACTIVITY_VIEW_NONE, ACTIVITY_VIEW_HOME, ACTIVITY_VIEW_MEDIA,

--- a/src/bin/calaos_home/views/ActivityWebView.cpp
+++ b/src/bin/calaos_home/views/ActivityWebView.cpp
@@ -156,7 +156,7 @@ void ActivityWebView::_webLoadProgress()
 {
     setDragValue("progress.level", elm_web_load_progress_get(web), 0.0);
 
-    string t = Utils::to_string((int)(elm_web_load_progress_get(web) * 100)) + " %";
+    std::string t = Utils::to_string((int)(elm_web_load_progress_get(web) * 100)) + " %";
     setPartText("progress.text", t);
 }
 
@@ -168,7 +168,7 @@ void ActivityWebView::_webLoadFinished(Elm_Web_Frame_Load_Error *error)
     if (error && !error->is_cancellation)
     {
 #ifdef HAVE_EWEBKIT
-        string t = WEBKIT_ERROR_HTML;
+        std::string t = WEBKIT_ERROR_HTML;
         replace_str(t, "{FAILING_URL}", error->failing_url);
         replace_str(t, "{DESC}", error->description);
 
@@ -199,7 +199,7 @@ void ActivityWebView::_webInputMethodChanged(bool en)
         EmitSignal("hide,keyboard", "calaos");
 }
 
-void ActivityWebView::buttonCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void ActivityWebView::buttonCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     if (source == "button.back")
         elm_web_back(web);
@@ -222,9 +222,9 @@ void ActivityWebView::buttonCallback(void *data, Evas_Object *edje_object, strin
     }
     else if (source == "button.bookmark")
     {
-        string url = elm_web_url_get(web);
+        std::string url = elm_web_url_get(web);
 
-        string _url = DEFAULT_BROWSER_URL;
+        std::string _url = DEFAULT_BROWSER_URL;
         _url += "Bookmark.php?new=" + url_encode(url);
         _url += "&title=" + url_encode(elm_web_title_get(web));
         _url += "&thumb_file=/tmp/thumb.png";
@@ -238,9 +238,9 @@ void ActivityWebView::buttonCallback(void *data, Evas_Object *edje_object, strin
     }
 }
 
-void ActivityWebView::goToCallback(string text)
+void ActivityWebView::goToCallback(std::string text)
 {
-    string url;
+    std::string url;
 
     remove_tag(text, "<", ">");
     if (text.substr(0, 7) != "http://" && text.substr(0, 8) != "https://")

--- a/src/bin/calaos_home/views/ActivityWebView.h
+++ b/src/bin/calaos_home/views/ActivityWebView.h
@@ -26,7 +26,6 @@
 #include "ActivityView.h"
 #include "KeyboardView.h"
 
-using namespace Utils;
 
 class ActivityWebView: public ActivityView
 {
@@ -34,8 +33,8 @@ private:
     KeyboardView *keyboard;
     Evas_Object *web;
 
-    void buttonCallback(void *data, Evas_Object *edje_object, string emission, string source);
-    void goToCallback(string url);
+    void buttonCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void goToCallback(std::string url);
 
 public:
     ActivityWebView(Evas *evas, Evas_Object *parent);

--- a/src/bin/calaos_home/views/ActivityWidgetsView.cpp
+++ b/src/bin/calaos_home/views/ActivityWidgetsView.cpp
@@ -58,7 +58,7 @@ ActivityWidgetsView::ActivityWidgetsView(Evas *_e, Evas_Object *_parent):
 
 ActivityWidgetsView::~ActivityWidgetsView()
 {
-    for_each(widgets.begin(), widgets.end(), Delete());
+    for_each(widgets.begin(), widgets.end(), Utils::Delete());
     widgets.clear();
 
     if (timer) delete timer;
@@ -157,7 +157,7 @@ void ActivityWidgetsView::DeleteWidget(Widget *w)
 
 void ActivityWidgetsView::DeleteAllWidgets()
 {
-    for_each(widgets.begin(), widgets.end(), Delete());
+    for_each(widgets.begin(), widgets.end(), Utils::Delete());
     widgets.clear();
     SaveWidgets();
     if (!xmas_widget) evas_object_color_set(clipper, 255, 255, 255, 0);
@@ -216,19 +216,19 @@ void ActivityWidgetsView::LoadWidgets()
                 node->Attribute("width") &&
                 node->Attribute("height"))
             {
-                string type, id;
+                std::string type, id;
 
                 type = node->Attribute("type");
                 id = node->Attribute("id");
 
                 int x, y, w, h;
-                from_string(node->Attribute("posx"), x);
-                from_string(node->Attribute("posy"), y);
-                from_string(node->Attribute("width"), w);
-                from_string(node->Attribute("height"), h);
+                Utils::from_string(node->Attribute("posx"), x);
+                Utils::from_string(node->Attribute("posy"), y);
+                Utils::from_string(node->Attribute("width"), w);
+                Utils::from_string(node->Attribute("height"), h);
 
                 ModuleDef t;
-                vector<ModuleDef> mods = ModuleManager::Instance().getAvailableModules();
+                std::vector<ModuleDef> mods = ModuleManager::Instance().getAvailableModules();
                 for (uint i = 0;i < mods.size();i++)
                 {
                     if (mods[i].mod_fname == type)
@@ -264,11 +264,11 @@ void ActivityWidgetsView::SaveWidgets()
         widgets[i]->Save(rootnode);
     }
 
-    string file = Utils::getConfigFile(WIDGET_CONFIG);
+    std::string file = Utils::getConfigFile(WIDGET_CONFIG);
     document.SaveFile(file);
 }
 
-bool ActivityWidgetsView::AddWidget(ModuleDef &type, int x, int y, int w, int h, string id)
+bool ActivityWidgetsView::AddWidget(ModuleDef &type, int x, int y, int w, int h, std::string id)
 {
     for (uint i = 0;i < widgets.size();i++)
     {

--- a/src/bin/calaos_home/views/ActivityWidgetsView.h
+++ b/src/bin/calaos_home/views/ActivityWidgetsView.h
@@ -27,14 +27,13 @@
 #include "Widget.h"
 #include "Xmas.h"
 
-using namespace Utils;
 
 class ActivityWidgetsView: public ActivityView
 {
 private:
     Evas_Object *clipper;
 
-    vector<Widget *> widgets;
+    std::vector<Widget *> widgets;
 
     //timer to do some maintenance stuff
     //like showing/hiding xmas widget
@@ -64,7 +63,7 @@ public:
 
     void LoadWidgets();
 
-    bool AddWidget(ModuleDef &mtype, int x, int y, int w = 0, int h = 0, string id = "");
+    bool AddWidget(ModuleDef &mtype, int x, int y, int w = 0, int h = 0, std::string id = "");
     void DeleteWidget(Widget *w);
     void DeleteAllWidgets();
 

--- a/src/bin/calaos_home/views/BaseView.h
+++ b/src/bin/calaos_home/views/BaseView.h
@@ -21,6 +21,7 @@
 #ifndef BASEVIEW_H
 #define BASEVIEW_H
 
+#include "EdjeObject.h"
 #include <Utils.h>
 
 #include <Eina.h>
@@ -31,11 +32,9 @@
 #include <Edje.h>
 #include <Elementary.h>
 
-#include "EdjeObject.h"
 
 #include <EcoreTimer.h>
 
-using namespace Utils;
 
 class ActivityController;
 class BaseView: public EdjeObject
@@ -49,7 +48,7 @@ public:
     BaseView(Evas *evas, Evas_Object *parent);
     virtual ~BaseView();
 
-    virtual string getTitle() { return "None"; }
+    virtual std::string getTitle() { return "None"; }
 
     sigc::signal<void> view_deleted;
 

--- a/src/bin/calaos_home/views/GengridItems/GengridItemBase.cpp
+++ b/src/bin/calaos_home/views/GengridItems/GengridItemBase.cpp
@@ -27,7 +27,7 @@ static Eina_Bool _item_state(void *data, Evas_Object *obj, const char *part);
 static char *_item_label(void *data, Evas_Object *obj, const char *part);
 static void _item_sel_cb(void *data, Evas_Object *obj, void *event_info);
 
-GengridItemBase::GengridItemBase(Evas *_evas, Evas_Object *_parent, string _style, void *select_user_data):
+GengridItemBase::GengridItemBase(Evas *_evas, Evas_Object *_parent, std::string _style, void *select_user_data):
     evas(_evas),
     parent(_parent),
     gengrid(NULL),
@@ -114,22 +114,22 @@ void GengridItemBase::BringInItem(Elm_Gengrid_Item_Scrollto_Type type)
     elm_gengrid_item_bring_in(item, type);
 }
 
-Evas_Object *GengridItemBase::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GengridItemBase::getPartItem(Evas_Object *obj, std::string part)
 {
     return NULL;
 }
 
-string GengridItemBase::getLabelItem(Evas_Object *obj, string part)
+std::string GengridItemBase::getLabelItem(Evas_Object *obj, std::string part)
 {
     return "none";
 }
 
-bool GengridItemBase::getStateItem(Evas_Object *obj, string part)
+bool GengridItemBase::getStateItem(Evas_Object *obj, std::string part)
 {
     return false;
 }
 
-void GengridItemBase::itemEmitSignal(string signal, string source)
+void GengridItemBase::itemEmitSignal(std::string signal, std::string source)
 {
     if (!item) return;
 

--- a/src/bin/calaos_home/views/GengridItems/GengridItemBase.h
+++ b/src/bin/calaos_home/views/GengridItems/GengridItemBase.h
@@ -25,7 +25,6 @@
 #include <Utils.h>
 #include <IOView.h>
 
-using namespace Utils;
 
 //This macro is used to add a C callback for elementary buttons on items
 #define ITEM_BUTTON_CALLBACK(_class, it_name) \
@@ -42,16 +41,16 @@ protected:
     Elm_Object_Item *item;
 
     Elm_Gengrid_Item_Class item_class;
-    string style;
+    std::string style;
 
     void *user_data;
 
-    DeletorBase *autodel_userdata;
+    Utils::DeletorBase *autodel_userdata;
 
     virtual void itemAdded() {} //item was added to a gengrid
 
 public:
-    GengridItemBase(Evas *evas, Evas_Object *parent, string style, void *select_user_data = NULL);
+    GengridItemBase(Evas *evas, Evas_Object *parent, std::string style, void *select_user_data = NULL);
     virtual ~GengridItemBase();
 
     //Add item to gengrid
@@ -67,9 +66,9 @@ public:
     void ShowItem(Elm_Gengrid_Item_Scrollto_Type type);
     void BringInItem(Elm_Gengrid_Item_Scrollto_Type type);
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
-    virtual bool getStateItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
+    virtual bool getStateItem(Evas_Object *obj, std::string part);
 
     void setSelected(bool sel) { elm_gengrid_item_selected_set(item, sel); }
     bool isSelected() { return elm_gengrid_item_selected_get(item); }
@@ -82,7 +81,7 @@ public:
     void *getUserData() { return user_data; }
     void setAutoDeleteUserData(DeletorBase *how_to_delete_user_data) { autodel_userdata = how_to_delete_user_data; }
 
-    void itemEmitSignal(string signal, string source);
+    void itemEmitSignal(std::string signal, std::string source);
 
     //Used by C callback
     void emitSelectedSignal();

--- a/src/bin/calaos_home/views/GengridItems/GengridItemConfig.cpp
+++ b/src/bin/calaos_home/views/GengridItems/GengridItemConfig.cpp
@@ -19,12 +19,12 @@
  **
  ******************************************************************************/
 
-#include "GengridItemConfig.h"
 #include <ApplicationMain.h>
+#include "GengridItemConfig.h"
 
-GengridItemConfig::GengridItemConfig(Evas *_evas, Evas_Object *_parent, string _label, string style_addition, void *data):
+GengridItemConfig::GengridItemConfig(Evas *_evas, Evas_Object *_parent, std::string _label, std::string style_addition, void *data):
     GengridItemBase(_evas, _parent,
-                    "config" + string((style_addition != "")? "/" + style_addition:""),
+                    "config" + std::string((style_addition != "")? "/" + style_addition:""),
                     data),
     label(_label)
 {
@@ -34,7 +34,7 @@ GengridItemConfig::~GengridItemConfig()
 {
 }
 
-string GengridItemConfig::getLabelItem(Evas_Object *obj, string part)
+std::string GengridItemConfig::getLabelItem(Evas_Object *obj, std::string part)
 {
     return label;
 }

--- a/src/bin/calaos_home/views/GengridItems/GengridItemConfig.h
+++ b/src/bin/calaos_home/views/GengridItems/GengridItemConfig.h
@@ -25,19 +25,18 @@
 #include <Utils.h>
 #include <GengridItemBase.h>
 
-using namespace Utils;
 
 class GengridItemConfig: public GengridItemBase
 {
 private:
-    string label;
-    string icon_style;
+    std::string label;
+    std::string icon_style;
 
 public:
-    GengridItemConfig(Evas *evas, Evas_Object *parent, string label, string style_addition, void *data = NULL);
+    GengridItemConfig(Evas *evas, Evas_Object *parent, std::string label, std::string style_addition, void *data = NULL);
     virtual ~GengridItemConfig();
 
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 };
 
 #endif // GENGRIDITEMSIMPLE_H

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemAlbum.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemAlbum.cpp
@@ -40,7 +40,7 @@ GenlistItemAlbum::~GenlistItemAlbum()
 {
 }
 
-string GenlistItemAlbum::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemAlbum::getLabelItem(Evas_Object *obj, std::string part)
 {
     if (!in_query)
     {
@@ -84,7 +84,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemAlbum::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemAlbum::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemAlbum.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemAlbum.h
@@ -25,17 +25,16 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemAlbum: public GenlistItemBase
 {
 private:
-    string label_album, label_artist, label_year;
+    std::string label_album, label_artist, label_year;
     AudioPlayer *player;
     int item_id;
     Params item_infos;
     bool in_query;
-    string cover_fname;
+    std::string cover_fname;
     bool cover_downloaded;
     int reqtype;
     int command_id;
@@ -49,8 +48,8 @@ public:
     GenlistItemAlbum(Evas *evas, Evas_Object *parent, AudioPlayer *player, int item_id, int request_type, int _command_id = 0, void *data = NULL);
     virtual ~GenlistItemAlbum();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickPlay();
     void buttonClickAdd();

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemAlbumHeader.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemAlbumHeader.cpp
@@ -19,8 +19,8 @@
  **
  ******************************************************************************/
 
-#include "GenlistItemAlbumHeader.h"
 #include <ApplicationMain.h>
+#include "GenlistItemAlbumHeader.h"
 
 ITEM_BUTTON_CALLBACK(GenlistItemAlbumHeader, Play)
 ITEM_BUTTON_CALLBACK(GenlistItemAlbumHeader, Add)
@@ -41,13 +41,13 @@ GenlistItemAlbumHeader::~GenlistItemAlbumHeader()
     DELETE_NULL(dltimer);
 }
 
-string GenlistItemAlbumHeader::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemAlbumHeader::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (part == "text")
     {
-        string album = _("Unknown album");
+        std::string album = _("Unknown album");
         if (album_infos.Exists("name")) album = album_infos["name"];
         text = album;
     }
@@ -98,7 +98,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemAlbumHeader::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemAlbumHeader::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemAlbumHeader.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemAlbumHeader.h
@@ -25,7 +25,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemAlbumHeader: public GenlistItemBase
 {
@@ -34,7 +33,7 @@ private:
     Params album_infos;
     int album_id;
     bool in_query;
-    string cover_fname;
+    std::string cover_fname;
     bool cover_downloaded;
 
     EcoreTimer *dltimer;
@@ -46,8 +45,8 @@ public:
     GenlistItemAlbumHeader(Evas *evas, Evas_Object *parent, AudioPlayer *player, Params &album_infos, int album_id, void *data = NULL);
     virtual ~GenlistItemAlbumHeader();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickPlay();
     void buttonClickAdd();

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemArtist.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemArtist.cpp
@@ -19,8 +19,8 @@
  **
  ******************************************************************************/
 
-#include "GenlistItemArtist.h"
 #include <ApplicationMain.h>
+#include "GenlistItemArtist.h"
 
 ITEM_BUTTON_CALLBACK(GenlistItemArtist, Play)
 ITEM_BUTTON_CALLBACK(GenlistItemArtist, Add)
@@ -39,9 +39,9 @@ GenlistItemArtist::~GenlistItemArtist()
 {
 }
 
-string GenlistItemArtist::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemArtist::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!in_query)
     {
@@ -80,7 +80,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemArtist::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemArtist::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemArtist.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemArtist.h
@@ -25,7 +25,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemArtist: public GenlistItemBase
 {
@@ -45,8 +44,8 @@ public:
     GenlistItemArtist(Evas *evas, Evas_Object *parent, AudioPlayer *player, int item_id, int request_type, int _command_id = 0, void *data = NULL);
     virtual ~GenlistItemArtist();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickPlay();
     void buttonClickAdd();

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemBase.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemBase.cpp
@@ -27,7 +27,7 @@ static Eina_Bool _item_state(void *data, Evas_Object *obj, const char *part);
 static char *_item_label(void *data, Evas_Object *obj, const char *part);
 static void _item_sel_cb(void *data, Evas_Object *obj, void *event_info);
 
-GenlistItemBase::GenlistItemBase(Evas *_evas, Evas_Object *_parent, string _style, Elm_Genlist_Item_Type _flags, void *select_user_data):
+GenlistItemBase::GenlistItemBase(Evas *_evas, Evas_Object *_parent, std::string _style, Elm_Genlist_Item_Type _flags, void *select_user_data):
     evas(_evas),
     parent(_parent),
     genlist(NULL),
@@ -123,22 +123,22 @@ void GenlistItemBase::BringInItem(Elm_Genlist_Item_Scrollto_Type type)
     elm_genlist_item_bring_in(item, type);
 }
 
-Evas_Object *GenlistItemBase::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemBase::getPartItem(Evas_Object *obj, std::string part)
 {
     return NULL;
 }
 
-string GenlistItemBase::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemBase::getLabelItem(Evas_Object *obj, std::string part)
 {
     return "none";
 }
 
-bool GenlistItemBase::getStateItem(Evas_Object *obj, string part)
+bool GenlistItemBase::getStateItem(Evas_Object *obj, std::string part)
 {
     return false;
 }
 
-void GenlistItemBase::itemEmitSignal(string signal, string source)
+void GenlistItemBase::itemEmitSignal(std::string signal, std::string source)
 {
     if (!item) return;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemBase.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemBase.h
@@ -25,7 +25,6 @@
 #include <Utils.h>
 #include <IOView.h>
 
-using namespace Utils;
 
 //This macro is used to add a C callback for elementary buttons on items
 #define ITEM_BUTTON_CALLBACK(_class, it_name) \
@@ -42,7 +41,7 @@ protected:
     Elm_Object_Item *item;
 
     Elm_Genlist_Item_Class item_class;
-    string style;
+    std::string style;
 
     void *user_data;
     Elm_Genlist_Item_Type flags;
@@ -52,7 +51,7 @@ protected:
     virtual void itemAdded() {} //item was added to a genlist
 
 public:
-    GenlistItemBase(Evas *evas, Evas_Object *parent, string style, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE, void *select_user_data = NULL);
+    GenlistItemBase(Evas *evas, Evas_Object *parent, std::string style, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE, void *select_user_data = NULL);
     virtual ~GenlistItemBase();
 
     //Add item to genlist
@@ -68,14 +67,14 @@ public:
     void ShowItem(Elm_Genlist_Item_Scrollto_Type type);
     void BringInItem(Elm_Genlist_Item_Scrollto_Type type);
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
-    virtual bool getStateItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
+    virtual bool getStateItem(Evas_Object *obj, std::string part);
 
     void setSelected(bool sel) { elm_genlist_item_selected_set(item, sel); }
     bool isSelected() { return elm_genlist_item_selected_get(item); }
 
-    void updateField(string part, Elm_Genlist_Item_Field_Type type) { elm_genlist_item_fields_update(item, part.c_str(),  type); }
+    void updateField(std::string part, Elm_Genlist_Item_Field_Type type) { elm_genlist_item_fields_update(item, part.c_str(),  type); }
 
     sigc::signal<void, void *> item_selected;
 
@@ -83,7 +82,7 @@ public:
     void *getUserData() { return user_data; }
     void setAutoDeleteUserData(DeletorBase *how_to_delete_user_data) { autodel_userdata = how_to_delete_user_data; }
 
-    void itemEmitSignal(string signal, string source);
+    void itemEmitSignal(std::string signal, std::string source);
 
     //Used by C callback
     void emitSelectedSignal();

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemBrowserPlaylist.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemBrowserPlaylist.cpp
@@ -47,9 +47,9 @@ GenlistItemBrowserPlaylist::~GenlistItemBrowserPlaylist()
 {
 }
 
-string GenlistItemBrowserPlaylist::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemBrowserPlaylist::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!in_query)
     {
@@ -83,7 +83,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemBrowserPlaylist::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemBrowserPlaylist::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemBrowserPlaylist.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemBrowserPlaylist.h
@@ -25,7 +25,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemBrowserPlaylist: public GenlistItemBase
 {
@@ -43,8 +42,8 @@ public:
     GenlistItemBrowserPlaylist(Evas *evas, Evas_Object *parent, AudioPlayer *player, Params &infos, void *data = NULL);
     virtual ~GenlistItemBrowserPlaylist();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickPlay();
     void buttonClickAdd();

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemGenre.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemGenre.cpp
@@ -37,9 +37,9 @@ GenlistItemGenre::~GenlistItemGenre()
 {
 }
 
-string GenlistItemGenre::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemGenre::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!in_query)
     {
@@ -73,7 +73,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemGenre::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemGenre::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemGenre.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemGenre.h
@@ -25,7 +25,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemGenre: public GenlistItemBase
 {
@@ -41,8 +40,8 @@ public:
     GenlistItemGenre(Evas *evas, Evas_Object *parent, AudioPlayer *player, int item_id, void *data = NULL);
     virtual ~GenlistItemGenre();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickPlay();
     void buttonClickAdd();

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemPlaylist.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemPlaylist.cpp
@@ -38,7 +38,7 @@ GenlistItemPlaylist::~GenlistItemPlaylist()
 {
 }
 
-string GenlistItemPlaylist::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemPlaylist::getLabelItem(Evas_Object *obj, std::string part)
 {
     if (label != "")
         return label;
@@ -63,7 +63,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemPlaylist::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemPlaylist::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -104,12 +104,12 @@ void GenlistItemPlaylist::buttonClickMore()
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    string title_label = _("<light_blue>Track #%1</light_blue> infos<br><small>Track details.</small>");
+    std::string title_label = _("<light_blue>Track #%1</light_blue> infos<br><small>Track details.</small>");
     Utils::replace_str(title_label, "%1", Utils::to_string(playlist_item + 1));
     GenlistItemBase *header = new GenlistItemSimpleHeader(evas, glist, title_label);
     header->Append(glist);
 
-    string infolabel;
+    std::string infolabel;
     if (label == "")
     {
         GenlistItemSimpleKeyValue *it = new GenlistItemSimpleKeyValue(evas, glist, _("Loading"), "...");

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemPlaylist.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemPlaylist.h
@@ -25,12 +25,11 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemPlaylist: public GenlistItemBase
 {
 private:
-    string label;
+    std::string label;
     AudioPlayer *player;
     int playlist_item;
     Params item_infos;
@@ -43,8 +42,8 @@ public:
     GenlistItemPlaylist(Evas *evas, Evas_Object *parent, AudioPlayer *player, int playlist_item, void *data = NULL);
     virtual ~GenlistItemPlaylist();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickPlay();
     void buttonClickMore();

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemPlaylistHeader.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemPlaylistHeader.cpp
@@ -38,9 +38,9 @@ GenlistItemPlaylistHeader::~GenlistItemPlaylistHeader()
 {
 }
 
-string GenlistItemPlaylistHeader::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemPlaylistHeader::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (part == "text")
     {
@@ -68,7 +68,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemPlaylistHeader::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemPlaylistHeader::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemPlaylistHeader.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemPlaylistHeader.h
@@ -25,7 +25,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemPlaylistHeader: public GenlistItemBase
 {
@@ -38,8 +37,8 @@ public:
     GenlistItemPlaylistHeader(Evas *evas, Evas_Object *parent, AudioPlayer *player, Params &playlist_infos, int playlist_id, void *data = NULL);
     virtual ~GenlistItemPlaylistHeader();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickPlay();
     void buttonClickAdd();

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemRadio.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemRadio.cpp
@@ -36,9 +36,9 @@ GenlistItemRadio::~GenlistItemRadio()
 {
 }
 
-string GenlistItemRadio::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemRadio::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (part == "text")
         text = item_infos["name"];
@@ -61,7 +61,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemRadio::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemRadio::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemRadio.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemRadio.h
@@ -25,7 +25,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemRadio: public GenlistItemBase
 {
@@ -39,8 +38,8 @@ public:
     GenlistItemRadio(Evas *evas, Evas_Object *parent, AudioPlayer *player, Params item, void *data = NULL);
     virtual ~GenlistItemRadio();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickPlay();
     void buttonClickAdd();

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioAction.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioAction.cpp
@@ -49,9 +49,9 @@ ScenarioAction &GenlistItemScenarioAction::getAction()
     return scenario_data.steps[sc_step].actions[sc_action];
 }
 
-string GenlistItemScenarioAction::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemScenarioAction::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (part == "text")
     {
@@ -82,7 +82,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemScenarioAction::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemScenarioAction::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -120,7 +120,7 @@ void GenlistItemScenarioAction::buttonClickEdit()
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    string title_label = _("Edit element<br><small><light_blue>Choose action that will be executed</light_blue></small>");
+    std::string title_label = _("Edit element<br><small><light_blue>Choose action that will be executed</light_blue></small>");
     GenlistItemBase *header = new GenlistItemSimpleHeader(evas, glist, title_label);
     header->Append(glist);
 
@@ -162,7 +162,7 @@ void GenlistItemScenarioAction::createActionList(Evas_Object *glist, GenlistItem
     GenlistItemSimple *it = NULL;
 
     ScenarioAction &ac_current = getAction();
-    vector<IOActionList> v = ac_current.io->getActionList();
+    std::vector<IOActionList> v = ac_current.io->getActionList();
 
     for (uint i = 0;i < v.size();i++)
     {
@@ -206,12 +206,12 @@ void GenlistItemScenarioAction::actionSimple(void *data, IOActionList ac)
     elm_ctxpopup_dismiss(popup);
 }
 
-void GenlistItemScenarioAction::buttonBackClick(void *data, Evas_Object *edje_object, string emission, string source)
+void GenlistItemScenarioAction::buttonBackClick(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     elm_naviframe_item_pop(pager_action);
 }
 
-void GenlistItemScenarioAction::buttonValidClick(void *data, Evas_Object *edje_object, string emission, string source)
+void GenlistItemScenarioAction::buttonValidClick(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     action = action_temp;
     if (sc_step == ScenarioData::END_STEP)
@@ -225,7 +225,7 @@ void GenlistItemScenarioAction::buttonValidClick(void *data, Evas_Object *edje_o
     elm_ctxpopup_dismiss(popup);
 }
 
-void GenlistItemScenarioAction::buttonValidTimeClick(void *data, Evas_Object *edje_object, string emission, string source)
+void GenlistItemScenarioAction::buttonValidTimeClick(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     action = action_temp;
     action.dvalue = elm_spinner_value_get(spin_hours) * 60.0 * 60.0 * 1000.0 +
@@ -255,14 +255,14 @@ void GenlistItemScenarioAction::actionSlider(void *data, IOActionList ac)
     page->addCallback("button.valid", "pressed", sigc::mem_fun(*this, &GenlistItemScenarioAction::buttonValidClick));
     page->addCallback("slider_obj:object", "*", sigc::mem_fun(*this, &GenlistItemScenarioAction::sliderSignalCallback));
     page->setDragValue("slider", action_temp.dvalue / 100.0, 0.0);
-    string t = "<b>";
-    t += _("Choose value") + string("</b><br><light_blue><small>") + ac.title + "</small></light_blue>";
+    std::string t = "<b>";
+    t += _("Choose value") + std::string("</b><br><light_blue><small>") + ac.title + "</small></light_blue>";
     page->setPartText("text", t);
 
     elm_naviframe_item_push(pager_action, NULL, NULL, NULL, page->getEvasObject(), "calaos");
 }
 
-void GenlistItemScenarioAction::sliderSignalCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void GenlistItemScenarioAction::sliderSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     if (emission == "slider,changed")
     {
@@ -283,17 +283,17 @@ void GenlistItemScenarioAction::actionNumber(void *data, IOActionList ac)
     page->addCallback("button.back", "pressed", sigc::mem_fun(*this, &GenlistItemScenarioAction::buttonBackClick));
     page->addCallback("button.valid", "pressed", sigc::mem_fun(*this, &GenlistItemScenarioAction::buttonValidClick));
     page->addCallback("button.pad.*", "pressed", sigc::mem_fun(*this, &GenlistItemScenarioAction::numberSignalCallback));
-    string t = "<b>";
-    t += _("Choose number") + string("</b><br><light_blue><small>") + ac.title + "</small></light_blue>";
+    std::string t = "<b>";
+    t += _("Choose number") + std::string("</b><br><light_blue><small>") + ac.title + "</small></light_blue>";
     page->setPartText("text", t);
     page->setPartText("value", Utils::to_string(action_temp.dvalue));
 
     elm_naviframe_item_push(pager_action, NULL, NULL, NULL, page->getEvasObject(), "calaos");
 }
 
-void GenlistItemScenarioAction::numberSignalCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void GenlistItemScenarioAction::numberSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
-    string val = page->getPartText("value");
+    std::string val = page->getPartText("value");
 
     if (source == "button.pad.0") val += "0";
     else if (source == "button.pad.1") val += "1";
@@ -307,7 +307,7 @@ void GenlistItemScenarioAction::numberSignalCallback(void *data, Evas_Object *ed
     else if (source == "button.pad.9") val += "9";
     else if (source == "button.pad.dot")
     {
-        if (val.find('.') == string::npos)
+        if (val.find('.') == std::string::npos)
             val += ".";
     }
     else if (source == "button.pad.del")
@@ -342,8 +342,8 @@ void GenlistItemScenarioAction::actionTime(void *data, IOActionList ac)
     page->setAutoDelete(true);
     page->addCallback("button.back", "pressed", sigc::mem_fun(*this, &GenlistItemScenarioAction::buttonBackClick));
     page->addCallback("button.valid", "pressed", sigc::mem_fun(*this, &GenlistItemScenarioAction::buttonValidTimeClick));
-    string t = "<b>";
-    t += _("Choose duration") + string("</b><br><light_blue><small>") + ac.title + "</small></light_blue>";
+    std::string t = "<b>";
+    t += _("Choose duration") + std::string("</b><br><light_blue><small>") + ac.title + "</small></light_blue>";
     page->setPartText("text", t);
 
     double sec = action_temp.dvalue / 1000.0;
@@ -352,11 +352,11 @@ void GenlistItemScenarioAction::actionTime(void *data, IOActionList ac)
     sec -= hours * 3600;
     int min = (int)(sec / 60.0);
     sec -= min * 60;
-    string f;
+    std::string f;
 
     spin_hours = elm_spinner_add(parent);
     elm_object_style_set(spin_hours, "calaos/time/vertical");
-    f = string("%.0f<br><subtitle>") + _("Hours") + "</subtitle>";
+    f = std::string("%.0f<br><subtitle>") + _("Hours") + "</subtitle>";
     elm_spinner_label_format_set(spin_hours, f.c_str());
     elm_spinner_min_max_set(spin_hours, 0, 99);
     elm_spinner_step_set(spin_hours, 1);
@@ -367,7 +367,7 @@ void GenlistItemScenarioAction::actionTime(void *data, IOActionList ac)
 
     spin_min = elm_spinner_add(parent);
     elm_object_style_set(spin_min, "calaos/time/vertical");
-    f = string("%.0f<br><subtitle>") + _("Min.") + "</subtitle>";
+    f = std::string("%.0f<br><subtitle>") + _("Min.") + "</subtitle>";
     elm_spinner_label_format_set(spin_min, f.c_str());
     elm_spinner_min_max_set(spin_min, 0, 59);
     elm_spinner_step_set(spin_min, 1);
@@ -378,7 +378,7 @@ void GenlistItemScenarioAction::actionTime(void *data, IOActionList ac)
 
     spin_sec = elm_spinner_add(parent);
     elm_object_style_set(spin_sec, "calaos/time/vertical");
-    f = string("%.0f<br><subtitle>") + _("Sec.") + "</subtitle>";
+    f = std::string("%.0f<br><subtitle>") + _("Sec.") + "</subtitle>";
     elm_spinner_label_format_set(spin_sec, f.c_str());
     elm_spinner_min_max_set(spin_sec, 0, 59);
     elm_spinner_step_set(spin_sec, 1);
@@ -389,7 +389,7 @@ void GenlistItemScenarioAction::actionTime(void *data, IOActionList ac)
 
     spin_ms = elm_spinner_add(parent);
     elm_object_style_set(spin_ms, "calaos/time/vertical");
-    f = string("%.0f<br><subtitle>") + _("Ms.") + "</subtitle>";
+    f = std::string("%.0f<br><subtitle>") + _("Ms.") + "</subtitle>";
     elm_spinner_label_format_set(spin_ms, f.c_str());
     elm_spinner_min_max_set(spin_ms, 0, 999);
     elm_spinner_step_set(spin_ms, 1);
@@ -414,8 +414,8 @@ void GenlistItemScenarioAction::actionColor(void *data, IOActionList ac)
     page->addCallback("slider.green:object", "*", sigc::mem_fun(*this, &GenlistItemScenarioAction::sliderGreenSignalCallback));
     page->addCallback("slider.blue:object", "*", sigc::mem_fun(*this, &GenlistItemScenarioAction::sliderBlueSignalCallback));
     page->setDragValue("slider", action_temp.dvalue / 100.0, 0.0);
-    string t = "<b>";
-    t += _("Choose color") + string("</b><br><light_blue><small>") + ac.title + "</small></light_blue>";
+    std::string t = "<b>";
+    t += _("Choose color") + std::string("</b><br><light_blue><small>") + ac.title + "</small></light_blue>";
     page->setPartText("text", t);
 
     page->setDragValue("slider.red:slider", action_temp.colorval.getRed() / 255.0, 0.0);
@@ -433,7 +433,7 @@ void GenlistItemScenarioAction::actionColor(void *data, IOActionList ac)
     elm_naviframe_item_push(pager_action, NULL, NULL, NULL, page->getEvasObject(), "calaos");
 }
 
-void GenlistItemScenarioAction::sliderRedSignalCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void GenlistItemScenarioAction::sliderRedSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     if (emission == "slider,changed")
     {
@@ -449,7 +449,7 @@ void GenlistItemScenarioAction::sliderRedSignalCallback(void *data, Evas_Object 
     }
 }
 
-void GenlistItemScenarioAction::sliderGreenSignalCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void GenlistItemScenarioAction::sliderGreenSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     if (emission == "slider,changed")
     {
@@ -465,7 +465,7 @@ void GenlistItemScenarioAction::sliderGreenSignalCallback(void *data, Evas_Objec
     }
 }
 
-void GenlistItemScenarioAction::sliderBlueSignalCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void GenlistItemScenarioAction::sliderBlueSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     if (emission == "slider,changed")
     {

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioAction.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioAction.h
@@ -27,7 +27,6 @@
 #include <CalaosModel.h>
 #include <ScenarioModel.h>
 
-using namespace Utils;
 
 class GenlistItemScenarioAction: public GenlistItemBase
 {
@@ -61,14 +60,14 @@ private:
     void actionTime(void *data, IOActionList ac);
     void actionColor(void *data, IOActionList ac);
 
-    void buttonBackClick(void *data, Evas_Object *edje_object, string emission, string source);
-    void buttonValidClick(void *data, Evas_Object *edje_object, string emission, string source);
-    void buttonValidTimeClick(void *data, Evas_Object *edje_object, string emission, string source);
-    void sliderSignalCallback(void *data, Evas_Object *edje_object, string emission, string source);
-    void numberSignalCallback(void *data, Evas_Object *edje_object, string emission, string source);
-    void sliderRedSignalCallback(void *data, Evas_Object *edje_object, string emission, string source);
-    void sliderGreenSignalCallback(void *data, Evas_Object *edje_object, string emission, string source);
-    void sliderBlueSignalCallback(void *data, Evas_Object *edje_object, string emission, string source);
+    void buttonBackClick(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void buttonValidClick(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void buttonValidTimeClick(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void sliderSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void numberSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void sliderRedSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void sliderGreenSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void sliderBlueSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source);
 
     void deleteItemSelected(void *data);
 
@@ -76,8 +75,8 @@ public:
     GenlistItemScenarioAction(Evas *evas, Evas_Object *parent, ScenarioData &scd, int step, int action, void *data = NULL);
     virtual ~GenlistItemScenarioAction();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickEdit();
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioHeader.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioHeader.cpp
@@ -21,7 +21,7 @@
 #include "GenlistItemScenarioHeader.h"
 #include <ApplicationMain.h>
 
-GenlistItemScenarioHeader::GenlistItemScenarioHeader(Evas *_evas, Evas_Object *_parent, string _title):
+GenlistItemScenarioHeader::GenlistItemScenarioHeader(Evas *_evas, Evas_Object *_parent, std::string _title):
     GenlistItemBase(_evas, _parent, "scenario/header", ELM_GENLIST_ITEM_GROUP),
     title(_title)
 {
@@ -36,14 +36,14 @@ void GenlistItemScenarioHeader::itemAdded()
     elm_genlist_item_select_mode_set(item, ELM_OBJECT_SELECT_MODE_DISPLAY_ONLY);
 }
 
-Evas_Object *GenlistItemScenarioHeader::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemScenarioHeader::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
     return o;
 }
 
-string GenlistItemScenarioHeader::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemScenarioHeader::getLabelItem(Evas_Object *obj, std::string part)
 {
     if (part == "elm.text")
         return title;

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioHeader.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioHeader.h
@@ -24,20 +24,19 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemScenarioHeader: public GenlistItemBase
 {
 private:
-    string title;
+    std::string title;
 
     virtual void itemAdded();
 public:
-    GenlistItemScenarioHeader(Evas *evas, Evas_Object *parent, string title);
+    GenlistItemScenarioHeader(Evas *evas, Evas_Object *parent, std::string title);
     virtual ~GenlistItemScenarioHeader();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 };
 
 #endif // GenlistItemScenarioHeader_H

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioSchedule.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioSchedule.cpp
@@ -67,9 +67,9 @@ void GenlistItemScenarioSchedule::updateView()
     }
 }
 
-string GenlistItemScenarioSchedule::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemScenarioSchedule::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!scenario) return text;
 
@@ -83,7 +83,7 @@ string GenlistItemScenarioSchedule::getLabelItem(Evas_Object *obj, string part)
 
         if (scenario->isScheduled())
         {
-            vector<TimeRange> v = scenario->ioSchedule->range_infos.getRange(scheduleRange);
+            std::vector<TimeRange> v = scenario->ioSchedule->range_infos.getRange(scheduleRange);
 
             if (scheduleRangeNum >= 0 && scheduleRangeNum < (int)v.size())
             {
@@ -124,7 +124,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemScenarioSchedule::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemScenarioSchedule::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -157,7 +157,7 @@ void GenlistItemScenarioSchedule::buttonClickMore()
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    string title_label = _("Scenario parameters<br><small><light_blue>Modify, add or delete a schedule.</light_blue></small>");
+    std::string title_label = _("Scenario parameters<br><small><light_blue>Modify, add or delete a schedule.</light_blue></small>");
     GenlistItemBase *header = new GenlistItemSimpleHeader(evas, glist, title_label);
     header->Append(glist);
 
@@ -270,7 +270,7 @@ void GenlistItemScenarioSchedule::scenarioDelete(void *data)
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    string title_label = _("Confirmation<br><small><light_blue>Are you sure to delete this scenarios?</light_blue></small>");
+    std::string title_label = _("Confirmation<br><small><light_blue>Are you sure to delete this scenarios?</light_blue></small>");
     GenlistItemBase *header = new GenlistItemSimpleHeader(evas, glist, title_label);
     header->Append(glist);
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioSchedule.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioSchedule.h
@@ -26,7 +26,6 @@
 #include <GenlistItemBase.h>
 #include "ScenarioModel.h"
 
-using namespace Utils;
 
 class GenlistItemSimple;
 class GenlistItemScenarioSchedule: public GenlistItemBase, public IOBaseElement
@@ -66,8 +65,8 @@ public:
         scDate = sdate;
     }
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickMore();
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioScheduleTime.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioScheduleTime.cpp
@@ -38,14 +38,14 @@ GenlistItemScenarioScheduleTime::~GenlistItemScenarioScheduleTime()
 {
 }
 
-string GenlistItemScenarioScheduleTime::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemScenarioScheduleTime::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (part == "text")
     {
         bool same = range.isSameStartEnd();
-        string starttxt;
+        std::string starttxt;
         if (same)
             starttxt = _("Execute at ");
         else
@@ -62,9 +62,9 @@ string GenlistItemScenarioScheduleTime::getLabelItem(Evas_Object *obj, string pa
                 int v = h * 3600 + m * 60 + s;
 
                 if (range.start_offset == 1)
-                    return string(" +") + Utils::time2string_digit(v);
+                    return std::string(" +") + Utils::time2string_digit(v);
                 else if (range.start_offset == -1)
-                    return string(" -") + Utils::time2string_digit(v);
+                    return std::string(" -") + Utils::time2string_digit(v);
 
             }
             else
@@ -76,13 +76,13 @@ string GenlistItemScenarioScheduleTime::getLabelItem(Evas_Object *obj, string pa
                 int v = h * 3600 + m * 60 + s;
 
                 if (range.end_offset == 1)
-                    return string(" +") + Utils::time2string_digit(v);
+                    return std::string(" +") + Utils::time2string_digit(v);
                 else
                     if (range.end_offset == -1)
-                        return string(" -") + Utils::time2string_digit(v);
+                        return std::string(" -") + Utils::time2string_digit(v);
             }
 
-            return string();
+            return std::string();
         };
 
         if (range.start_type == TimeRange::HTYPE_NORMAL)
@@ -129,7 +129,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemScenarioScheduleTime::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemScenarioScheduleTime::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -159,7 +159,7 @@ Evas_Object *GenlistItemScenarioScheduleTime::getPartItem(Evas_Object *obj, stri
         elm_image_file_set(o, ApplicationMain::getTheme(), "calaos/icons/element/simple/play");
     }
 
-    auto setDay = [=](string day, int active)
+    auto setDay = [=](std::string day, int active)
     {
         if (active == 1)
             itemEmitSignal(day + ",active", "calaos");

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioScheduleTime.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemScenarioScheduleTime.h
@@ -25,7 +25,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemScenarioScheduleTime: public GenlistItemBase
 {
@@ -36,8 +35,8 @@ class GenlistItemScenarioScheduleTime: public GenlistItemBase
         GenlistItemScenarioScheduleTime(Evas *evas, Evas_Object *parent, TimeRange &range, void *data = NULL);
         virtual ~GenlistItemScenarioScheduleTime();
 
-        virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-        virtual string getLabelItem(Evas_Object *obj, string part);
+        virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+        virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
         void buttonClickEdit();
         void buttonClickDelete();

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemSimple.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemSimple.cpp
@@ -19,14 +19,14 @@
  **
  ******************************************************************************/
 
-#include "GenlistItemSimple.h"
 #include <ApplicationMain.h>
+#include "GenlistItemSimple.h"
 
 ITEM_BUTTON_CALLBACK(GenlistItemSimple, Pressed)
 
-GenlistItemSimple::GenlistItemSimple(Evas *_evas, Evas_Object *_parent, string _label, bool can_select, bool _multiline, void *data, string style_addition):
+GenlistItemSimple::GenlistItemSimple(Evas *_evas, Evas_Object *_parent, std::string _label, bool can_select, bool _multiline, void *data, std::string style_addition):
     GenlistItemBase(_evas, _parent,
-                    string(can_select? "simple_select":"simple") + string(_multiline? "/multiline":"") + string((style_addition != "")? "/" + style_addition:""),
+                    std::string(can_select? "simple_select":"simple") + std::string(_multiline? "/multiline":"") + std::string((style_addition != "")? "/" + style_addition:""),
                     ELM_GENLIST_ITEM_NONE, data),
     label(_label),
     multiline(_multiline)
@@ -42,7 +42,7 @@ GenlistItemSimple::~GenlistItemSimple()
 {
 }
 
-string GenlistItemSimple::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemSimple::getLabelItem(Evas_Object *obj, std::string part)
 {
     return label;
 }
@@ -62,7 +62,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemSimple::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemSimple::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -108,7 +108,7 @@ void GenlistItemSimple::buttonClickPressed()
     button_pressed.emit();
 }
 
-GenlistItemSimpleKeyValue::GenlistItemSimpleKeyValue(Evas *_evas, Evas_Object *_parent, string _label_key, string _label_value, void *data):
+GenlistItemSimpleKeyValue::GenlistItemSimpleKeyValue(Evas *_evas, Evas_Object *_parent, std::string _label_key, std::string _label_value, void *data):
     GenlistItemBase(_evas, _parent, "simple_info", ELM_GENLIST_ITEM_NONE, data),
     label_key(_label_key),
     label_value(_label_value)
@@ -119,7 +119,7 @@ GenlistItemSimpleKeyValue::~GenlistItemSimpleKeyValue()
 {
 }
 
-string GenlistItemSimpleKeyValue::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemSimpleKeyValue::getLabelItem(Evas_Object *obj, std::string part)
 {
     if (part == "key.text")
         return label_key;
@@ -129,7 +129,7 @@ string GenlistItemSimpleKeyValue::getLabelItem(Evas_Object *obj, string part)
     return "?";
 }
 
-Evas_Object *GenlistItemSimpleKeyValue::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemSimpleKeyValue::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemSimple.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemSimple.h
@@ -25,26 +25,25 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemSimple: public GenlistItemBase
 {
 private:
-    string label;
-    string icon;
-    string button_icon;
+    std::string label;
+    std::string icon;
+    std::string button_icon;
     bool multiline;
 
 public:
-    GenlistItemSimple(Evas *evas, Evas_Object *parent, string label, bool can_select, bool multiline = false, void *data = NULL, string style_addition = "");
+    GenlistItemSimple(Evas *evas, Evas_Object *parent, std::string label, bool can_select, bool multiline = false, void *data = NULL, std::string style_addition = "");
     virtual ~GenlistItemSimple();
 
-    virtual string getLabelItem(Evas_Object *obj, string part);
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
 
-    void setIcon(string ic) { icon = ic; }
-    void setButtonIcon(string ic) { button_icon = ic; }
-    void setLabelText(string t) { label = t; updateField("text", ELM_GENLIST_ITEM_FIELD_TEXT); }
+    void setIcon(std::string ic) { icon = ic; }
+    void setButtonIcon(std::string ic) { button_icon = ic; }
+    void setLabelText(std::string t) { label = t; updateField("text", ELM_GENLIST_ITEM_FIELD_TEXT); }
 
     //private, from c callback
     void buttonClickPressed();
@@ -56,17 +55,17 @@ public:
 class GenlistItemSimpleKeyValue: public GenlistItemBase
 {
 private:
-    string label_key, label_value;
-    string icon;
+    std::string label_key, label_value;
+    std::string icon;
 
 public:
-    GenlistItemSimpleKeyValue(Evas *evas, Evas_Object *parent, string label_key, string label_value, void *data = NULL);
+    GenlistItemSimpleKeyValue(Evas *evas, Evas_Object *parent, std::string label_key, std::string label_value, void *data = NULL);
     virtual ~GenlistItemSimpleKeyValue();
 
-    virtual string getLabelItem(Evas_Object *obj, string part);
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
 
-    void setIcon(string ic) { icon = ic; }
+    void setIcon(std::string ic) { icon = ic; }
 };
 
 #endif // GENLISTITEMSIMPLE_H

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemSimpleHeader.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemSimpleHeader.cpp
@@ -19,14 +19,14 @@
  **
  ******************************************************************************/
 
-#include "GenlistItemSimpleHeader.h"
 #include "ApplicationMain.h"
+#include "GenlistItemSimpleHeader.h"
 
 ITEM_BUTTON_CALLBACK(GenlistItemSimpleHeader, Back)
 ITEM_BUTTON_CALLBACK(GenlistItemSimpleHeader, Valid)
 
-GenlistItemSimpleHeader::GenlistItemSimpleHeader(Evas *_evas, Evas_Object *_parent, string _label, string style_addition):
-    GenlistItemBase(_evas, _parent, string("simple_header") + string((style_addition != "")? "/" + style_addition:""), ELM_GENLIST_ITEM_GROUP),
+GenlistItemSimpleHeader::GenlistItemSimpleHeader(Evas *_evas, Evas_Object *_parent, std::string _label, std::string style_addition):
+    GenlistItemBase(_evas, _parent, std::string("simple_header") + std::string((style_addition != "")? "/" + style_addition:""), ELM_GENLIST_ITEM_GROUP),
     label(_label)
 {
 }
@@ -35,7 +35,7 @@ GenlistItemSimpleHeader::~GenlistItemSimpleHeader()
 {
 }
 
-string GenlistItemSimpleHeader::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemSimpleHeader::getLabelItem(Evas_Object *obj, std::string part)
 {
     return label;
 }
@@ -55,7 +55,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemSimpleHeader::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemSimpleHeader::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemSimpleHeader.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemSimpleHeader.h
@@ -25,28 +25,27 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemSimpleHeader: public GenlistItemBase
 {
 private:
-    string label;
+    std::string label;
 
     Params bt_labels;
 
 public:
-    GenlistItemSimpleHeader(Evas *evas, Evas_Object *parent, string label, string style_addition = "");
+    GenlistItemSimpleHeader(Evas *evas, Evas_Object *parent, std::string label, std::string style_addition = "");
     virtual ~GenlistItemSimpleHeader();
 
-    virtual string getLabelItem(Evas_Object *obj, string part);
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
 
-    void setButtonLabel(string _button, string _label) { bt_labels.Add(_button, _label); }
+    void setButtonLabel(std::string _button, std::string _label) { bt_labels.Add(_button, _label); }
 
     void buttonClickBack();
     void buttonClickValid();
 
-    sigc::signal<void, string> button_click; //special headers can have buttons
+    sigc::signal<void, std::string> button_click; //special headers can have buttons
 };
 
 #endif // GENLISTITEMSIMPLEHEADER_H

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemTrack.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemTrack.cpp
@@ -42,9 +42,9 @@ GenlistItemTrack::~GenlistItemTrack()
 {
 }
 
-string GenlistItemTrack::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemTrack::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!in_query)
     {
@@ -84,7 +84,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemTrack::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemTrack::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -173,12 +173,12 @@ void GenlistItemTrack::buttonClickMore()
     evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     evas_object_show(glist);
 
-    string title_label = _("<light_blue>Track #%1</light_blue> infos<br><small>Track details.</small>");
+    std::string title_label = _("<light_blue>Track #%1</light_blue> infos<br><small>Track details.</small>");
     Utils::replace_str(title_label, "%1", Utils::to_string(item_id + 1));
     GenlistItemBase *header = new GenlistItemSimpleHeader(evas, glist, title_label);
     header->Append(glist);
 
-    string infolabel;
+    std::string infolabel;
     if (item_infos["artist"] != "")
     {
         infolabel = item_infos["artist"];

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemTrack.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemTrack.h
@@ -25,7 +25,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemTrack: public GenlistItemBase
 {
@@ -45,8 +44,8 @@ public:
     GenlistItemTrack(Evas *evas, Evas_Object *parent, AudioPlayer *player, int item_id, int request_type, int _command_id, void *data = NULL);
     virtual ~GenlistItemTrack();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickPlay();
     void buttonClickAdd();

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemWidget.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemWidget.cpp
@@ -32,7 +32,7 @@ GenlistItemWidget::~GenlistItemWidget()
 {
 }
 
-string GenlistItemWidget::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemWidget::getLabelItem(Evas_Object *obj, std::string part)
 {
     if (part == "title")
         return modinfo.mod_name;
@@ -42,7 +42,7 @@ string GenlistItemWidget::getLabelItem(Evas_Object *obj, string part)
     return "";
 }
 
-Evas_Object *GenlistItemWidget::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemWidget::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = nullptr;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemWidget.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemWidget.h
@@ -26,7 +26,6 @@
 #include <GenlistItemBase.h>
 #include <Modules.h>
 
-using namespace Utils;
 
 class GenlistItemWidget: public GenlistItemBase
 {
@@ -37,8 +36,8 @@ public:
     GenlistItemWidget(Evas *evas, Evas_Object *parent, ModuleDef mod, void *data = NULL);
     virtual ~GenlistItemWidget();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 };
 
 #endif // GenlistItemWidget_H

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemYear.cpp
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemYear.cpp
@@ -37,9 +37,9 @@ GenlistItemYear::~GenlistItemYear()
 {
 }
 
-string GenlistItemYear::getLabelItem(Evas_Object *obj, string part)
+std::string GenlistItemYear::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!in_query)
     {
@@ -73,7 +73,7 @@ _button_mouse_up_cb(void *data,
   ev->event_flags = (Evas_Event_Flags)(ev->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
 }
 
-Evas_Object *GenlistItemYear::getPartItem(Evas_Object *obj, string part)
+Evas_Object *GenlistItemYear::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 

--- a/src/bin/calaos_home/views/GenlistItems/GenlistItemYear.h
+++ b/src/bin/calaos_home/views/GenlistItems/GenlistItemYear.h
@@ -25,7 +25,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class GenlistItemYear: public GenlistItemBase
 {
@@ -41,8 +40,8 @@ public:
     GenlistItemYear(Evas *evas, Evas_Object *parent, AudioPlayer *player, int item_id, void *data = NULL);
     virtual ~GenlistItemYear();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     void buttonClickPlay();
     void buttonClickAdd();

--- a/src/bin/calaos_home/views/IO/IOGenlistRoomGroup.cpp
+++ b/src/bin/calaos_home/views/IO/IOGenlistRoomGroup.cpp
@@ -18,11 +18,12 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
-#include "IOGenlistRoomGroup.h"
-#include <ApplicationMain.h>
 
-IOGenlistRoomGroup::IOGenlistRoomGroup(Evas *_evas, Evas_Object *_parent, Room *_room, string style_addition):
-    GenlistItemBase(_evas, _parent, string("group_room") + style_addition, ELM_GENLIST_ITEM_GROUP),
+#include <ApplicationMain.h>
+#include "IOGenlistRoomGroup.h"
+
+IOGenlistRoomGroup::IOGenlistRoomGroup(Evas *_evas, Evas_Object *_parent, Room *_room, std::string style_addition):
+    GenlistItemBase(_evas, _parent, std::string("group_room") + style_addition, ELM_GENLIST_ITEM_GROUP),
     room(_room)
 {
 }
@@ -36,20 +37,20 @@ void IOGenlistRoomGroup::itemAdded()
     elm_genlist_item_select_mode_set(item, ELM_OBJECT_SELECT_MODE_DISPLAY_ONLY);
 }
 
-Evas_Object *IOGenlistRoomGroup::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOGenlistRoomGroup::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
     return o;
 }
 
-string IOGenlistRoomGroup::getLabelItem(Evas_Object *obj, string part)
+std::string IOGenlistRoomGroup::getLabelItem(Evas_Object *obj, std::string part)
 {
     return room->name;
 }
 
-IOGenlistRoomGroupIcon::IOGenlistRoomGroupIcon(Evas *_evas, Evas_Object *_parent, Room *_room, string style_addition):
-    GenlistItemBase(_evas, _parent, string("group_room/icon") + style_addition, ELM_GENLIST_ITEM_GROUP),
+IOGenlistRoomGroupIcon::IOGenlistRoomGroupIcon(Evas *_evas, Evas_Object *_parent, Room *_room, std::string style_addition):
+    GenlistItemBase(_evas, _parent, std::string("group_room/icon") + style_addition, ELM_GENLIST_ITEM_GROUP),
     room(_room)
 {
 }
@@ -63,14 +64,14 @@ void IOGenlistRoomGroupIcon::itemAdded()
     elm_genlist_item_select_mode_set(item, ELM_OBJECT_SELECT_MODE_DISPLAY_ONLY);
 }
 
-Evas_Object *IOGenlistRoomGroupIcon::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOGenlistRoomGroupIcon::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
     if (part == "icon")
     {
-        string type = room->type;
-        string t = type;
+        std::string type = room->type;
+        std::string t = type;
 
         if (type == "salon") t = "lounge";
         if (type == "chambre") t = "bedroom";
@@ -86,7 +87,7 @@ Evas_Object *IOGenlistRoomGroupIcon::getPartItem(Evas_Object *obj, string part)
         if (type == "couloir") t = "corridor";
 
         EdjeObject *icon = new EdjeObject(ApplicationMain::getTheme(), evas);
-        string group = "calaos/icons/room/";
+        std::string group = "calaos/icons/room/";
 
         try
         {
@@ -105,7 +106,7 @@ Evas_Object *IOGenlistRoomGroupIcon::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOGenlistRoomGroupIcon::getLabelItem(Evas_Object *obj, string part)
+std::string IOGenlistRoomGroupIcon::getLabelItem(Evas_Object *obj, std::string part)
 {
     return room->name;
 }

--- a/src/bin/calaos_home/views/IO/IOGenlistRoomGroup.h
+++ b/src/bin/calaos_home/views/IO/IOGenlistRoomGroup.h
@@ -24,7 +24,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOGenlistRoomGroup: public GenlistItemBase
 {
@@ -34,11 +33,11 @@ private:
     virtual void itemAdded();
 
 public:
-    IOGenlistRoomGroup(Evas *evas, Evas_Object *parent, Room *room, string style_addition);
+    IOGenlistRoomGroup(Evas *evas, Evas_Object *parent, Room *room, std::string style_addition);
     virtual ~IOGenlistRoomGroup();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 };
 
 class IOGenlistRoomGroupIcon: public GenlistItemBase
@@ -49,11 +48,11 @@ private:
     virtual void itemAdded();
 
 public:
-    IOGenlistRoomGroupIcon(Evas *evas, Evas_Object *parent, Room *room, string style_addition);
+    IOGenlistRoomGroupIcon(Evas *evas, Evas_Object *parent, Room *room, std::string style_addition);
     virtual ~IOGenlistRoomGroupIcon();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     Room *getRoom() { return room; }
 };

--- a/src/bin/calaos_home/views/IO/IOGenlistScenarioHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOGenlistScenarioHomeView.cpp
@@ -18,13 +18,14 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
-#include "IOGenlistScenarioHomeView.h"
+
 #include <ApplicationMain.h>
+#include "IOGenlistScenarioHomeView.h"
 
 ITEM_BUTTON_CALLBACK(IOGenlistScenarioHomeView, Go)
 
-IOGenlistScenarioHomeView::IOGenlistScenarioHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("scenario_") + style_addition, _flags),
+IOGenlistScenarioHomeView::IOGenlistScenarioHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("scenario_") + style_addition, _flags),
     IOBaseElement(_io)
 {
 }
@@ -40,7 +41,7 @@ void IOGenlistScenarioHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOGenlistScenarioHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOGenlistScenarioHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -66,9 +67,9 @@ Evas_Object *IOGenlistScenarioHomeView::getPartItem(Evas_Object *obj, string par
     return o;
 }
 
-string IOGenlistScenarioHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOGenlistScenarioHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 

--- a/src/bin/calaos_home/views/IO/IOGenlistScenarioHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOGenlistScenarioHomeView.h
@@ -24,24 +24,23 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOGenlistScenarioHomeView: public GenlistItemBase, public IOBaseElement
 {
 private:
     Evas_Object *object_button;
 
-    string state;
+    std::string state;
 
     virtual void ioDeleted();
     void clickFlashButton_cb();
 
 public:
-    IOGenlistScenarioHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOGenlistScenarioHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOGenlistScenarioHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOInternalBoolHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOInternalBoolHomeView.cpp
@@ -24,8 +24,8 @@
 ITEM_BUTTON_CALLBACK(IOInternalBoolHomeView, On)
 ITEM_BUTTON_CALLBACK(IOInternalBoolHomeView, Off)
 
-IOInternalBoolHomeView::IOInternalBoolHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("InternalBool_") + style_addition + ((_io->params["rw"] == "true")?"/rw":""), _flags),
+IOInternalBoolHomeView::IOInternalBoolHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("InternalBool_") + style_addition + ((_io->params["rw"] == "true")?"/rw":""), _flags),
     IOBaseElement(_io)
 {
 }
@@ -41,7 +41,7 @@ void IOInternalBoolHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOInternalBoolHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOInternalBoolHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -71,9 +71,9 @@ Evas_Object *IOInternalBoolHomeView::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOInternalBoolHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOInternalBoolHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 

--- a/src/bin/calaos_home/views/IO/IOInternalBoolHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOInternalBoolHomeView.h
@@ -24,7 +24,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOInternalBoolHomeView: public GenlistItemBase, public IOBaseElement
 {
@@ -32,11 +31,11 @@ private:
     virtual void ioDeleted();
 
 public:
-    IOInternalBoolHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOInternalBoolHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOInternalBoolHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOInternalIntHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOInternalIntHomeView.cpp
@@ -18,14 +18,15 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
-#include "IOInternalIntHomeView.h"
+
 #include <ApplicationMain.h>
+#include "IOInternalIntHomeView.h"
 
 ITEM_BUTTON_CALLBACK(IOInternalIntHomeView, More)
 ITEM_BUTTON_CALLBACK(IOInternalIntHomeView, Less)
 
-IOInternalIntHomeView::IOInternalIntHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("InternalInt_") + style_addition + ((_io->params["rw"] == "true")?"/rw":""), _flags),
+IOInternalIntHomeView::IOInternalIntHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("InternalInt_") + style_addition + ((_io->params["rw"] == "true")?"/rw":""), _flags),
     IOBaseElement(_io)
 {
 }
@@ -41,7 +42,7 @@ void IOInternalIntHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOInternalIntHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOInternalIntHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -71,9 +72,9 @@ Evas_Object *IOInternalIntHomeView::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOInternalIntHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOInternalIntHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 

--- a/src/bin/calaos_home/views/IO/IOInternalIntHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOInternalIntHomeView.h
@@ -24,7 +24,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOInternalIntHomeView: public GenlistItemBase, public IOBaseElement
 {
@@ -32,11 +31,11 @@ private:
     virtual void ioDeleted();
 
 public:
-    IOInternalIntHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOInternalIntHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOInternalIntHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOInternalStringHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOInternalStringHomeView.cpp
@@ -23,8 +23,8 @@
 
 ITEM_BUTTON_CALLBACK(IOInternalStringHomeView, Text)
 
-IOInternalStringHomeView::IOInternalStringHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("InternalString_") + style_addition + ((_io->params["rw"] == "true")?"/rw":""), _flags),
+IOInternalStringHomeView::IOInternalStringHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("InternalString_") + style_addition + ((_io->params["rw"] == "true")?"/rw":""), _flags),
     IOBaseElement(_io)
 {
 }
@@ -40,7 +40,7 @@ void IOInternalStringHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOInternalStringHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOInternalStringHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -61,9 +61,9 @@ Evas_Object *IOInternalStringHomeView::getPartItem(Evas_Object *obj, string part
     return o;
 }
 
-string IOInternalStringHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOInternalStringHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 
@@ -103,7 +103,7 @@ void IOInternalStringHomeView::buttonClickText()
                                              false);
 }
 
-void IOInternalStringHomeView::changeTextCb(string text)
+void IOInternalStringHomeView::changeTextCb(std::string text)
 {
     if (!io) return;
 

--- a/src/bin/calaos_home/views/IO/IOInternalStringHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOInternalStringHomeView.h
@@ -24,21 +24,20 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOInternalStringHomeView: public GenlistItemBase, public IOBaseElement
 {
 private:
     virtual void ioDeleted();
 
-    void changeTextCb(string text);
+    void changeTextCb(std::string text);
 
 public:
-    IOInternalStringHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOInternalStringHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOInternalStringHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOScenarioHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOScenarioHomeView.cpp
@@ -70,7 +70,7 @@ void IOScenarioHomeView::updateView()
     }
 }
 
-void IOScenarioHomeView::clickScenario(void *data, Evas_Object *edje_object, string emission, string source)
+void IOScenarioHomeView::clickScenario(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     if (!io) return;
 

--- a/src/bin/calaos_home/views/IO/IOScenarioHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOScenarioHomeView.h
@@ -24,14 +24,13 @@
 #include <Utils.h>
 #include <IOView.h>
 
-using namespace Utils;
 
 class IOScenarioHomeView: public IOView
 {
 private:
-    void clickScenario(void *data, Evas_Object *edje_object, string emission, string source);
+    void clickScenario(void *data, Evas_Object *edje_object, std::string emission, std::string source);
 
-    string state;
+    std::string state;
 
     void clickFlashButton_cb();
 

--- a/src/bin/calaos_home/views/IO/IOWIAnalogHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOWIAnalogHomeView.cpp
@@ -21,8 +21,8 @@
 #include "IOWIAnalogHomeView.h"
 #include <ApplicationMain.h>
 
-IOWIAnalogHomeView::IOWIAnalogHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("WIAnalog_") + style_addition, _flags),
+IOWIAnalogHomeView::IOWIAnalogHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("WIAnalog_") + style_addition, _flags),
     IOBaseElement(_io)
 {
 }
@@ -38,7 +38,7 @@ void IOWIAnalogHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOWIAnalogHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOWIAnalogHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -49,9 +49,9 @@ Evas_Object *IOWIAnalogHomeView::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOWIAnalogHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOWIAnalogHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 

--- a/src/bin/calaos_home/views/IO/IOWIAnalogHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOWIAnalogHomeView.h
@@ -24,7 +24,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOWIAnalogHomeView: public GenlistItemBase, public IOBaseElement
 {
@@ -32,11 +31,11 @@ private:
     virtual void ioDeleted();
 
 public:
-    IOWIAnalogHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOWIAnalogHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOWIAnalogHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOWITempHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOWITempHomeView.cpp
@@ -21,8 +21,8 @@
 #include "IOWITempHomeView.h"
 #include <ApplicationMain.h>
 
-IOWITempHomeView::IOWITempHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("WITemp_") + style_addition, _flags),
+IOWITempHomeView::IOWITempHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("WITemp_") + style_addition, _flags),
     IOBaseElement(_io)
 {
 }
@@ -38,7 +38,7 @@ void IOWITempHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOWITempHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOWITempHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -49,9 +49,9 @@ Evas_Object *IOWITempHomeView::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOWITempHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOWITempHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 

--- a/src/bin/calaos_home/views/IO/IOWITempHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOWITempHomeView.h
@@ -24,7 +24,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOWITempHomeView: public GenlistItemBase, public IOBaseElement
 {
@@ -32,11 +31,11 @@ private:
     virtual void ioDeleted();
 
 public:
-    IOWITempHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOWITempHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOWITempHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOWOAnalogHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOWOAnalogHomeView.cpp
@@ -24,8 +24,8 @@
 ITEM_BUTTON_CALLBACK(IOWOAnalogHomeView, More)
 ITEM_BUTTON_CALLBACK(IOWOAnalogHomeView, Less)
 
-IOWOAnalogHomeView::IOWOAnalogHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("WOAnalog_") + style_addition, _flags),
+IOWOAnalogHomeView::IOWOAnalogHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("WOAnalog_") + style_addition, _flags),
     IOBaseElement(_io)
 {
 }
@@ -41,7 +41,7 @@ void IOWOAnalogHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOWOAnalogHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOWOAnalogHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -71,9 +71,9 @@ Evas_Object *IOWOAnalogHomeView::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOWOAnalogHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOWOAnalogHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 

--- a/src/bin/calaos_home/views/IO/IOWOAnalogHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOWOAnalogHomeView.h
@@ -24,7 +24,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOWOAnalogHomeView: public GenlistItemBase, public IOBaseElement
 {
@@ -32,11 +31,11 @@ private:
     virtual void ioDeleted();
 
 public:
-    IOWOAnalogHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOWOAnalogHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOWOAnalogHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOWODaliHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOWODaliHomeView.cpp
@@ -26,8 +26,8 @@ ITEM_BUTTON_CALLBACK(IOWODaliHomeView, Off)
 ITEM_BUTTON_CALLBACK(IOWODaliHomeView, More)
 ITEM_BUTTON_CALLBACK(IOWODaliHomeView, Less)
 
-IOWODaliHomeView::IOWODaliHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("WODali_") + style_addition, _flags),
+IOWODaliHomeView::IOWODaliHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("WODali_") + style_addition, _flags),
     IOBaseElement(_io)
 {
 }
@@ -43,7 +43,7 @@ void IOWODaliHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOWODaliHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOWODaliHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -104,9 +104,9 @@ Evas_Object *IOWODaliHomeView::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOWODaliHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOWODaliHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 
@@ -175,7 +175,7 @@ void IOWODaliHomeView::updateView()
     }
 }
 
-void IOWODaliHomeView::sliderSignalCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void IOWODaliHomeView::sliderSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     if (emission == "slider,start")
     {
@@ -189,7 +189,7 @@ void IOWODaliHomeView::sliderSignalCallback(void *data, Evas_Object *edje_object
         double x;
         slider->getDragValue("slider", &x, NULL);
 
-        string action = "set ";
+        std::string action = "set ";
         action += Utils::to_string((int)(x * 100.0));
 
         if (io) io->sendAction(action);
@@ -217,7 +217,7 @@ void IOWODaliHomeView::buttonClickMore()
 {
     if (!io) return;
 
-    string action = "set ";
+    std::string action = "set ";
     action += Utils::to_string((int)(io->getDaliValueFromState() + 1));
 
     io->sendAction(action);
@@ -227,7 +227,7 @@ void IOWODaliHomeView::buttonClickLess()
 {
     if (!io) return;
 
-    string action = "set ";
+    std::string action = "set ";
     action += Utils::to_string((int)(io->getDaliValueFromState() - 1));
 
     io->sendAction(action);

--- a/src/bin/calaos_home/views/IO/IOWODaliHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOWODaliHomeView.h
@@ -24,7 +24,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOWODaliHomeView: public GenlistItemBase, public IOBaseElement
 {
@@ -35,14 +34,14 @@ private:
 
     void sliderObjectDeleted();
 
-    void sliderSignalCallback(void *data, Evas_Object *edje_object, string emission, string source);
+    void sliderSignalCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source);
 
 public:
-    IOWODaliHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOWODaliHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOWODaliHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOWODaliRVBHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOWODaliRVBHomeView.cpp
@@ -31,8 +31,8 @@ ITEM_BUTTON_CALLBACK(IOWODaliRVBHomeView, GreenLess)
 ITEM_BUTTON_CALLBACK(IOWODaliRVBHomeView, BlueMore)
 ITEM_BUTTON_CALLBACK(IOWODaliRVBHomeView, BlueLess)
 
-IOWODaliRVBHomeView::IOWODaliRVBHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("WODaliRVB_") + style_addition, _flags),
+IOWODaliRVBHomeView::IOWODaliRVBHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("WODaliRVB_") + style_addition, _flags),
     IOBaseElement(_io)
 {
 }
@@ -48,7 +48,7 @@ void IOWODaliRVBHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOWODaliRVBHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOWODaliRVBHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -192,9 +192,9 @@ Evas_Object *IOWODaliRVBHomeView::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOWODaliRVBHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOWODaliRVBHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 
@@ -290,7 +290,7 @@ void IOWODaliRVBHomeView::updateView()
     }
 }
 
-void IOWODaliRVBHomeView::sliderSignalCallbackRed(void *data, Evas_Object *edje_object, string emission, string source)
+void IOWODaliRVBHomeView::sliderSignalCallbackRed(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     EdjeObject *slider = reinterpret_cast<EdjeObject *>(data);
     if (!slider) return;
@@ -311,7 +311,7 @@ void IOWODaliRVBHomeView::sliderSignalCallbackRed(void *data, Evas_Object *edje_
 
         c.setRed(x * 100.0 * 255.0 / 100.0);
 
-        string action = "set " + c.toString();
+        std::string action = "set " + c.toString();
 
         if (io) io->sendAction(action);
 
@@ -320,7 +320,7 @@ void IOWODaliRVBHomeView::sliderSignalCallbackRed(void *data, Evas_Object *edje_
 
 }
 
-void IOWODaliRVBHomeView::sliderSignalCallbackGreen(void *data, Evas_Object *edje_object, string emission, string source)
+void IOWODaliRVBHomeView::sliderSignalCallbackGreen(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     EdjeObject *slider = reinterpret_cast<EdjeObject *>(data);
     if (!slider) return;
@@ -341,7 +341,7 @@ void IOWODaliRVBHomeView::sliderSignalCallbackGreen(void *data, Evas_Object *edj
 
         c.setGreen(x * 100.0 * 255.0 / 100.0);
 
-        string action = "set " + c.toString();
+        std::string action = "set " + c.toString();
 
         if (io) io->sendAction(action);
 
@@ -350,7 +350,7 @@ void IOWODaliRVBHomeView::sliderSignalCallbackGreen(void *data, Evas_Object *edj
 
 }
 
-void IOWODaliRVBHomeView::sliderSignalCallbackBlue(void *data, Evas_Object *edje_object, string emission, string source)
+void IOWODaliRVBHomeView::sliderSignalCallbackBlue(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     EdjeObject *slider = reinterpret_cast<EdjeObject *>(data);
     if (!slider) return;
@@ -371,7 +371,7 @@ void IOWODaliRVBHomeView::sliderSignalCallbackBlue(void *data, Evas_Object *edje
 
         c.setBlue(x * 100.0 * 255.0 / 100.0);
 
-        string action = "set " + c.toString();
+        std::string action = "set " + c.toString();
 
         if (io) io->sendAction(action);
 
@@ -400,7 +400,7 @@ void IOWODaliRVBHomeView::buttonClickRedMore()
 
     ColorValue c(io->params["state"]);
     c.setRed(c.getRed() + 5);
-    string action = "set " + c.toString();
+    std::string action = "set " + c.toString();
 
     io->sendAction(action);
 }
@@ -411,7 +411,7 @@ void IOWODaliRVBHomeView::buttonClickRedLess()
 
     ColorValue c(io->params["state"]);
     c.setRed(c.getRed() - 5);
-    string action = "set " + c.toString();
+    std::string action = "set " + c.toString();
 
     io->sendAction(action);
 }
@@ -422,7 +422,7 @@ void IOWODaliRVBHomeView::buttonClickGreenMore()
 
     ColorValue c(io->params["state"]);
     c.setGreen(c.getGreen() + 5);
-    string action = "set " + c.toString();
+    std::string action = "set " + c.toString();
 
     io->sendAction(action);
 }
@@ -433,7 +433,7 @@ void IOWODaliRVBHomeView::buttonClickGreenLess()
 
     ColorValue c(io->params["state"]);
     c.setGreen(c.getGreen() - 5);
-    string action = "set " + c.toString();
+    std::string action = "set " + c.toString();
 
     io->sendAction(action);
 }
@@ -444,7 +444,7 @@ void IOWODaliRVBHomeView::buttonClickBlueMore()
 
     ColorValue c(io->params["state"]);
     c.setBlue(c.getBlue() + 5);
-    string action = "set " + c.toString();
+    std::string action = "set " + c.toString();
 
     io->sendAction(action);
 }
@@ -455,7 +455,7 @@ void IOWODaliRVBHomeView::buttonClickBlueLess()
 
     ColorValue c(io->params["state"]);
     c.setBlue(c.getBlue() - 5);
-    string action = "set " + c.toString();
+    std::string action = "set " + c.toString();
 
     io->sendAction(action);
 }

--- a/src/bin/calaos_home/views/IO/IOWODaliRVBHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOWODaliRVBHomeView.h
@@ -24,7 +24,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOWODaliRVBHomeView: public GenlistItemBase, public IOBaseElement
 {
@@ -42,16 +41,16 @@ private:
     void sliderGreenObjectDeleted();
     void sliderBlueObjectDeleted();
 
-    void sliderSignalCallbackRed(void *data, Evas_Object *edje_object, string emission, string source);
-    void sliderSignalCallbackGreen(void *data, Evas_Object *edje_object, string emission, string source);
-    void sliderSignalCallbackBlue(void *data, Evas_Object *edje_object, string emission, string source);
+    void sliderSignalCallbackRed(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void sliderSignalCallbackGreen(void *data, Evas_Object *edje_object, std::string emission, std::string source);
+    void sliderSignalCallbackBlue(void *data, Evas_Object *edje_object, std::string emission, std::string source);
 
 public:
-    IOWODaliRVBHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOWODaliRVBHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOWODaliRVBHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOWODigitalHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOWODigitalHomeView.cpp
@@ -24,8 +24,8 @@
 ITEM_BUTTON_CALLBACK(IOWODigitalHomeView, On)
 ITEM_BUTTON_CALLBACK(IOWODigitalHomeView, Off)
 
-IOWODigitalHomeView::IOWODigitalHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("WODigital_") + style_addition, _flags),
+IOWODigitalHomeView::IOWODigitalHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("WODigital_") + style_addition, _flags),
     IOBaseElement(_io)
 {
 }
@@ -41,7 +41,7 @@ void IOWODigitalHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOWODigitalHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOWODigitalHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -71,9 +71,9 @@ Evas_Object *IOWODigitalHomeView::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOWODigitalHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOWODigitalHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 

--- a/src/bin/calaos_home/views/IO/IOWODigitalHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOWODigitalHomeView.h
@@ -24,7 +24,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOWODigitalHomeView: public GenlistItemBase, public IOBaseElement
 {
@@ -32,11 +31,11 @@ private:
     virtual void ioDeleted();
 
 public:
-    IOWODigitalHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOWODigitalHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOWODigitalHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOWOStringHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOWOStringHomeView.cpp
@@ -23,8 +23,8 @@
 
 ITEM_BUTTON_CALLBACK(IOWOStringHomeView, Text)
 
-IOWOStringHomeView::IOWOStringHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("InternalString_") + style_addition + "/rw", _flags),
+IOWOStringHomeView::IOWOStringHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("InternalString_") + style_addition + "/rw", _flags),
     IOBaseElement(_io)
 {
 }
@@ -40,7 +40,7 @@ void IOWOStringHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOWOStringHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOWOStringHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -61,9 +61,9 @@ Evas_Object *IOWOStringHomeView::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOWOStringHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOWOStringHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 
@@ -103,7 +103,7 @@ void IOWOStringHomeView::buttonClickText()
                                              false);
 }
 
-void IOWOStringHomeView::changeTextCb(string text)
+void IOWOStringHomeView::changeTextCb(std::string text)
 {
     if (!io) return;
 

--- a/src/bin/calaos_home/views/IO/IOWOStringHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOWOStringHomeView.h
@@ -24,21 +24,20 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOWOStringHomeView: public GenlistItemBase, public IOBaseElement
 {
 private:
     virtual void ioDeleted();
 
-    void changeTextCb(string text);
+    void changeTextCb(std::string text);
 
 public:
-    IOWOStringHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOWOStringHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOWOStringHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOWOVoletHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOWOVoletHomeView.cpp
@@ -25,8 +25,8 @@ ITEM_BUTTON_CALLBACK(IOWOVoletHomeView, Up)
 ITEM_BUTTON_CALLBACK(IOWOVoletHomeView, Down)
 ITEM_BUTTON_CALLBACK(IOWOVoletHomeView, Stop)
 
-IOWOVoletHomeView::IOWOVoletHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("WOVolet_") + style_addition, _flags),
+IOWOVoletHomeView::IOWOVoletHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("WOVolet_") + style_addition, _flags),
     IOBaseElement(_io)
 {
 }
@@ -42,7 +42,7 @@ void IOWOVoletHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOWOVoletHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOWOVoletHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -81,9 +81,9 @@ Evas_Object *IOWOVoletHomeView::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOWOVoletHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOWOVoletHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 

--- a/src/bin/calaos_home/views/IO/IOWOVoletHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOWOVoletHomeView.h
@@ -24,7 +24,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOWOVoletHomeView: public GenlistItemBase, public IOBaseElement
 {
@@ -32,11 +31,11 @@ private:
     virtual void ioDeleted();
 
 public:
-    IOWOVoletHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOWOVoletHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOWOVoletHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IO/IOWOVoletSmartHomeView.cpp
+++ b/src/bin/calaos_home/views/IO/IOWOVoletSmartHomeView.cpp
@@ -18,8 +18,9 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
-#include "IOWOVoletSmartHomeView.h"
+
 #include <ApplicationMain.h>
+#include "IOWOVoletSmartHomeView.h"
 
 ITEM_BUTTON_CALLBACK(IOWOVoletSmartHomeView, Up)
 ITEM_BUTTON_CALLBACK(IOWOVoletSmartHomeView, Down)
@@ -30,8 +31,8 @@ ITEM_BUTTON_CALLBACK(IOWOVoletSmartHomeView, Set25)
 ITEM_BUTTON_CALLBACK(IOWOVoletSmartHomeView, Set50)
 ITEM_BUTTON_CALLBACK(IOWOVoletSmartHomeView, Set75)
 
-IOWOVoletSmartHomeView::IOWOVoletSmartHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string style_addition, Elm_Genlist_Item_Type _flags):
-    GenlistItemBase(_evas, _parent, string("WOVoletSmart_") + style_addition, _flags),
+IOWOVoletSmartHomeView::IOWOVoletSmartHomeView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string style_addition, Elm_Genlist_Item_Type _flags):
+    GenlistItemBase(_evas, _parent, std::string("WOVoletSmart_") + style_addition, _flags),
     IOBaseElement(_io),
     window_slider(NULL)
 {
@@ -48,7 +49,7 @@ void IOWOVoletSmartHomeView::ioDeleted()
     DELETE_NULL_FUNC(elm_object_item_del, item)
 }
 
-Evas_Object *IOWOVoletSmartHomeView::getPartItem(Evas_Object *obj, string part)
+Evas_Object *IOWOVoletSmartHomeView::getPartItem(Evas_Object *obj, std::string part)
 {
     Evas_Object *o = NULL;
 
@@ -136,9 +137,9 @@ Evas_Object *IOWOVoletSmartHomeView::getPartItem(Evas_Object *obj, string part)
     return o;
 }
 
-string IOWOVoletSmartHomeView::getLabelItem(Evas_Object *obj, string part)
+std::string IOWOVoletSmartHomeView::getLabelItem(Evas_Object *obj, std::string part)
 {
-    string text;
+    std::string text;
 
     if (!io) return text;
 
@@ -162,7 +163,7 @@ string IOWOVoletSmartHomeView::getLabelItem(Evas_Object *obj, string part)
     }
     else if (part == "shutter.action")
     {
-        string status = io->getStatusVoletSmart();
+        std::string status = io->getStatusVoletSmart();
         if (status == "stop" || status == "")
             text = _("Action: <light_blue>Stopped.</light_blue>");
         else if (status == "down")

--- a/src/bin/calaos_home/views/IO/IOWOVoletSmartHomeView.h
+++ b/src/bin/calaos_home/views/IO/IOWOVoletSmartHomeView.h
@@ -24,7 +24,6 @@
 #include <Utils.h>
 #include <GenlistItemBase.h>
 
-using namespace Utils;
 
 class IOWOVoletSmartHomeView: public GenlistItemBase, public IOBaseElement
 {
@@ -36,11 +35,11 @@ private:
     void sliderObjectDeleted();
 
 public:
-    IOWOVoletSmartHomeView(Evas *evas, Evas_Object *parent, IOBase *io, string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
+    IOWOVoletSmartHomeView(Evas *evas, Evas_Object *parent, IOBase *io, std::string style_addition, Elm_Genlist_Item_Type flags = ELM_GENLIST_ITEM_NONE);
     virtual ~IOWOVoletSmartHomeView();
 
-    virtual Evas_Object *getPartItem(Evas_Object *obj, string part);
-    virtual string getLabelItem(Evas_Object *obj, string part);
+    virtual Evas_Object *getPartItem(Evas_Object *obj, std::string part);
+    virtual std::string getLabelItem(Evas_Object *obj, std::string part);
 
     //Called when the real IO changed
     virtual void initView();

--- a/src/bin/calaos_home/views/IOView.cpp
+++ b/src/bin/calaos_home/views/IOView.cpp
@@ -36,7 +36,7 @@
 #include "IO/IOWOVoletSmartHomeView.h"
 #include "IO/IOWOStringHomeView.h"
 
-IOView::IOView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string _collection):
+IOView::IOView(Evas *_evas, Evas_Object *_parent, IOBase *_io, std::string _collection):
     BaseView(_evas, _parent),
     IOBaseElement(_io)
 {
@@ -44,7 +44,7 @@ IOView::IOView(Evas *_evas, Evas_Object *_parent, IOBase *_io, string _collectio
     {
         LoadEdje(_collection);
     }
-    catch (exception const &e)
+    catch (std::exception const &e)
     {
         cCritical() <<  "IOView: Can't load edje";
         throw;
@@ -112,7 +112,7 @@ IOView *IOViewFactory::CreateIOView(Evas *evas, Evas_Object *parent, int type)
     return CreateIOView(evas, parent, NULL, type);
 }
 
-IOBaseElement *IOViewFactory::CreateIOBaseElement(Evas *evas, Evas_Object *parent, IOBase *io, Evas_Object *genlist, string style_addition, GenlistItemBase *gparent)
+IOBaseElement *IOViewFactory::CreateIOBaseElement(Evas *evas, Evas_Object *parent, IOBase *io, Evas_Object *genlist, std::string style_addition, GenlistItemBase *gparent)
 {
     IOBaseElement *element = NULL;
 

--- a/src/bin/calaos_home/views/IOView.h
+++ b/src/bin/calaos_home/views/IOView.h
@@ -26,7 +26,6 @@
 
 #include <CalaosModel.h>
 
-using namespace Utils;
 
 class IOBaseElement
 {
@@ -56,7 +55,7 @@ public:
     enum { IO_NONE = 0, IO_SCENARIO_HOME };
 
 public:
-    IOView(Evas *evas, Evas_Object *parent, IOBase *io, string collection);
+    IOView(Evas *evas, Evas_Object *parent, IOBase *io, std::string collection);
     IOView(Evas *evas, Evas_Object *parent, IOBase *io);
     virtual ~IOView();
 };
@@ -67,7 +66,7 @@ public:
     static IOView *CreateIOView(Evas *evas, Evas_Object *parent, IOBase *io, int type);
     static IOView *CreateIOView(Evas *evas, Evas_Object *parent, int type);
 
-    static IOBaseElement *CreateIOBaseElement(Evas *evas, Evas_Object *parent, IOBase *io, Evas_Object *genlist, string style_addition, GenlistItemBase *gparent = NULL);
+    static IOBaseElement *CreateIOBaseElement(Evas *evas, Evas_Object *parent, IOBase *io, Evas_Object *genlist, std::string style_addition, GenlistItemBase *gparent = NULL);
 };
 
 #endif // IOVIEW_H

--- a/src/bin/calaos_home/views/KeyboardView.cpp
+++ b/src/bin/calaos_home/views/KeyboardView.cpp
@@ -41,7 +41,7 @@ KeyboardView::KeyboardView(Evas *_e, Evas_Object *_parent):
     {
         LoadEdje("calaos/keyboard");
     }
-    catch (exception const &e)
+    catch (std::exception const &e)
     {
         cCritical() <<  "KeyboardView: Can't load edje";
         throw;
@@ -54,7 +54,7 @@ KeyboardView::~KeyboardView()
 {
 }
 
-void KeyboardView::pressKey(string k)
+void KeyboardView::pressKey(std::string k)
 {
 #ifdef HAVE_ECORE_X
     /* Code from enlightenment/Illume */
@@ -76,7 +76,7 @@ void KeyboardView::pressKey(string k)
 #endif
 }
 
-void KeyboardView::onKeyboardCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void KeyboardView::onKeyboardCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
 #ifdef HAVE_ECORE_X
     if (source == "keyboard" && emission == "key,key_maj")
@@ -143,7 +143,7 @@ void KeyboardView::onKeyboardCallback(void *data, Evas_Object *edje_object, stri
     {
         emission.erase(0, 4);
         if (keys_upper)
-            std::transform (emission.begin(), emission.end(), emission.begin(), to_upper());
+            std::transform (emission.begin(), emission.end(), emission.begin(), Utils::to_upper());
 
         pressKey(emission);
     }

--- a/src/bin/calaos_home/views/KeyboardView.h
+++ b/src/bin/calaos_home/views/KeyboardView.h
@@ -25,12 +25,11 @@
 
 #include "BaseView.h"
 
-using namespace Utils;
 
 class KeyboardView: public BaseView
 {
 private:
-    void onKeyboardCallback(void *data, Evas_Object *edje_object, string emission, string source);
+    void onKeyboardCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source);
 
     bool keys_upper;
     bool keys_other;
@@ -40,10 +39,10 @@ public:
     ~KeyboardView();
 
     //simulate a pressed key
-    void pressKey(string key);
+    void pressKey(std::string key);
 
     enum { KEY_ALPHA, KEY_SHIFT, KEY_SPACE, KEY_ENTER };
-    sigc::signal<void, string, int> key_pressed;
+    sigc::signal<void, std::string, int> key_pressed;
 };
 
 #endif // KeyboardView_H

--- a/src/bin/calaos_home/views/MainContentView.cpp
+++ b/src/bin/calaos_home/views/MainContentView.cpp
@@ -32,7 +32,7 @@ MainContentView::MainContentView(Evas *_e, Evas_Object *_p):
 
 MainContentView::~MainContentView()
 {
-    list<ViewAnimation *>::iterator it = views.begin();
+    std::list<ViewAnimation *>::iterator it = views.begin();
     for (;it != views.end();it++)
     {
         ViewAnimation *va = (*it);
@@ -53,7 +53,7 @@ MainContentView::~MainContentView()
 void MainContentView::addView(BaseView *view)
 {
     if (!view)
-        throw(runtime_error("MainContentView::addView(): view is NULL !"));
+        throw(std::runtime_error("MainContentView::addView(): view is NULL !"));
 
     int x, y, w, h;
     evas_object_geometry_get(clip, &x, &y, &w, &h);
@@ -110,10 +110,10 @@ void MainContentView::showView(BaseView *view)
     cCritical() <<  "MainMenuView:showView() not implemented !";
 
     if (!view)
-        throw(runtime_error("MainContentView::showView(): view is NULL !"));
+        throw(std::runtime_error("MainContentView::showView(): view is NULL !"));
 }
 
-void MainContentView::hideFinished(void *data, Evas_Object *edje_object, string emission, string source)
+void MainContentView::hideFinished(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     ViewAnimation *va = reinterpret_cast<ViewAnimation *>(data);
     if (!va) return;
@@ -128,7 +128,7 @@ void MainContentView::hideFinished(void *data, Evas_Object *edje_object, string 
         delete va->animation;
 
         //Don't delete view if it has been pushed again to MainContentView
-        list<ViewAnimation *>::iterator it = views.begin();
+        std::list<ViewAnimation *>::iterator it = views.begin();
         bool found = false;
         for (;it != views.end();it++)
         {

--- a/src/bin/calaos_home/views/MainContentView.h
+++ b/src/bin/calaos_home/views/MainContentView.h
@@ -26,7 +26,6 @@
 #include "BaseView.h"
 #include "EvasSmart.h"
 
-using namespace Utils;
 
 class ViewAnimation
 {
@@ -51,12 +50,12 @@ public:
 class MainContentView: public BaseView, public EvasSmart
 {
 private:
-    list<ViewAnimation *> views;
+    std::list<ViewAnimation *> views;
     BaseView *top_item;
 
     Evas_Object *clip;
 
-    void hideFinished(void *data, Evas_Object *edje_object, string emission, string source);
+    void hideFinished(void *data, Evas_Object *edje_object, std::string emission, std::string source);
 
 public:
     MainContentView(Evas *evas, Evas_Object *parent);

--- a/src/bin/calaos_home/views/MainMenuView.cpp
+++ b/src/bin/calaos_home/views/MainMenuView.cpp
@@ -48,7 +48,7 @@ MainMenuView::MainMenuView(Evas *_e, Evas_Object *_p):
         setPartText("menu_buttons_configuration_label", _("Configuration"));
 
     }
-    catch(exception const& e)
+    catch(std::exception const& e)
     {
         cCritical() <<  "MainMenuView: Can't load edje";
         throw;
@@ -128,13 +128,13 @@ void MainMenuView::EdjeCallback(void *data, Evas_Object *_edje, std::string emis
             int val;
             from_string(Utils::get_config_option("dpms_standby"), val);
 
-            string _t = _("Auto: ") + Utils::time2string(val);
+            std::string _t = _("Auto: ") + Utils::time2string(val);
             edje_object_part_text_set(elm_list_item_object_get(item_sleep_screen), "object.more_infos",
                                       _t.c_str());
         }
 
         //Update number of widgets
-        string nb = Utils::to_string(ApplicationMain::Instance().getMainController()->getWidgetController()->getWidgetCount());
+        std::string nb = Utils::to_string(ApplicationMain::Instance().getMainController()->getWidgetController()->getWidgetCount());
         nb += " Widgets";
 
         edje_object_part_text_set(elm_list_item_object_get(item_config_addwidget), "object.more_infos",
@@ -162,7 +162,7 @@ void MainMenuView::EdjeCallback(void *data, Evas_Object *_edje, std::string emis
     }
 }
 
-void MainMenuView::ButtonPressedCallback(void *data, Evas_Object *_edje, string emission, string source)
+void MainMenuView::ButtonPressedCallback(void *data, Evas_Object *_edje, std::string emission, std::string source)
 {
     if (source == "button.valid")
     {
@@ -238,7 +238,7 @@ void MainMenuView::CloseLinkMenu()
     EmitSignal("menu,link,close", "calaos");
 }
 
-void MainMenuView::setVersionString(string version)
+void MainMenuView::setVersionString(std::string version)
 {
     setPartText("calaos.version", version);
 }

--- a/src/bin/calaos_home/views/MainMenuView.h
+++ b/src/bin/calaos_home/views/MainMenuView.h
@@ -25,7 +25,6 @@
 
 #include "BaseView.h"
 
-using namespace Utils;
 
 class MainMenuView: public BaseView
 {
@@ -67,7 +66,7 @@ public:
     void OpenLinkMenu();
     void CloseLinkMenu();
 
-    void setVersionString(string version);
+    void setVersionString(std::string version);
 
     /**
                  * UI Signals

--- a/src/bin/calaos_home/views/PagingView.cpp
+++ b/src/bin/calaos_home/views/PagingView.cpp
@@ -51,7 +51,7 @@ PagingView::PagingView(Evas *_e, Evas_Object *_parent):
     {
         LoadEdje("calaos/paging_view");
     }
-    catch(exception const& e)
+    catch(std::exception const& e)
     {
         cCritical() <<  "PagingView: Can't load edje";
         throw;
@@ -101,7 +101,7 @@ PagingView::~PagingView()
         evas_object_del(pages[i]);
     pages.clear();
 
-    for_each(selectors.begin(), selectors.end(), Delete());
+    for_each(selectors.begin(), selectors.end(), Utils::Delete());
     selectors.clear();
 
     DELETE_NULL_FUNC(evas_object_del, box_content)
@@ -120,7 +120,7 @@ int PagingView::addPage(Evas_Object *content)
     {
         o->LoadEdje("calaos/paging_view/selector");
     }
-    catch(exception const& e)
+    catch(std::exception const& e)
     {
         cCritical() <<  "PagingView: Can't load edje calaos/paging_view/selector";
         throw;

--- a/src/bin/calaos_home/views/PagingView.h
+++ b/src/bin/calaos_home/views/PagingView.h
@@ -38,8 +38,8 @@ protected:
     Evas_Object *box_content;
     Evas_Object *box_selector;
 
-    vector<Evas_Object *> pages;
-    vector<EdjeObject *> selectors;
+    std::vector<Evas_Object *> pages;
+    std::vector<EdjeObject *> selectors;
 
 public:
     PagingView(Evas *evas, Evas_Object *parent);

--- a/src/bin/calaos_home/views/ScreenSuspendView.cpp
+++ b/src/bin/calaos_home/views/ScreenSuspendView.cpp
@@ -39,7 +39,7 @@ ScreenSuspendView::ScreenSuspendView(Evas *_e, Evas_Object *p):
     {
         LoadEdje("calaos/screen_suspend");
     }
-    catch(exception const& e)
+    catch(std::exception const& e)
     {
         cCritical() <<  "ScreenSuspendView: Can't load edje";
         throw;
@@ -106,7 +106,7 @@ void ScreenSuspendView::ResizeCb()
     Move(0, 0);
 }
 
-void ScreenSuspendView::edjeCallback(void *data, Evas_Object *obj, string emission, string source)
+void ScreenSuspendView::edjeCallback(void *data, Evas_Object *obj, std::string emission, std::string source)
 {
     if (!is_during_wakeup)
         ScreenManager::instance().updateTimer();

--- a/src/bin/calaos_home/views/Widget.cpp
+++ b/src/bin/calaos_home/views/Widget.cpp
@@ -60,7 +60,7 @@ static void _evas_resize_move_cb(void *data, Evas *e, Evas_Object *obj, void *ev
     if (w) w->Callback(NULL, "resizing", "widget");
 }
 
-Widget::Widget(string &_theme, Evas *_evas, ModuleDef &_mtype, string _id, Evas_Object *_parent, ActivityWidgetsView *_view):
+Widget::Widget(std::string &_theme, Evas *_evas, ModuleDef &_mtype, std::string _id, Evas_Object *_parent, ActivityWidgetsView *_view):
     EdjeObject(_theme, _evas),
     parent(_parent),
     view(_view),
@@ -84,7 +84,7 @@ Widget::Widget(string &_theme, Evas *_evas, ModuleDef &_mtype, string _id, Evas_
 
     if (!ModuleManager::Instance().createModuleInstance(evas, _mtype, mdef, id))
     {
-        string msg = "Error, createModuleInstance(" + mtype + ") failed !";
+        std::string msg = "Error, createModuleInstance(" + mtype + ") failed !";
         throw line_exception(msg.c_str(), __LINE__);
     }
 
@@ -92,7 +92,7 @@ Widget::Widget(string &_theme, Evas *_evas, ModuleDef &_mtype, string _id, Evas_
 
     if (!module)
     {
-        string msg = "Error, getModuleInstance(" + mtype + ") failed !";
+        std::string msg = "Error, getModuleInstance(" + mtype + ") failed !";
         throw line_exception(msg.c_str(), __LINE__);
     }
 
@@ -200,7 +200,7 @@ void Widget::Callback(Evas_Object *edj, std::string emission, std::string source
         evas_object_size_hint_weight_set(glist, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
         evas_object_show(glist);
 
-        string title_label = _("Confirmation<br><small><light_blue>Are you sure to delete this widget?</light_blue></small>");
+        std::string title_label = _("Confirmation<br><small><light_blue>Are you sure to delete this widget?</light_blue></small>");
         GenlistItemBase *header = new GenlistItemSimpleHeader(evas, glist, title_label);
         header->Append(glist);
 
@@ -384,13 +384,13 @@ void Widget::Save(TiXmlElement *pnode)
     node->SetAttribute("height", Utils::to_string(height));
 }
 
-string Widget::getStringInfo()
+std::string Widget::getStringInfo()
 {
     CalaosModuleBase *module = ModuleManager::Instance().getModuleInstance(mdef);
 
     if (!module)
     {
-        string msg = "Error, getModuleInstance(" + mtype + ") failed !";
+        std::string msg = "Error, getModuleInstance(" + mtype + ") failed !";
         throw line_exception(msg.c_str(), __LINE__);
 
         return "Error !";

--- a/src/bin/calaos_home/views/Widget.h
+++ b/src/bin/calaos_home/views/Widget.h
@@ -36,7 +36,7 @@ protected:
     ActivityWidgetsView *view;
 
     double x, y, start_time;
-    string id, mtype;
+    std::string id, mtype;
 
     ModuleDef mdef;
 
@@ -61,7 +61,7 @@ protected:
     void deleteCancel(void *data);
 
 public:
-    Widget(string &_theme, Evas *_evas, ModuleDef &_mtype, string _id, Evas_Object *parent, ActivityWidgetsView *view);
+    Widget(std::string &_theme, Evas *_evas, ModuleDef &_mtype, std::string _id, Evas_Object *parent, ActivityWidgetsView *view);
     ~Widget();
 
     void Callback(Evas_Object *edje, std::string emission, std::string source);
@@ -80,9 +80,9 @@ public:
     //Save config & position to xml
     virtual void Save(TiXmlElement *node);
 
-    virtual string getId() { return id; }
-    virtual string getType() { return mtype; }
-    virtual string getStringInfo();
+    virtual std::string getId() { return id; }
+    virtual std::string getType() { return mtype; }
+    virtual std::string getStringInfo();
 };
 
 #endif

--- a/src/bin/calaos_home/views/Xmas.cpp
+++ b/src/bin/calaos_home/views/Xmas.cpp
@@ -30,7 +30,7 @@ static Eina_Bool _snow_cb_animator (void *data)
         return EINA_TRUE;
 }
 
-XmasWidget::XmasWidget(string &_theme, Evas *_evas, ModuleDef &_mdef, string _id, Evas_Object *_parent, ActivityWidgetsView *_view):
+XmasWidget::XmasWidget(std::string &_theme, Evas *_evas, ModuleDef &_mdef, std::string _id, Evas_Object *_parent, ActivityWidgetsView *_view):
                         Widget(_theme, _evas, _mdef, _id, _parent, _view),
                         animator(NULL), clip(NULL)
 {
@@ -42,7 +42,7 @@ XmasWidget::~XmasWidget()
         if (animator) ecore_animator_del(animator);
         animator = NULL;
 
-        for_each(flakes.begin(), flakes.end(), Delete());
+        for_each(flakes.begin(), flakes.end(), Utils::Delete());
 
         evas_object_del(clip);
 }
@@ -64,9 +64,9 @@ void XmasWidget::Hide()
         animator = NULL;
 }
 
-bool XmasWidget::LoadWidget(string, double _x, double _y, string _id)
+bool XmasWidget::LoadWidget(std::string, double _x, double _y, std::string _id)
 {
-        string witem = "calaos/widget/xmas";
+        std::string witem = "calaos/widget/xmas";
         if (!LoadEdje(witem))
         {
                 return false;
@@ -84,7 +84,7 @@ bool XmasWidget::LoadWidget(string, double _x, double _y, string _id)
         //create some flakes
         for (int i = 0;i < MAX_FLAKE;i++)
         {
-                string type;
+                std::string type;
                 if (i < MAX_FLAKE / 3) type = "flake_small";
                 else if (i >= MAX_FLAKE / 3 && i < (MAX_FLAKE / 3) * 2) type = "flake_medium";
                 else type = "flake_large";
@@ -173,7 +173,7 @@ void XmasWidget::Save(TiXmlElement *node)
 {
 }
 
-string XmasWidget::getStringInfo()
+std::string XmasWidget::getStringInfo()
 {
         return "Xmas";
 }

--- a/src/bin/calaos_home/views/Xmas.h
+++ b/src/bin/calaos_home/views/Xmas.h
@@ -66,13 +66,13 @@ class XmasWidget: public Widget
         private:
                 Ecore_Animator *animator;
                 Evas_Object *clip;
-                vector<Flake *> flakes;
+                std::vector<Flake *> flakes;
                 int clipx, clipy, clipw, cliph;
 
-                bool LoadWidget(string type, double x, double y, string _id);
+                bool LoadWidget(std::string type, double x, double y, std::string _id);
 
         public:
-                XmasWidget(string &_theme, Evas *_evas, ModuleDef &_mdef, string _id, Evas_Object *parent, ActivityWidgetsView *view);
+                XmasWidget(std::string &_theme, Evas *_evas, ModuleDef &_mdef, std::string _id, Evas_Object *parent, ActivityWidgetsView *view);
                 ~XmasWidget();
 
                 virtual void Show();
@@ -89,9 +89,9 @@ class XmasWidget: public Widget
                 //Save config & position to xml
                 virtual void Save(TiXmlElement *node);
 
-                virtual string getId() { return id; }
-                virtual string getType() { return mtype; }
-                virtual string getStringInfo();
+                virtual std::string getId() { return id; }
+                virtual std::string getType() { return mtype; }
+                virtual std::string getStringInfo();
 
                 void _Animator();
 };

--- a/src/bin/calaos_server/Audio/AVRDenon.cpp
+++ b/src/bin/calaos_server/Audio/AVRDenon.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "AVRDenon.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 AVRDenon::AVRDenon(Params &p):
     AVReceiver(p, 23)
@@ -73,7 +73,7 @@ void AVRDenon::connectionEstablished()
     sendRequest("MV?");
 }
 
-void AVRDenon::processMessage(string msg)
+void AVRDenon::processMessage(std::string msg)
 {
     cDebugDom("output") << "Recv: " << msg;
 
@@ -191,7 +191,7 @@ void AVRDenon::Power(bool on, int zone)
         sendRequest("Z3OFF");
 }
 
-int AVRDenon::inputFromString(string source)
+int AVRDenon::inputFromString(std::string source)
 {
     if (source == "PHONO") return AVReceiver::AVR_INPUT_PHONO;
     if (source == "CD") return AVReceiver::AVR_INPUT_CD;
@@ -220,7 +220,7 @@ int AVRDenon::inputFromString(string source)
     return AVReceiver::AVR_UNKNOWN;
 }
 
-string AVRDenon::inputToString(int source)
+std::string AVRDenon::inputToString(int source)
 {
     switch (source)
     {
@@ -257,7 +257,7 @@ void AVRDenon::setVolume(int volume, int zone)
 {
     int v = volume * 99 / 100;
     v = 99 - v;
-    stringstream ss;
+    std::stringstream ss;
     ss.width(2);
     ss.fill('0');
 
@@ -271,14 +271,16 @@ void AVRDenon::setVolume(int volume, int zone)
 
 void AVRDenon::selectInputSource(int source, int zone)
 {
-    string s = inputToString(source);
+    std::string s = inputToString(source);
     if (s == "") return;
 
-    string cmd;
+    std::string cmd;
     if (zone == 1) cmd = "SI" + s;
     else if (zone == 2) cmd = "Z2" + s;
     else if (zone == 3) cmd = "Z3" + s;
     else return;
 
     sendRequest(cmd);
+}
+
 }

--- a/src/bin/calaos_server/Audio/AVRDenon.h
+++ b/src/bin/calaos_server/Audio/AVRDenon.h
@@ -32,10 +32,10 @@ class AVRDenon: public AVReceiver
 {
 protected:
 
-    int inputFromString(string source);
-    string inputToString(int source);
+    int inputFromString(std::string source);
+    std::string inputToString(int source);
 
-    virtual void processMessage(string msg);
+    virtual void processMessage(std::string msg);
     virtual void connectionEstablished();
 
 public:

--- a/src/bin/calaos_server/Audio/AVRManager.cpp
+++ b/src/bin/calaos_server/Audio/AVRManager.cpp
@@ -25,7 +25,7 @@
 #include "AVRMarantz.h"
 #include "AVRYamaha.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 AVRManager::AVRManager()
 {
@@ -93,7 +93,7 @@ void AVRManager::Delete(AVReceiver *obj)
     }
 }
 
-AVReceiver *AVRManager::getReceiver(string host)
+AVReceiver *AVRManager::getReceiver(std::string host)
 {
     for (unsigned int i = 0;i < avrs.size();i++)
     {
@@ -102,4 +102,6 @@ AVReceiver *AVRManager::getReceiver(string host)
     }
 
     return NULL;
+}
+
 }

--- a/src/bin/calaos_server/Audio/AVRManager.h
+++ b/src/bin/calaos_server/Audio/AVRManager.h
@@ -34,7 +34,7 @@ class AVRManager
 private:
     AVRManager();
 
-    vector<AVReceiver *> avrs;
+    std::vector<AVReceiver *> avrs;
 public:
     static AVRManager &Instance(); //Singleton
     ~AVRManager();
@@ -42,7 +42,7 @@ public:
     AVReceiver *Create(Params &p);
     void Delete(AVReceiver *obj);
 
-    AVReceiver *getReceiver(string host);
+    AVReceiver *getReceiver(std::string host);
 };
 
 }

--- a/src/bin/calaos_server/Audio/AVRMarantz.cpp
+++ b/src/bin/calaos_server/Audio/AVRMarantz.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "AVRMarantz.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 AVRMarantz::AVRMarantz(Params &p):
     AVReceiver(p, 23)
@@ -76,7 +76,7 @@ void AVRMarantz::connectionEstablished()
     sendRequest("MV?");
 }
 
-void AVRMarantz::processMessage(string msg)
+void AVRMarantz::processMessage(std::string msg)
 {
     cDebugDom("output") << "Recv: " << msg;
 
@@ -194,7 +194,7 @@ void AVRMarantz::Power(bool on, int zone)
         sendRequest("Z3OFF");
 }
 
-int AVRMarantz::inputFromString(string source)
+int AVRMarantz::inputFromString(std::string source)
 {
     if (source == "PHONO") return AVReceiver::AVR_INPUT_PHONO;
     if (source == "CD") return AVReceiver::AVR_INPUT_CD;
@@ -225,7 +225,7 @@ int AVRMarantz::inputFromString(string source)
     return AVReceiver::AVR_UNKNOWN;
 }
 
-string AVRMarantz::inputToString(int source)
+std::string AVRMarantz::inputToString(int source)
 {
     switch (source)
     {
@@ -264,7 +264,7 @@ void AVRMarantz::setVolume(int volume, int zone)
 {
     int v = volume * 99 / 100;
     v = 99 - v;
-    stringstream ss;
+    std::stringstream ss;
     ss.width(2);
     ss.fill('0');
 
@@ -278,14 +278,16 @@ void AVRMarantz::setVolume(int volume, int zone)
 
 void AVRMarantz::selectInputSource(int source, int zone)
 {
-    string s = inputToString(source);
+    std::string s = inputToString(source);
     if (s == "") return;
 
-    string cmd;
+    std::string cmd;
     if (zone == 1) cmd = "SI" + s;
     else if (zone == 2) cmd = "Z2" + s;
     else if (zone == 3) cmd = "Z3" + s;
     else return;
 
     sendRequest(cmd);
+}
+
 }

--- a/src/bin/calaos_server/Audio/AVRMarantz.h
+++ b/src/bin/calaos_server/Audio/AVRMarantz.h
@@ -32,10 +32,10 @@ class AVRMarantz: public AVReceiver
 {
 protected:
 
-    int inputFromString(string source);
-    string inputToString(int source);
+    int inputFromString(std::string source);
+    std::string inputToString(int source);
 
-    virtual void processMessage(string msg);
+    virtual void processMessage(std::string msg);
     virtual void connectionEstablished();
 
 public:

--- a/src/bin/calaos_server/Audio/AVROnkyo.cpp
+++ b/src/bin/calaos_server/Audio/AVROnkyo.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "AVROnkyo.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 AVROnkyo::AVROnkyo(Params &p):
     AVReceiver(p, 60128, AVR_CON_BYTES)
@@ -71,9 +71,9 @@ void AVROnkyo::connectionEstablished()
     sendCustomCommand("VL3QSTN");
 }
 
-void AVROnkyo::sendCustomCommand(string command)
+void AVROnkyo::sendCustomCommand(std::string command)
 {
-    vector<char> eISCP;
+    std::vector<char> eISCP;
 
     int data_size = command.length() + 3; //2 more bytes for !1
     //        int msg_size = data_size + 16; //end char + header
@@ -120,7 +120,7 @@ void AVROnkyo::sendCustomCommand(string command)
     sendRequest(eISCP);
 }
 
-void AVROnkyo::processMessage(vector<char> data)
+void AVROnkyo::processMessage(std::vector<char> data)
 {
     if (data.size() < 18) //msg is too small, wait for more data to come
     {
@@ -140,8 +140,8 @@ void AVROnkyo::processMessage(vector<char> data)
         brecv_buffer.clear();
     }
 
-    vector<char>::iterator it = data.begin();
-    string msg;
+    std::vector<char>::iterator it = data.begin();
+    std::string msg;
     for (int i = 0;it < data.end();it++, i++)
     {
         if (i < 18) continue;
@@ -182,7 +182,7 @@ void AVROnkyo::processMessage(vector<char> data)
     }
 }
 
-void AVROnkyo::processMessage(string msg)
+void AVROnkyo::processMessage(std::string msg)
 {
     cDebugDom("output") << "Recv new message: " << msg;
 
@@ -191,8 +191,8 @@ void AVROnkyo::processMessage(string msg)
         msg.erase(0, 3);
         if (is_of_type<int>(msg))
         {
-            istringstream iss(msg);
-            iss >> hex >> volume_main;
+            std::istringstream iss(msg);
+            iss >> std::hex >> volume_main;
 
             state_changed_1.emit("volume", Utils::to_string(volume_main));
         }
@@ -202,8 +202,8 @@ void AVROnkyo::processMessage(string msg)
         msg.erase(0, 3);
         if (is_of_type<int>(msg))
         {
-            istringstream iss(msg);
-            iss >> hex >> volume_zone2;
+            std::istringstream iss(msg);
+            iss >> std::hex >> volume_zone2;
 
             state_changed_2.emit("volume", Utils::to_string(volume_zone2));
         }
@@ -213,8 +213,8 @@ void AVROnkyo::processMessage(string msg)
         msg.erase(0, 3);
         if (is_of_type<int>(msg))
         {
-            istringstream iss(msg);
-            iss >> hex >> volume_zone3;
+            std::istringstream iss(msg);
+            iss >> std::hex >> volume_zone3;
 
             state_changed_3.emit("volume", Utils::to_string(volume_zone3));
         }
@@ -295,7 +295,7 @@ void AVROnkyo::Power(bool on, int zone)
         sendCustomCommand("PW300");
 }
 
-int AVROnkyo::inputFromString(string source)
+int AVROnkyo::inputFromString(std::string source)
 {
     if (source == "00") return AVReceiver::AVR_INPUT_VIDEO_1;
     if (source == "01") return AVReceiver::AVR_INPUT_VIDEO_2;
@@ -320,7 +320,7 @@ int AVROnkyo::inputFromString(string source)
     return AVReceiver::AVR_UNKNOWN;
 }
 
-string AVROnkyo::inputToString(int source)
+std::string AVROnkyo::inputToString(int source)
 {
     switch (source)
     {
@@ -351,13 +351,13 @@ string AVROnkyo::inputToString(int source)
 
 void AVROnkyo::setVolume(int volume, int zone)
 {
-    stringstream ss;
+    std::stringstream ss;
     ss.width(2);
     ss.fill('0');
 
-    if (zone == 1) ss << "MVL" << uppercase << hex << volume;
-    else if (zone == 2) ss << "ZVL" << uppercase << hex << volume;
-    else if (zone == 3) ss << "VL3" << uppercase << hex << volume;
+    if (zone == 1) ss << "MVL" << std::uppercase << std::hex << volume;
+    else if (zone == 2) ss << "ZVL" << std::uppercase << std::hex << volume;
+    else if (zone == 3) ss << "VL3" << std::uppercase << std::hex << volume;
     else return;
 
     sendCustomCommand(ss.str());
@@ -365,14 +365,16 @@ void AVROnkyo::setVolume(int volume, int zone)
 
 void AVROnkyo::selectInputSource(int source, int zone)
 {
-    string s = inputToString(source);
+    std::string s = inputToString(source);
     if (s == "") return;
 
-    string cmd;
+    std::string cmd;
     if (zone == 1) cmd = "SLI" + s;
     else if (zone == 2) cmd = "SLZ" + s;
     else if (zone == 3) cmd = "SL3" + s;
     else return;
 
     sendCustomCommand(cmd);
+}
+
 }

--- a/src/bin/calaos_server/Audio/AVROnkyo.h
+++ b/src/bin/calaos_server/Audio/AVROnkyo.h
@@ -33,13 +33,13 @@ class AVROnkyo: public AVReceiver
 protected:
 
     //buffer to store received data
-    vector<char> brecv_buffer;
+    std::vector<char> brecv_buffer;
 
-    int inputFromString(string source);
-    string inputToString(int source);
+    int inputFromString(std::string source);
+    std::string inputToString(int source);
 
-    virtual void processMessage(vector<char> msg);
-    virtual void processMessage(string msg);
+    virtual void processMessage(std::vector<char> msg);
+    virtual void processMessage(std::string msg);
     virtual void connectionEstablished();
 
 public:
@@ -51,7 +51,7 @@ public:
     virtual void selectInputSource(int source, int zone = 1);
     virtual bool hasDisplay() { return false; }
 
-    virtual void sendCustomCommand(string command);
+    virtual void sendCustomCommand(std::string command);
 };
 
 }

--- a/src/bin/calaos_server/Audio/AVRPioneer.cpp
+++ b/src/bin/calaos_server/Audio/AVRPioneer.cpp
@@ -21,7 +21,7 @@
 #include "AVRPioneer.h"
 #include "AVRManager.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 AVRPioneer::AVRPioneer(Params &p):
     AVReceiver(p, 23)
@@ -72,7 +72,7 @@ void AVRPioneer::connectionEstablished()
     sendRequest("?FL"); //get display text
 }
 
-void AVRPioneer::processMessage(string msg)
+void AVRPioneer::processMessage(std::string msg)
 {
     cDebugDom("output") << "Recv: " << msg;
 
@@ -251,7 +251,7 @@ void AVRPioneer::setVolume(int volume, int zone)
     if (zone == 1)
     {
         int v = volume * 185 / 100;
-        stringstream ss;
+        std::stringstream ss;
         ss.width(3);
         ss.fill('0');
         ss << v << "VL";
@@ -260,7 +260,7 @@ void AVRPioneer::setVolume(int volume, int zone)
     else if (zone == 2)
     {
         int v = volume * 81 / 100;
-        stringstream ss;
+        std::stringstream ss;
         ss.width(2);
         ss.fill('0');
         ss << v << "ZV";
@@ -269,7 +269,7 @@ void AVRPioneer::setVolume(int volume, int zone)
     else if (zone == 3)
     {
         int v = volume * 81 / 100;
-        stringstream ss;
+        std::stringstream ss;
         ss.width(2);
         ss.fill('0');
         ss << v << "YV";
@@ -277,10 +277,10 @@ void AVRPioneer::setVolume(int volume, int zone)
     }
 }
 
-void AVRPioneer::decodeDisplayText(string &text)
+void AVRPioneer::decodeDisplayText(std::string &text)
 {
     display_text.clear();
-    string tmp;
+    std::string tmp;
 
     for (uint i = 0;i < text.length();i++)
     {
@@ -288,7 +288,7 @@ void AVRPioneer::decodeDisplayText(string &text)
         if (tmp.length() < 2) continue;
 
         int c;
-        istringstream iss(tmp);
+        std::istringstream iss(tmp);
         iss >> std::hex >> c;
         display_text += (char)c;
         tmp.clear();
@@ -367,4 +367,6 @@ void AVRPioneer::selectInputSource(int source, int zone)
         default: break;
         }
     }
+}
+
 }

--- a/src/bin/calaos_server/Audio/AVRPioneer.h
+++ b/src/bin/calaos_server/Audio/AVRPioneer.h
@@ -32,9 +32,9 @@ class AVRPioneer: public AVReceiver
 {
 protected:
 
-    void decodeDisplayText(string &text);
+    void decodeDisplayText(std::string &text);
 
-    virtual void processMessage(string msg);
+    virtual void processMessage(std::string msg);
     virtual void connectionEstablished();
 
 public:

--- a/src/bin/calaos_server/Audio/AVRYamaha.cpp
+++ b/src/bin/calaos_server/Audio/AVRYamaha.cpp
@@ -21,7 +21,7 @@
 #include "AVRYamaha.h"
 #include <cmath>
 
-using namespace Calaos;
+namespace Calaos {
 
 AVRYamaha::AVRYamaha(Params &p):
     AVReceiver(p, 50000)
@@ -82,7 +82,7 @@ void AVRYamaha::connectionEstablished()
     sendRequest("@ZONE3:VOL=?");
 }
 
-void AVRYamaha::processMessage(string msg)
+void AVRYamaha::processMessage(std::string msg)
 {
     cDebugDom("output") << "Recv: " << msg;
 
@@ -218,7 +218,7 @@ void AVRYamaha::Power(bool on, int zone)
         sendRequest("@ZONE3:PWR=Standby");
 }
 
-int AVRYamaha::inputFromString(string source)
+int AVRYamaha::inputFromString(std::string source)
 {
     if (source == "TUNER") return AVReceiver::AVR_INPUT_TUNER;
     if (source == "PHONO") return AVReceiver::AVR_INPUT_PHONO;
@@ -250,7 +250,7 @@ int AVRYamaha::inputFromString(string source)
     return AVReceiver::AVR_UNKNOWN;
 }
 
-string AVRYamaha::inputToString(int source)
+std::string AVRYamaha::inputToString(int source)
 {
     switch (source)
     {
@@ -294,7 +294,7 @@ void AVRYamaha::setVolume(int volume, int zone)
     v -= 80.5;
     v = std::floor(v / 0.5) * 0.5;
 
-    stringstream ss;
+    std::stringstream ss;
     ss.width(2);
     ss.fill('0');
     ss.setf(std::ios::showpoint);
@@ -310,10 +310,10 @@ void AVRYamaha::setVolume(int volume, int zone)
 
 void AVRYamaha::selectInputSource(int source, int zone)
 {
-    string s = inputToString(source);
+    std::string s = inputToString(source);
     if (s == "") return;
 
-    string cmd;
+    std::string cmd;
     if (zone == 1) cmd = "@MAIN:INP=" + s;
     else if (zone == 2) cmd = "@ZONE2:INP=" + s;
     else if (zone == 3) cmd = "@ZONE3:INP=" + s;
@@ -322,3 +322,4 @@ void AVRYamaha::selectInputSource(int source, int zone)
     sendRequest(cmd);
 }
 
+}

--- a/src/bin/calaos_server/Audio/AVRYamaha.h
+++ b/src/bin/calaos_server/Audio/AVRYamaha.h
@@ -32,10 +32,10 @@ class AVRYamaha: public AVReceiver
 {
 protected:
 
-    int inputFromString(string source);
-    string inputToString(int source);
+    int inputFromString(std::string source);
+    std::string inputToString(int source);
 
-    virtual void processMessage(string msg);
+    virtual void processMessage(std::string msg);
     virtual void connectionEstablished();
 
 public:

--- a/src/bin/calaos_server/Audio/AVReceiver.cpp
+++ b/src/bin/calaos_server/Audio/AVReceiver.cpp
@@ -23,7 +23,7 @@
 #include "IOFactory.h"
 #include "EventManager.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO_USERTYPE(AVReceiver, IOAVReceiver)
 
@@ -163,13 +163,13 @@ void AVReceiver::dataGet(Ecore_Con_Server *srv, void *data, int size)
 
     if (connection_type == AVR_CON_CHAR)
     {
-        string msg((char *)data, size);
+        std::string msg((char *)data, size);
         dataGet(msg);
     }
     else if (connection_type == AVR_CON_BYTES)
     {
         char *cdata = (char *)data;
-        vector<char> d(cdata, cdata + size);
+        std::vector<char> d(cdata, cdata + size);
 
         //We don't know how to handle these messages,
         //so we delegate the processing to the child class
@@ -178,10 +178,10 @@ void AVReceiver::dataGet(Ecore_Con_Server *srv, void *data, int size)
     }
 }
 
-void AVReceiver::dataGet(string msg)
+void AVReceiver::dataGet(std::string msg)
 {
-    if (msg.find('\n') == string::npos &&
-        msg.find('\r') == string::npos)
+    if (msg.find('\n') == std::string::npos &&
+        msg.find('\r') == std::string::npos)
     {
         //We have not a complete paquet yet, buffurize it.
         recv_buffer += msg;
@@ -202,8 +202,8 @@ void AVReceiver::dataGet(string msg)
     replace_str(msg, "\r\n", "\n");
     replace_str(msg, "\r", "\n");
 
-    vector<string> tokens;
-    split(msg, tokens, "\n");
+    std::vector<std::string> tokens;
+    Utils::split(msg, tokens, "\n");
 
     cDebugDom("output") << "Got " << tokens.size() << " messages.";
 
@@ -211,17 +211,17 @@ void AVReceiver::dataGet(string msg)
         processMessage(tokens[i]);
 }
 
-void AVReceiver::processMessage(string msg)
+void AVReceiver::processMessage(std::string msg)
 {
     cWarningDom("output") << "Should be inherited !";
 }
 
-void AVReceiver::processMessage(vector<char> msg)
+void AVReceiver::processMessage(std::vector<char> msg)
 {
     cWarningDom("output") << "Should be inherited !";
 }
 
-void AVReceiver::sendRequest(string request)
+void AVReceiver::sendRequest(std::string request)
 {
     if (!econ || !isConnected) return;
 
@@ -232,7 +232,7 @@ void AVReceiver::sendRequest(string request)
     ecore_con_server_send(econ, request.c_str(), request.length());
 }
 
-void AVReceiver::sendRequest(vector<char> request)
+void AVReceiver::sendRequest(std::vector<char> request)
 {
     if (!econ || !isConnected) return;
 
@@ -299,7 +299,7 @@ IOAVReceiver::~IOAVReceiver()
     AVRManager::Instance().Delete(receiver);
 }
 
-void IOAVReceiver::statusChanged(string _param, string value)
+void IOAVReceiver::statusChanged(std::string _param, std::string value)
 {
     EmitSignalIO();
 
@@ -308,16 +308,16 @@ void IOAVReceiver::statusChanged(string _param, string value)
                            { _param, value } });
 }
 
-string IOAVReceiver::get_value_string()
+std::string IOAVReceiver::get_value_string()
 {
     if (!receiver) return "";
 
     return Utils::to_string(receiver->getInputSource(zone));
 }
 
-map<string, string> IOAVReceiver::get_all_values_string()
+std::map<std::string, std::string> IOAVReceiver::get_all_values_string()
 {
-    map<string, string> m;
+    std::map<std::string, std::string> m;
 
     if (!receiver)
         return m;
@@ -341,7 +341,7 @@ map<string, string> IOAVReceiver::get_all_values_string()
     return m;
 }
 
-bool IOAVReceiver::set_value(string val)
+bool IOAVReceiver::set_value(std::string val)
 {
     if (!isEnabled() || !receiver) return false;
 
@@ -381,7 +381,7 @@ bool IOAVReceiver::SaveToXml(TiXmlElement *node)
 
     for (int i = 0;i < get_params().size();i++)
     {
-        string key, value;
+        std::string key, value;
         get_params().get_item(i, key, value);
         cnode->SetAttribute(key, value);
     }
@@ -389,9 +389,9 @@ bool IOAVReceiver::SaveToXml(TiXmlElement *node)
     return true;
 }
 
-map<string, string> IOAVReceiver::query_param(string key)
+std::map<std::string, std::string> IOAVReceiver::query_param(std::string key)
 {
-    map<string, string> m;
+    std::map<std::string, std::string> m;
 
     if (!receiver) return m;
 
@@ -404,4 +404,6 @@ map<string, string> IOAVReceiver::query_param(string key)
     }
 
     return m;
+}
+
 }

--- a/src/bin/calaos_server/Audio/AVReceiver.h
+++ b/src/bin/calaos_server/Audio/AVReceiver.h
@@ -30,7 +30,7 @@
 namespace Calaos
 {
 
-typedef map<int ,string> AVRList;
+typedef std::map<int ,std::string> AVRList;
 
 class AVReceiver
 {
@@ -46,16 +46,16 @@ protected:
     EcoreTimer *timer_con;
 
     bool isConnected;
-    string recv_buffer;
-    string host;
+    std::string recv_buffer;
+    std::string host;
     int port;
 
     int volume_main, volume_zone2, volume_zone3;
     bool power_main, power_zone2, power_zone3;
-    string display_text;
+    std::string display_text;
     int source_main, source_zone2, source_zone3;
 
-    string command_suffix;
+    std::string command_suffix;
 
     Ecore_Event_Handler *ehandler_add;
     Ecore_Event_Handler *ehandler_del;
@@ -65,15 +65,15 @@ protected:
     int connection_type;
 
     void timerConnReconnect();
-    virtual void processMessage(string msg);
-    virtual void processMessage(vector<char> msg);
+    virtual void processMessage(std::string msg);
+    virtual void processMessage(std::vector<char> msg);
 
-    void sendRequest(string request);
-    void sendRequest(vector<char> request);
+    void sendRequest(std::string request);
+    void sendRequest(std::vector<char> request);
 
     virtual void connectionEstablished() {}
 
-    void dataGet(string data);
+    void dataGet(std::string data);
 
 public:
     AVReceiver(Params &p, int default_port, int connection_type = AVR_CON_CHAR);
@@ -118,13 +118,13 @@ public:
 
     //return true if AVR can send his display status text
     virtual bool hasDisplay() { return false; }
-    virtual string getDisplayText() { return display_text; }
+    virtual std::string getDisplayText() { return display_text; }
 
-    virtual void sendCustomCommand(string command) { sendRequest(command); }
+    virtual void sendCustomCommand(std::string command) { sendRequest(command); }
 
-    sigc::signal<void, string, string> state_changed_1; //zone 1
-    sigc::signal<void, string, string> state_changed_2; //zone 2
-    sigc::signal<void, string, string> state_changed_3; //zone 3
+    sigc::signal<void, std::string, std::string> state_changed_1; //zone 1
+    sigc::signal<void, std::string, std::string> state_changed_2; //zone 2
+    sigc::signal<void, std::string, std::string> state_changed_3; //zone 3
 
     /* This is private for C callbacks */
     void addConnection(Ecore_Con_Server *srv);
@@ -139,7 +139,7 @@ private:
     AVReceiver *receiver;
     int zone;
 
-    void statusChanged(string param, string value);
+    void statusChanged(std::string param, std::string value);
 
 public:
     IOAVReceiver(Params &p);
@@ -148,14 +148,14 @@ public:
     /* Input/Output functions */
     virtual DATA_TYPE get_type() { return TSTRING; }
 
-    virtual map<string, string> query_param(string key);
+    virtual std::map<std::string, std::string> query_param(std::string key);
 
     //Input
-    virtual string get_value_string();
-    virtual map<string, string> get_all_values_string();
+    virtual std::string get_value_string();
+    virtual std::map<std::string, std::string> get_all_values_string();
 
     //Output
-    virtual bool set_value(string val);
+    virtual bool set_value(std::string val);
 
     virtual bool SaveToXml(TiXmlElement *node);
 };

--- a/src/bin/calaos_server/Audio/AudioDB.cpp
+++ b/src/bin/calaos_server/Audio/AudioDB.cpp
@@ -20,8 +20,7 @@
  ******************************************************************************/
 #include "AudioDB.h"
 
-using namespace std;
-using namespace Calaos;
+namespace Calaos {
 
 AudioDB::AudioDB(Params &p):
     param(p)
@@ -30,4 +29,6 @@ AudioDB::AudioDB(Params &p):
 
 AudioDB::~AudioDB()
 {
+}
+
 }

--- a/src/bin/calaos_server/Audio/AudioDB.h
+++ b/src/bin/calaos_server/Audio/AudioDB.h
@@ -40,37 +40,37 @@ public:
 
     //Album
     virtual void getAlbums(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData()) {}
-    virtual void getAlbumsTitles(AudioRequest_cb callback, int from, int nb, string album_id, AudioPlayerData user_data = AudioPlayerData()) {}
+    virtual void getAlbumsTitles(AudioRequest_cb callback, int from, int nb, std::string album_id, AudioPlayerData user_data = AudioPlayerData()) {}
 
     //Artist
     virtual void getArtists(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData()) {}
-    virtual void getArtistsAlbums(AudioRequest_cb callback, int from, int nb, string artist_id, AudioPlayerData user_data = AudioPlayerData()) {}
+    virtual void getArtistsAlbums(AudioRequest_cb callback, int from, int nb, std::string artist_id, AudioPlayerData user_data = AudioPlayerData()) {}
 
     //Genre
     virtual void getGenres(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData()) {}
-    virtual void getGenresArtists(AudioRequest_cb callback, int from, int nb, string genre_id, AudioPlayerData user_data = AudioPlayerData()) {}
+    virtual void getGenresArtists(AudioRequest_cb callback, int from, int nb, std::string genre_id, AudioPlayerData user_data = AudioPlayerData()) {}
 
     //Year
     virtual void getYears(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData()) {}
-    virtual void getYearsAlbums(AudioRequest_cb callback, int from, int nb, string year, AudioPlayerData user_data = AudioPlayerData()) {}
+    virtual void getYearsAlbums(AudioRequest_cb callback, int from, int nb, std::string year, AudioPlayerData user_data = AudioPlayerData()) {}
 
     //Playlists
     virtual void getPlaylists(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData()) {}
-    virtual void getPlaylistsTracks(AudioRequest_cb callback, int from, int nb, string playlist_id, AudioPlayerData user_data = AudioPlayerData()) {}
+    virtual void getPlaylistsTracks(AudioRequest_cb callback, int from, int nb, std::string playlist_id, AudioPlayerData user_data = AudioPlayerData()) {}
 
     //Radios
     virtual void getRadios(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData()) {}
-    virtual void getRadiosItems(AudioRequest_cb callback, int from, int nb, string radio, string item_id = "", string search = "", AudioPlayerData user_data = AudioPlayerData()) {}
+    virtual void getRadiosItems(AudioRequest_cb callback, int from, int nb, std::string radio, std::string item_id = "", std::string search = "", AudioPlayerData user_data = AudioPlayerData()) {}
 
     //Random
     virtual void getRandoms(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData()) {}
-    virtual void setRandomsType(string type) {}
+    virtual void setRandomsType(std::string type) {}
     //TODO:Random genre selection with  "<playerid>  randomplaygenrelist"
 
-    virtual void getSearch(AudioRequest_cb callback, int from, int nb, string search, AudioPlayerData user_data = AudioPlayerData()) {}
+    virtual void getSearch(AudioRequest_cb callback, int from, int nb, std::string search, AudioPlayerData user_data = AudioPlayerData()) {}
 
-    virtual void getMusicFolder(AudioRequest_cb callback, int from, int nb, string folder_id = "", AudioPlayerData user_data = AudioPlayerData()) {}
-    virtual void getTrackInfos(AudioRequest_cb callback, string track_id, AudioPlayerData user_data = AudioPlayerData()) {}
+    virtual void getMusicFolder(AudioRequest_cb callback, int from, int nb, std::string folder_id = "", AudioPlayerData user_data = AudioPlayerData()) {}
+    virtual void getTrackInfos(AudioRequest_cb callback, std::string track_id, AudioPlayerData user_data = AudioPlayerData()) {}
 
     //TODO:Favorites
 };

--- a/src/bin/calaos_server/Audio/AudioPlayer.cpp
+++ b/src/bin/calaos_server/Audio/AudioPlayer.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include <AudioPlayer.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 AudioPlayer::AudioPlayer(Params &p):
     IOBase(p, IOBase::IO_INOUT),
@@ -60,7 +60,7 @@ bool AudioPlayer::SaveToXml(TiXmlElement *node)
 
     for (int i = 0;i < get_params().size();i++)
     {
-        string key, value;
+        std::string key, value;
         param.get_item(i, key, value);
         cnode->SetAttribute(key, value);
     }
@@ -72,7 +72,7 @@ void AudioPlayer::hasChanged()
 {
     if (!isEnabled()) return;
 
-    string answer;
+    std::string answer;
 
     switch (astatus)
     {
@@ -103,7 +103,7 @@ bool AudioPlayer::set_value(std::string value)
 {
     if (!isEnabled()) return true;
 
-    string val = value;
+    std::string val = value;
 
     cInfoDom("output") << "AudioPlayer(" << get_param("id") << "): got action \"" << val << "\"";
 
@@ -185,4 +185,6 @@ void AudioPlayer::get_volume_cb(AudioPlayerData data)
     from_string(data.svalue, vol);
 
     set_volume(data.ivalue + vol);
+}
+
 }

--- a/src/bin/calaos_server/Audio/AudioPlayer.h
+++ b/src/bin/calaos_server/Audio/AudioPlayer.h
@@ -50,7 +50,7 @@ public:
     virtual void Previous() { }
     virtual void Power(bool on) { }
     virtual void Sleep(int seconds) { }
-    virtual void Synchronize(string playerid, bool sync) { }
+    virtual void Synchronize(std::string playerid, bool sync) { }
     virtual void getSynchronizeList(AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData()) { } //get all players wich we can sync with
 
     virtual void get_volume(AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData()) { }
@@ -79,23 +79,23 @@ public:
     virtual void playlist_movedown(int item) { }
     virtual void playlist_delete(int item) { }
     virtual void playlist_play(int item) { }
-    virtual void playlist_play_artist(string item) { }
-    virtual void playlist_play_album(string item) { }
-    virtual void playlist_play_title(string item) { }
-    virtual void playlist_add_artist(string item) { }
-    virtual void playlist_add_album(string item) { }
-    virtual void playlist_add_title(string item) { }
-    virtual void playlist_add_items(string item) { }
-    virtual void playlist_play_items(string item) { }
+    virtual void playlist_play_artist(std::string item) { }
+    virtual void playlist_play_album(std::string item) { }
+    virtual void playlist_play_title(std::string item) { }
+    virtual void playlist_add_artist(std::string item) { }
+    virtual void playlist_add_album(std::string item) { }
+    virtual void playlist_add_title(std::string item) { }
+    virtual void playlist_add_items(std::string item) { }
+    virtual void playlist_play_items(std::string item) { }
     virtual void playlist_clear() { }
-    virtual void playlist_save(string name) { }
-    virtual void playlist_delete(string id) { }
+    virtual void playlist_save(std::string name) { }
+    virtual void playlist_delete(std::string id) { }
     virtual void get_playlist_current(AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData()) { }
     virtual void get_playlist_size(AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData()) { }
     virtual void get_playlist_item(int index, AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData()) { }
     virtual void get_playlist_basic_info(int index, AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData()) { }
     virtual void get_playlist_album_cover(int i, AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData()) { }
-    virtual void get_album_cover_id(string track_id, AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData()) { }
+    virtual void get_album_cover_id(std::string track_id, AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData()) { }
 
     virtual bool canPlaylist() { return false; }
     virtual bool canDatabase() { return false; }

--- a/src/bin/calaos_server/Audio/AudioPlayerData.h
+++ b/src/bin/calaos_server/Audio/AudioPlayerData.h
@@ -82,9 +82,9 @@ public:
     }
 
     Params params;
-    vector<Params> vparams;
+    std::vector<Params> vparams;
     int ivalue = 0, ivalue2 = 0;
-    string svalue;
+    std::string svalue;
     double dvalue = 0.0;
 
     void set_chain_data(AudioPlayerData *data)

--- a/src/bin/calaos_server/Audio/Squeezebox.cpp
+++ b/src/bin/calaos_server/Audio/Squeezebox.cpp
@@ -30,7 +30,7 @@
 #define SQ_TIMEOUT      40.0
 #define SQ_RECONNECT    3.0
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO_USERTYPE(slim, Squeezebox)
 REGISTER_IO(Squeezebox)
@@ -221,7 +221,7 @@ void Squeezebox::addConnection(Ecore_Con_Server *srv)
 
         //we need to subscribe to these commands to watch for status changes
         //string cmd = "subscribe playlist,mixer,pause,stop\n\r";
-        string cmd = "listen 1\n\r";
+        std::string cmd = "listen 1\n\r";
 
         cDebugDom("squeezebox") <<  "trying to subscribe to events";
 
@@ -287,12 +287,12 @@ void Squeezebox::delConnection(Ecore_Con_Server *srv)
 
 void Squeezebox::dataGet(Ecore_Con_Server *srv, void *data, int size)
 {
-    string msg((char *)data, size);
+    std::string msg((char *)data, size);
 
     if (srv == enotif)
     {
-        if (msg.find('\n') == string::npos &&
-            msg.find('\r') == string::npos)
+        if (msg.find('\n') == std::string::npos &&
+            msg.find('\r') == std::string::npos)
         {
             //We have not a complete paquet yet, buffurize it.
             buffer_notif += msg;
@@ -315,7 +315,7 @@ void Squeezebox::dataGet(Ecore_Con_Server *srv, void *data, int size)
         replace_str(msg, "\r\n", "\n");
         replace_str(msg, "\r", "\n");
 
-        vector<string> tokens;
+        std::vector<std::string> tokens;
         split(msg, tokens, "\n");
 
         isConnected = true;
@@ -326,8 +326,8 @@ void Squeezebox::dataGet(Ecore_Con_Server *srv, void *data, int size)
     }
     else if (srv == econ)
     {
-        if (msg.find('\n') == string::npos &&
-            msg.find('\r') == string::npos)
+        if (msg.find('\n') == std::string::npos &&
+            msg.find('\r') == std::string::npos)
         {
             //We have not a complete paquet yet, buffurize it.
             buffer_main += msg;
@@ -350,7 +350,7 @@ void Squeezebox::dataGet(Ecore_Con_Server *srv, void *data, int size)
         replace_str(msg, "\r\n", "\n");
         replace_str(msg, "\r", "\n");
 
-        vector<string> tokens;
+        std::vector<std::string> tokens;
         split(msg, tokens, "\n");
 
         cDebugDom("squeezebox") <<  "Got " << tokens.size() << " messages.";
@@ -364,7 +364,7 @@ void Squeezebox::dataGet(Ecore_Con_Server *srv, void *data, int size)
     }
 }
 
-void Squeezebox::processNotificationMessage(string msg)
+void Squeezebox::processNotificationMessage(std::string msg)
 {
     cDebugDom("squeezebox") << "Message: \"" << msg << "\"";
 
@@ -438,7 +438,7 @@ void Squeezebox::processNotificationMessage(string msg)
             else
                 set_status(AudioPause);
 
-            string state;
+            std::string state;
             if (p["3"] == "" || p["3"] == "0")
                 state = "play";
             else
@@ -471,7 +471,7 @@ void Squeezebox::processNotificationMessage(string msg)
     }
 }
 
-void Squeezebox::processMessage(bool status, string msg)
+void Squeezebox::processMessage(bool status, std::string msg)
 {
     if (status)
     {
@@ -516,7 +516,7 @@ void Squeezebox::processMessage(bool status, string msg)
     _sendRequest();
 }
 
-void Squeezebox::sendRequest(string command, SqueezeRequest_cb callback, AudioPlayerData user_data)
+void Squeezebox::sendRequest(std::string command, SqueezeRequest_cb callback, AudioPlayerData user_data)
 {
     SqueezeboxCommand cmd;
     cmd.request = command;
@@ -528,7 +528,7 @@ void Squeezebox::sendRequest(string command, SqueezeRequest_cb callback, AudioPl
     _sendRequest();
 }
 
-void Squeezebox::sendRequest(string command)
+void Squeezebox::sendRequest(std::string command)
 {
     SqueezeboxCommand cmd;
     cmd.request = command;
@@ -590,7 +590,7 @@ void Squeezebox::requestTimeout_cb()
 
 void Squeezebox::Play()
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " play";
 
     sendRequest(cmd);
@@ -598,7 +598,7 @@ void Squeezebox::Play()
 
 void Squeezebox::Pause()
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " pause";
 
     sendRequest(cmd);
@@ -606,7 +606,7 @@ void Squeezebox::Pause()
 
 void Squeezebox::Stop()
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " stop";
 
     sendRequest(cmd);
@@ -614,7 +614,7 @@ void Squeezebox::Stop()
 
 void Squeezebox::Next()
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlist index +1";
 
     sendRequest(cmd);
@@ -622,7 +622,7 @@ void Squeezebox::Next()
 
 void Squeezebox::Previous()
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlist index -1";
 
     sendRequest(cmd);
@@ -630,7 +630,7 @@ void Squeezebox::Previous()
 
 void Squeezebox::Power(bool on)
 {
-    string cmd = id;
+    std::string cmd = id;
 
     if (on)
         cmd += " power 1";
@@ -642,15 +642,15 @@ void Squeezebox::Power(bool on)
 
 void Squeezebox::Sleep(int seconds)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " sleep " + Utils::to_string(seconds);
 
     sendRequest(cmd);
 }
 
-void Squeezebox::Synchronize(string playerid, bool sync)
+void Squeezebox::Synchronize(std::string playerid, bool sync)
 {
-    string cmd = id;
+    std::string cmd = id;
     if (sync)
         cmd += " sync " + playerid;
     else
@@ -661,7 +661,7 @@ void Squeezebox::Synchronize(string playerid, bool sync)
 
 void Squeezebox::get_songinfo(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " path ?";
 
     AudioPlayerData data;
@@ -671,20 +671,20 @@ void Squeezebox::get_songinfo(AudioRequest_cb callback, AudioPlayerData user_dat
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_songinfo_cb), data);
 }
 
-void Squeezebox::get_songinfo_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_songinfo_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
 
-    string path = p["2"];
+    std::string path = p["2"];
 
-    string cmd = "songinfo 0 100 tags:algjdro url:";
+    std::string cmd = "songinfo 0 100 tags:algjdro url:";
     cmd += path;
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_songinfo_cb2), data);
 }
 
-void Squeezebox::get_songinfo_cb2(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_songinfo_cb2(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -701,8 +701,8 @@ void Squeezebox::get_songinfo_cb2(bool status, string request, string result, Au
 
     for (int i = 5;i < p.size();i++)
     {
-        string value = p[Utils::to_string(i)];
-        vector<string> attr;
+        std::string value = p[Utils::to_string(i)];
+        std::vector<std::string> attr;
         Utils::split(Utils::url_decode2(value), attr, ":", 2);
 
         if (attr.size() == 2)
@@ -745,7 +745,7 @@ void Squeezebox::get_songinfo_duration_cb(AudioPlayerData data)
 
 void Squeezebox::get_title(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " remote ?";
 
     AudioPlayerData data;
@@ -754,9 +754,9 @@ void Squeezebox::get_title(AudioRequest_cb callback, AudioPlayerData user_data)
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_title_cb), data);
 }
-void Squeezebox::get_title_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_title_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
-    string cmd;
+    std::string cmd;
     Params p;
     p.Parse(result);
 
@@ -767,7 +767,7 @@ void Squeezebox::get_title_cb(bool status, string request, string result, AudioP
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_title2_cb), data);
 }
-void Squeezebox::get_title2_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_title2_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -782,7 +782,7 @@ void Squeezebox::get_title2_cb(bool status, string request, string result, Audio
 
 void Squeezebox::get_artist(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " remote ?";
 
     AudioPlayerData data;
@@ -791,9 +791,9 @@ void Squeezebox::get_artist(AudioRequest_cb callback, AudioPlayerData user_data)
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_title_cb), data);
 }
-void Squeezebox::get_artist_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_artist_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
-    string cmd;
+    std::string cmd;
     Params p;
     p.Parse(result);
 
@@ -804,7 +804,7 @@ void Squeezebox::get_artist_cb(bool status, string request, string result, Audio
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_title2_cb), data);
 }
-void Squeezebox::get_artist2_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_artist2_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -819,7 +819,7 @@ void Squeezebox::get_artist2_cb(bool status, string request, string result, Audi
 
 void Squeezebox::get_album(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " album ?";
 
     AudioPlayerData data;
@@ -828,7 +828,7 @@ void Squeezebox::get_album(AudioRequest_cb callback, AudioPlayerData user_data)
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_album_cb), data);
 }
-void Squeezebox::get_album_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_album_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -845,11 +845,11 @@ void Squeezebox::get_album_cover(AudioRequest_cb callback, AudioPlayerData user_
 {
     //Try using a JSON call to get artwork_url if any
 
-    string url = "http://";
+    std::string url = "http://";
     url += param["host"] + ":9000";
     url += "/jsonrpc.js";
 
-    string postData = "{\"id\":1,\"method\":\"slim.request\",\"params\":[\"";
+    std::string postData = "{\"id\":1,\"method\":\"slim.request\",\"params\":[\"";
     postData += id;
     postData += "\",[\"status\",\"-\",1,\"tags:gABbehldiqtyrSuoKLN\"]]}";
 
@@ -862,7 +862,7 @@ void Squeezebox::get_album_cover(AudioRequest_cb callback, AudioPlayerData user_
 
     downloader->Start();
 }
-void Squeezebox::get_album_cover_json_cb(string result, void *data, void *user_data)
+void Squeezebox::get_album_cover_json_cb(std::string result, void *data, void *user_data)
 {
     if (result == "failed" || result == "aborted")
     {
@@ -879,7 +879,7 @@ void Squeezebox::get_album_cover_json_cb(string result, void *data, void *user_d
         delete _data;
 
         Buffer_CURL *buff = reinterpret_cast<Buffer_CURL *>(data);
-        string res((const char *)buff->buffer, buff->bufsize);
+        std::string res((const char *)buff->buffer, buff->bufsize);
 
         json_error_t jerr;
         json_t *json = json_loads(res.c_str(), 0, &jerr);
@@ -910,7 +910,7 @@ void Squeezebox::get_album_cover_json_cb(string result, void *data, void *user_d
                     artwork_url = json_object_get(remoteMeta, "artwork_url");
                     if (json_is_string(artwork_url))
                     {
-                        string aurl;
+                        std::string aurl;
 
                         aurl = json_string_value(artwork_url);
 
@@ -931,7 +931,7 @@ void Squeezebox::get_album_cover_json_cb(string result, void *data, void *user_d
                         }
                         else
                         {
-                            string s = "http://";
+                            std::string s = "http://";
                             s += host + ":9000/";
                             s += aurl;
 
@@ -965,34 +965,34 @@ void Squeezebox::get_album_cover_std(AudioPlayerData data)
 {
     cDebugDom("squeezebox") <<  "trying with standard CLI way...";
 
-    string cmd = id;
+    std::string cmd = id;
     cmd += " path ?";
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_album_cover_std_cb), data);
 }
-void Squeezebox::get_album_cover_std_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_album_cover_std_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
-    string cmd;
+    std::string cmd;
     Params p;
     p.Parse(result);
-    string path = p["2"];
+    std::string path = p["2"];
 
     cmd = "songinfo 0 100 url:";
     cmd += path;
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_album_cover_std2_cb), data);
 }
-void Squeezebox::get_album_cover_std2_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_album_cover_std2_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(result, tokens);
     for_each(tokens.begin(), tokens.end(), UrlDecode());
 
-    string aid = "";
+    std::string aid = "";
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
         split(tmp, tk, ":", 2);
         if (tk.size() != 2) continue;
 
@@ -1000,7 +1000,7 @@ void Squeezebox::get_album_cover_std2_cb(bool status, string request, string res
         if (tk[0] == "id" && aid == "") aid = tk[1];
     }
 
-    stringstream aurl;
+    std::stringstream aurl;
     if (aid == "") aid = "current";
     aurl << "http://" << host << ":" << port_web << "/music/" << aid << "/cover.jpg";
     if (aid == "") aurl << "?playerid=" << id;
@@ -1012,9 +1012,9 @@ void Squeezebox::get_album_cover_std2_cb(bool status, string request, string res
     sig.emit(data.get_chain_data());
 }
 
-void Squeezebox::get_album_cover_id(string track_id, AudioRequest_cb callback, AudioPlayerData user_data)
+void Squeezebox::get_album_cover_id(std::string track_id, AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    stringstream aurl;
+    std::stringstream aurl;
     if (track_id == "") track_id = "0";
     aurl << "http://" << host << ":" << port_web << "/music/" << track_id << "/cover.jpg";
 
@@ -1030,7 +1030,7 @@ void Squeezebox::get_album_cover_id(string track_id, AudioRequest_cb callback, A
 
 void Squeezebox::get_playlist_album_cover(int item, AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlist path " + Utils::to_string(item) + " ?";
 
     AudioPlayerData data;
@@ -1039,29 +1039,29 @@ void Squeezebox::get_playlist_album_cover(int item, AudioRequest_cb callback, Au
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_playlist_album_cover_cb), data);
 }
-void Squeezebox::get_playlist_album_cover_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_playlist_album_cover_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
-    string cmd;
+    std::string cmd;
     Params p;
     p.Parse(result);
-    string path = p["4"];
+    std::string path = p["4"];
 
     cmd = "songinfo 0 100 url:";
     cmd += path;
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_playlist_album_cover2_cb), data);
 }
-void Squeezebox::get_playlist_album_cover2_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_playlist_album_cover2_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(result, tokens);
     for_each(tokens.begin(), tokens.end(), UrlDecode());
 
-    string aid = "";
+    std::string aid = "";
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
         split(tmp, tk, ":", 2);
         if (tk.size() != 2) continue;
 
@@ -1069,7 +1069,7 @@ void Squeezebox::get_playlist_album_cover2_cb(bool status, string request, strin
         if (tk[0] == "id" && aid == "") aid = tk[1];
     }
 
-    stringstream aurl;
+    std::stringstream aurl;
     if (aid == "") aid = "0";
     aurl << "http://" << host << ":" << port_web << "/music/" << aid << "/cover.jpg";
 
@@ -1084,7 +1084,7 @@ void Squeezebox::get_playlist_album_cover2_cb(bool status, string request, strin
 
 void Squeezebox::get_genre(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " genre ?";
 
     AudioPlayerData data;
@@ -1093,7 +1093,7 @@ void Squeezebox::get_genre(AudioRequest_cb callback, AudioPlayerData user_data)
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_genre_cb), data);
 }
-void Squeezebox::get_genre_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_genre_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -1107,7 +1107,7 @@ void Squeezebox::get_genre_cb(bool status, string request, string result, AudioP
 
 void Squeezebox::get_current_time(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " time ?";
 
     AudioPlayerData data;
@@ -1117,7 +1117,7 @@ void Squeezebox::get_current_time(AudioRequest_cb callback, AudioPlayerData user
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_current_time_cb), data);
 }
 
-void Squeezebox::get_current_time_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_current_time_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -1134,7 +1134,7 @@ void Squeezebox::get_current_time_cb(bool status, string request, string result,
 
 void Squeezebox::set_current_time(double seconds)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " time " + Utils::to_string(seconds);
 
     sendRequest(cmd);
@@ -1142,7 +1142,7 @@ void Squeezebox::set_current_time(double seconds)
 
 void Squeezebox::get_duration(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " duration ?";
 
     AudioPlayerData data;
@@ -1153,7 +1153,7 @@ void Squeezebox::get_duration(AudioRequest_cb callback, AudioPlayerData user_dat
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_duration_cb), data);
 }
 
-void Squeezebox::get_duration_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_duration_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -1170,7 +1170,7 @@ void Squeezebox::get_duration_cb(bool status, string request, string result, Aud
 
 void Squeezebox::get_sleep(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " sleep ?";
 
     AudioPlayerData data;
@@ -1180,7 +1180,7 @@ void Squeezebox::get_sleep(AudioRequest_cb callback, AudioPlayerData user_data)
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_sleep_cb), data);
 }
 
-void Squeezebox::get_sleep_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_sleep_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -1197,7 +1197,7 @@ void Squeezebox::get_sleep_cb(bool status, string request, string result, AudioP
 
 void Squeezebox::get_status(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " mode ?";
 
     AudioPlayerData data;
@@ -1207,7 +1207,7 @@ void Squeezebox::get_status(AudioRequest_cb callback, AudioPlayerData user_data)
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_status_cb), data);
 }
 
-void Squeezebox::get_status_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_status_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -1230,7 +1230,7 @@ void Squeezebox::get_status_cb(bool status, string request, string result, Audio
 
 void Squeezebox::get_sync_status(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " sync ?";
 
     AudioPlayerData data;
@@ -1240,23 +1240,23 @@ void Squeezebox::get_sync_status(AudioRequest_cb callback, AudioPlayerData user_
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_sync_status_cb), data);
 }
 
-void Squeezebox::get_sync_status_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_sync_status_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
 
-    vector<Params> &results = data.get_chain_data().vparams;
+    std::vector<Params> &results = data.get_chain_data().vparams;
 
-    vector<string> splitter;
+    std::vector<std::string> splitter;
     Utils::split(url_decode2(p["2"]), splitter, ",");
 
     for (uint j = 0;j < splitter.size();j++)
     {
-        string tmp = splitter[j];
+        std::string tmp = splitter[j];
 
         if (tmp == "-") break;
 
-        list<IOBase *> audiolist = ListeRoom::Instance().getAudioList();
+        std::list<IOBase *> audiolist = ListeRoom::Instance().getAudioList();
         for (IOBase *io: audiolist)
         {
             AudioPlayer *ap = dynamic_cast<AudioPlayer *>(io);
@@ -1282,7 +1282,7 @@ void Squeezebox::get_sync_status_cb(bool status, string request, string result, 
 
 void Squeezebox::get_playlist_size(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlist tracks ?";
 
     AudioPlayerData data;
@@ -1292,7 +1292,7 @@ void Squeezebox::get_playlist_size(AudioRequest_cb callback, AudioPlayerData use
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_playlist_size_cb), data);
 }
 
-void Squeezebox::get_playlist_size_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_playlist_size_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -1309,7 +1309,7 @@ void Squeezebox::get_playlist_size_cb(bool status, string request, string result
 
 void Squeezebox::get_playlist_current(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlist index ?";
 
     AudioPlayerData data;
@@ -1319,7 +1319,7 @@ void Squeezebox::get_playlist_current(AudioRequest_cb callback, AudioPlayerData 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_playlist_current_cb), data);
 }
 
-void Squeezebox::get_playlist_current_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_playlist_current_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -1336,7 +1336,7 @@ void Squeezebox::get_playlist_current_cb(bool status, string request, string res
 
 void Squeezebox::get_playlist_item(int index, AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlist path " + Utils::to_string(index) + " ?";
 
     AudioPlayerData data;
@@ -1348,18 +1348,18 @@ void Squeezebox::get_playlist_item(int index, AudioRequest_cb callback, AudioPla
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_playlist_item_cb), data);
 }
 
-void Squeezebox::get_playlist_item_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_playlist_item_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
 
-    string path = url_decode2(p["4"]);
+    std::string path = url_decode2(p["4"]);
 
-    string cmd = "songinfo 0 100 tags:algjdro url:" + url_encode(path);
+    std::string cmd = "songinfo 0 100 tags:algjdro url:" + url_encode(path);
 
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_playlist_item2_cb), data);
 }
-void Squeezebox::get_playlist_item2_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_playlist_item2_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -1367,7 +1367,7 @@ void Squeezebox::get_playlist_item2_cb(bool status, string request, string resul
     //It's probably a remote stream, get infos with specific commands
     if (p.size() <= 5)
     {
-        string cmd = id;
+        std::string cmd = id;
         cmd += " playlist title " + Utils::to_string(data.ivalue) + " ?";
 
         sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_playlist_item3_cb), data);
@@ -1377,8 +1377,8 @@ void Squeezebox::get_playlist_item2_cb(bool status, string request, string resul
 
     for (int i = 5;i < p.size();i++)
     {
-        string value = p[Utils::to_string(i)];
-        vector<string> attr;
+        std::string value = p[Utils::to_string(i)];
+        std::vector<std::string> attr;
         split(url_decode2(value), attr, ":", 2);
 
         if (attr.size() == 2)
@@ -1389,7 +1389,7 @@ void Squeezebox::get_playlist_item2_cb(bool status, string request, string resul
     sig.connect(data.callback);
     sig.emit(data.get_chain_data());
 }
-void Squeezebox::get_playlist_item3_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_playlist_item3_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -1405,7 +1405,7 @@ void Squeezebox::get_playlist_item4_cb(AudioPlayerData data)
 
     if (index == data.ivalue)
     {
-        string cmd = id;
+        std::string cmd = id;
         cmd += " current_title ?";
 
         sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_playlist_item5_cb), data);
@@ -1417,7 +1417,7 @@ void Squeezebox::get_playlist_item4_cb(AudioPlayerData data)
         sig.emit(data.get_chain_data());
     }
 }
-void Squeezebox::get_playlist_item5_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_playlist_item5_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -1431,7 +1431,7 @@ void Squeezebox::get_playlist_item5_cb(bool status, string request, string resul
 
 void Squeezebox::get_playlist_basic_info(int index, AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlist artist " + Utils::to_string(index) + " ?";
 
     AudioPlayerData data;
@@ -1443,25 +1443,25 @@ void Squeezebox::get_playlist_basic_info(int index, AudioRequest_cb callback, Au
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_playlist_info_cb), data);
 }
 
-void Squeezebox::get_playlist_info_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_playlist_info_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
 
-    string key = url_decode2(p["2"]);
-    string val = url_decode2(p["4"]);
+    std::string key = url_decode2(p["2"]);
+    std::string val = url_decode2(p["4"]);
 
     data.get_chain_data().params.Add(key, val);
 
     if (key == "artist")
     {
-        string cmd = id;
+        std::string cmd = id;
         cmd += " playlist album " + Utils::to_string(data.ivalue) + " ?";
         sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_playlist_info_cb), data);
     }
     else if (key == "album")
     {
-        string cmd = id;
+        std::string cmd = id;
         cmd += " playlist title " + Utils::to_string(data.ivalue) + " ?";
         sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_playlist_info_cb), data);
     }
@@ -1475,7 +1475,7 @@ void Squeezebox::get_playlist_info_cb(bool status, string request, string result
 
 void Squeezebox::playlist_moveup(int item)
 {
-    stringstream cmd;
+    std::stringstream cmd;
     cmd << id << " playlist move " << item << " " << (item - 1);
 
     sendRequest(cmd.str());
@@ -1483,7 +1483,7 @@ void Squeezebox::playlist_moveup(int item)
 
 void Squeezebox::playlist_movedown(int item)
 {
-    stringstream cmd;
+    std::stringstream cmd;
     cmd << id << " playlist move " << item << " " << (item + 1);
 
     sendRequest(cmd.str());
@@ -1491,7 +1491,7 @@ void Squeezebox::playlist_movedown(int item)
 
 void Squeezebox::playlist_delete(int item)
 {
-    stringstream cmd;
+    std::stringstream cmd;
     cmd << id << " playlist delete " << item;
 
     sendRequest(cmd.str());
@@ -1499,7 +1499,7 @@ void Squeezebox::playlist_delete(int item)
 
 void Squeezebox::playlist_play(int item)
 {
-    stringstream cmd;
+    std::stringstream cmd;
     cmd << id << " playlist index " << item;
 
     sendRequest(cmd.str());
@@ -1507,86 +1507,86 @@ void Squeezebox::playlist_play(int item)
 
 void Squeezebox::playlist_clear()
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlist clear";
 
     sendRequest(cmd);
 }
 
-void Squeezebox::playlist_save(string name)
+void Squeezebox::playlist_save(std::string name)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlist save " + Utils::url_encode(name);
 
     sendRequest(cmd);
 }
 
-void Squeezebox::playlist_delete(string pid)
+void Squeezebox::playlist_delete(std::string pid)
 {
-    string cmd = "playlists delete playlist_id:" + pid;
+    std::string cmd = "playlists delete playlist_id:" + pid;
 
     sendRequest(cmd);
 }
 
-void Squeezebox::playlist_play_artist(string item)
+void Squeezebox::playlist_play_artist(std::string item)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlistcontrol cmd:load artist_id:";
     cmd += item;
 
     sendRequest(cmd);
 }
 
-void Squeezebox::playlist_play_album(string item)
+void Squeezebox::playlist_play_album(std::string item)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlistcontrol cmd:load album_id:";
     cmd += item;
 
     sendRequest(cmd);
 }
 
-void Squeezebox::playlist_play_title(string item)
+void Squeezebox::playlist_play_title(std::string item)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlistcontrol cmd:load track_id:";
     cmd += item;
 
     sendRequest(cmd);
 }
 
-void Squeezebox::playlist_add_artist(string item)
+void Squeezebox::playlist_add_artist(std::string item)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlistcontrol cmd:add artist_id:";
     cmd += item;
 
     sendRequest(cmd);
 }
 
-void Squeezebox::playlist_add_album(string item)
+void Squeezebox::playlist_add_album(std::string item)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlistcontrol cmd:add album_id:";
     cmd += item;
 
     sendRequest(cmd);
 }
 
-void Squeezebox::playlist_add_title(string item)
+void Squeezebox::playlist_add_title(std::string item)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " playlistcontrol cmd:add track_id:";
     cmd += item;
 
     sendRequest(cmd);
 }
 
-void Squeezebox::playlist_add_items(string item)
+void Squeezebox::playlist_add_items(std::string item)
 {
-    string cmd;
+    std::string cmd;
 
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     Utils::split(item, tokens, ":", 2);
     if (tokens.size() != 2) return;
 
@@ -1604,7 +1604,7 @@ void Squeezebox::playlist_add_items(string item)
     }
     else if (tokens[0] == "radio_id")
     {
-        vector<string> tok;
+        std::vector<std::string> tok;
         Utils::split(tokens[1], tok, ":", 2);
         if (tok.size() != 2) return;
 
@@ -1623,11 +1623,11 @@ void Squeezebox::playlist_add_items(string item)
     sendRequest(cmd);
 }
 
-void Squeezebox::playlist_play_items(string item)
+void Squeezebox::playlist_play_items(std::string item)
 {
-    string cmd;
+    std::string cmd;
 
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     Utils::split(item, tokens, ":", 2);
     if (tokens.size() != 2) return;
 
@@ -1646,7 +1646,7 @@ void Squeezebox::playlist_play_items(string item)
     }
     else if (tokens[0] == "radio_id")
     {
-        vector<string> tok;
+        std::vector<std::string> tok;
         Utils::split(tokens[1], tok, ":", 2);
         if (tok.size() != 2) return;
 
@@ -1667,7 +1667,7 @@ void Squeezebox::playlist_play_items(string item)
 
 void Squeezebox::get_volume(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " mixer volume ?";
 
     AudioPlayerData data;
@@ -1677,7 +1677,7 @@ void Squeezebox::get_volume(AudioRequest_cb callback, AudioPlayerData user_data)
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_volume_cb), data);
 }
 
-void Squeezebox::get_volume_cb(bool status, string request, string result, AudioPlayerData data)
+void Squeezebox::get_volume_cb(bool status, std::string request, std::string result, AudioPlayerData data)
 {
     Params p;
     p.Parse(result);
@@ -1694,7 +1694,7 @@ void Squeezebox::get_volume_cb(bool status, string request, string result, Audio
 
 void Squeezebox::set_volume(int vol)
 {
-    string cmd = id;
+    std::string cmd = id;
     cmd += " mixer volume ";
     cmd += Utils::to_string(vol);
 
@@ -1703,7 +1703,7 @@ void Squeezebox::set_volume(int vol)
 
 void Squeezebox::getSynchronizeList(AudioRequest_cb callback, AudioPlayerData user_data)
 {
-    string cmd = "players 0 20";
+    std::string cmd = "players 0 20";
 
     AudioPlayerData data;
     data.set_chain_data(new AudioPlayerData(user_data));
@@ -1712,11 +1712,11 @@ void Squeezebox::getSynchronizeList(AudioRequest_cb callback, AudioPlayerData us
     sendRequest(cmd, sigc::mem_fun(*this, &Squeezebox::get_sync_list_cb), data);
 }
 
-void Squeezebox::get_sync_list_cb(bool status, string request, string res, AudioPlayerData data)
+void Squeezebox::get_sync_list_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<Params> &result = data.get_chain_data().vparams;
 
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     if (tokens.size() > 0)
@@ -1726,8 +1726,8 @@ void Squeezebox::get_sync_list_cb(bool status, string request, string res, Audio
         Params item;
         for (uint i = 0;i < tokens.size();i++)
         {
-            string tmp = tokens[i];
-            vector<string> tk;
+            std::string tmp = tokens[i];
+            std::vector<std::string> tk;
 
             split(tmp, tk, ":", 2);
 
@@ -1735,9 +1735,9 @@ void Squeezebox::get_sync_list_cb(bool status, string request, string res, Audio
 
             if (tk[0] == "playerid")
             {
-                string pid = url_decode2(tk[1]);
+                std::string pid = url_decode2(tk[1]);
 
-                list<IOBase *> audiolist = ListeRoom::Instance().getAudioList();
+                std::list<IOBase *> audiolist = ListeRoom::Instance().getAudioList();
                 for (IOBase *io: audiolist)
                 {
                     AudioPlayer *ap = dynamic_cast<AudioPlayer *>(io);
@@ -1759,4 +1759,6 @@ void Squeezebox::get_sync_list_cb(bool status, string request, string res, Audio
     AudioRequest_signal sig;
     sig.connect(data.callback);
     sig.emit(data.get_chain_data());
+}
+
 }

--- a/src/bin/calaos_server/Audio/Squeezebox.h
+++ b/src/bin/calaos_server/Audio/Squeezebox.h
@@ -30,8 +30,8 @@
 namespace Calaos
 {
 
-typedef sigc::slot<void, bool, string, string, AudioPlayerData> SqueezeRequest_cb;
-typedef sigc::signal<void, bool, string, string, AudioPlayerData> SqueezeRequest_signal;
+typedef sigc::slot<void, bool, std::string, std::string, AudioPlayerData> SqueezeRequest_cb;
+typedef sigc::signal<void, bool, std::string, std::string, AudioPlayerData> SqueezeRequest_signal;
 
 class SqueezeboxCommand
 {
@@ -43,8 +43,8 @@ public:
 
     bool status;
 
-    string request;
-    string result;
+    std::string request;
+    std::string result;
 
     bool inProgress;
     bool noCallback;
@@ -72,72 +72,72 @@ protected:
     EcoreTimer *timer_con;
 
     EcoreTimer *timer_timeout;
-    queue<SqueezeboxCommand> squeeze_commands;
+    std::queue<SqueezeboxCommand> squeeze_commands;
 
-    string host, id;
+    std::string host, id;
     int port_cli, port_web;
 
     bool isConnected;
 
-    string buffer_notif, buffer_main;
+    std::string buffer_notif, buffer_main;
 
     void timerNotificationReconnect();
     void timerConnReconnect();
 
-    void processNotificationMessage(string msg);
+    void processNotificationMessage(std::string msg);
 
     void _sendRequest();
     void requestTimeout_cb();
 
-    void sendRequest(string request);
-    void sendRequest(string request, SqueezeRequest_cb callback, AudioPlayerData user_data);
+    void sendRequest(std::string request);
+    void sendRequest(std::string request, SqueezeRequest_cb callback, AudioPlayerData user_data);
 
-    void get_songinfo_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_songinfo_cb2(bool status, string request, string result, AudioPlayerData data);
+    void get_songinfo_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_songinfo_cb2(bool status, std::string request, std::string result, AudioPlayerData data);
     void get_songinfo_artist_cb(AudioPlayerData data);
     void get_songinfo_album_cb(AudioPlayerData data);
     void get_songinfo_title_cb(AudioPlayerData data);
     void get_songinfo_duration_cb(AudioPlayerData data);
     void get_songinfo_cover_cb(AudioPlayerData data);
 
-    void get_title_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_title2_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_title_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_title2_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void get_artist_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_artist2_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_artist_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_artist2_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void get_album_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_album_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void get_album_cover_json_cb(string result, void *data, void *user_data);
+    void get_album_cover_json_cb(std::string result, void *data, void *user_data);
     void get_album_cover_std(AudioPlayerData data);
-    void get_album_cover_std_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_album_cover_std2_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_album_cover_std_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_album_cover_std2_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void get_genre_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_current_time_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_duration_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_genre_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_current_time_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_duration_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void get_sleep_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_status_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_sync_status_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_sleep_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_status_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_sync_status_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void get_playlist_current_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_playlist_size_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_playlist_current_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_playlist_size_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void get_playlist_item_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_playlist_item2_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_playlist_item3_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_playlist_item_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_playlist_item2_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_playlist_item3_cb(bool status, std::string request, std::string result, AudioPlayerData data);
     void get_playlist_item4_cb(AudioPlayerData data);
-    void get_playlist_item5_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_playlist_item5_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void get_playlist_info_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_playlist_info_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void get_playlist_album_cover_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_playlist_album_cover2_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_playlist_album_cover_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_playlist_album_cover2_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void get_album_cover_id_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_volume_cb(bool status, string request, string result, AudioPlayerData data);
-    void get_sync_list_cb(bool status, string request, string result, AudioPlayerData data);
+    void get_album_cover_id_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_volume_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void get_sync_list_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
 public:
     Squeezebox(Params &p);
@@ -150,7 +150,7 @@ public:
     virtual void Previous();
     virtual void Power(bool on);
     virtual void Sleep(int seconds);
-    virtual void Synchronize(string playerid, bool sync);
+    virtual void Synchronize(std::string playerid, bool sync);
     virtual void getSynchronizeList(AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData()); //get all players wich we can sync with
 
     virtual void get_volume(AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData());
@@ -185,23 +185,23 @@ public:
     virtual void playlist_movedown(int item);
     virtual void playlist_delete(int item);
     virtual void playlist_play(int item);
-    virtual void playlist_play_artist(string item);
-    virtual void playlist_play_album(string item);
-    virtual void playlist_play_title(string item);
-    virtual void playlist_add_artist(string item);
-    virtual void playlist_add_album(string item);
-    virtual void playlist_add_title(string item);
-    virtual void playlist_add_items(string item);
-    virtual void playlist_play_items(string item);
+    virtual void playlist_play_artist(std::string item);
+    virtual void playlist_play_album(std::string item);
+    virtual void playlist_play_title(std::string item);
+    virtual void playlist_add_artist(std::string item);
+    virtual void playlist_add_album(std::string item);
+    virtual void playlist_add_title(std::string item);
+    virtual void playlist_add_items(std::string item);
+    virtual void playlist_play_items(std::string item);
     virtual void playlist_clear();
-    virtual void playlist_save(string name);
-    virtual void playlist_delete(string id);
+    virtual void playlist_save(std::string name);
+    virtual void playlist_delete(std::string id);
     virtual void get_playlist_current(AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData());
     virtual void get_playlist_size(AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData());
     virtual void get_playlist_item(int index, AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData());
     virtual void get_playlist_basic_info(int index, AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData());
     virtual void get_playlist_album_cover(int i, AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData());
-    virtual void get_album_cover_id(string track_id, AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData());
+    virtual void get_album_cover_id(std::string track_id, AudioRequest_cb callback, AudioPlayerData user_data = AudioPlayerData());
 
     virtual bool canPlaylist() { return true; }
     virtual bool canDatabase() { return true; }
@@ -224,7 +224,7 @@ public:
     void addConnection(Ecore_Con_Server *srv);
     void delConnection(Ecore_Con_Server *srv);
     void dataGet(Ecore_Con_Server *srv, void *data, int size);
-    void processMessage(bool status, string msg);
+    void processMessage(bool status, std::string msg);
 };
 
 }

--- a/src/bin/calaos_server/Audio/SqueezeboxDB.cpp
+++ b/src/bin/calaos_server/Audio/SqueezeboxDB.cpp
@@ -21,7 +21,7 @@
 #include "SqueezeboxDB.h"
 #include "Squeezebox.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 SqueezeboxDB::SqueezeboxDB(Squeezebox *squeezebox, Params &p):
     AudioDB(p),
@@ -37,7 +37,7 @@ SqueezeboxDB::~SqueezeboxDB()
 
 void SqueezeboxDB::getAlbums(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data)
 {
-    string cmd = "albums " + Utils::to_string(from) + " " + Utils::to_string(nb) + " tags:lyja";
+    std::string cmd = "albums " + Utils::to_string(from) + " " + Utils::to_string(nb) + " tags:lyja";
 
     AudioPlayerData data;
     data.callback = callback;
@@ -45,10 +45,10 @@ void SqueezeboxDB::getAlbums(AudioRequest_cb callback, int from, int nb, AudioPl
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getAlbums_cb), data);
 }
-void SqueezeboxDB::getAlbums_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getAlbums_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -57,8 +57,8 @@ void SqueezeboxDB::getAlbums_cb(bool status, string request, string res, AudioPl
     int cpt = 0;
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -79,7 +79,7 @@ void SqueezeboxDB::getAlbums_cb(bool status, string request, string res, AudioPl
         if (tk[0] == "artwork_track_id")
         {
             item.Add("cover_id", url_decode2(tk[1]));
-            stringstream aurl;
+            std::stringstream aurl;
             aurl << "http://" << player->host << ":" << player->port_web << "/music/" << item["cover_id"] << "/cover.jpg";
             item.Add("cover_url", aurl.str());
         }
@@ -92,9 +92,9 @@ void SqueezeboxDB::getAlbums_cb(bool status, string request, string res, AudioPl
     sig.emit(data.get_chain_data());
 }
 
-void SqueezeboxDB::getAlbumsTitles(AudioRequest_cb callback, int from, int nb, string album_id, AudioPlayerData user_data)
+void SqueezeboxDB::getAlbumsTitles(AudioRequest_cb callback, int from, int nb, std::string album_id, AudioPlayerData user_data)
 {
-    string cmd = "titles " + Utils::to_string(from) + " " + Utils::to_string(nb);
+    std::string cmd = "titles " + Utils::to_string(from) + " " + Utils::to_string(nb);
     cmd += " album_id:" + album_id + " sort:tracknum tags:galdyorJilkmqtTvf";
 
     AudioPlayerData data;
@@ -103,10 +103,10 @@ void SqueezeboxDB::getAlbumsTitles(AudioRequest_cb callback, int from, int nb, s
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getAlbumsTitles_cb), data);
 }
-void SqueezeboxDB::getAlbumsTitles_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getAlbumsTitles_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -115,8 +115,8 @@ void SqueezeboxDB::getAlbumsTitles_cb(bool status, string request, string res, A
     int cpt = 0;
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -139,7 +139,7 @@ void SqueezeboxDB::getAlbumsTitles_cb(bool status, string request, string res, A
         if (tk[0] == "artwork_track_id")
         {
             item.Add("cover_id", url_decode2(tk[1]));
-            stringstream aurl;
+            std::stringstream aurl;
             aurl << "http://" << player->host << ":" << player->port_web << "/music/" << item["cover_id"] << "/cover.jpg";
             item.Add("cover_url", aurl.str());
         }
@@ -162,7 +162,7 @@ void SqueezeboxDB::getAlbumsTitles_cb(bool status, string request, string res, A
 
 void SqueezeboxDB::getArtists(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data)
 {
-    string cmd = "artists " + Utils::to_string(from) + " " + Utils::to_string(nb);
+    std::string cmd = "artists " + Utils::to_string(from) + " " + Utils::to_string(nb);
 
     AudioPlayerData data;
     data.callback = callback;
@@ -170,10 +170,10 @@ void SqueezeboxDB::getArtists(AudioRequest_cb callback, int from, int nb, AudioP
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getArtists_cb), data);
 }
-void SqueezeboxDB::getArtists_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getArtists_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -182,8 +182,8 @@ void SqueezeboxDB::getArtists_cb(bool status, string request, string res, AudioP
     int cpt = 0;
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -208,9 +208,9 @@ void SqueezeboxDB::getArtists_cb(bool status, string request, string res, AudioP
     sig.emit(data.get_chain_data());
 }
 
-void SqueezeboxDB::getArtistsAlbums(AudioRequest_cb callback, int from, int nb, string artist_id, AudioPlayerData user_data)
+void SqueezeboxDB::getArtistsAlbums(AudioRequest_cb callback, int from, int nb, std::string artist_id, AudioPlayerData user_data)
 {
-    string cmd = "albums " + Utils::to_string(from) + " " + Utils::to_string(nb);
+    std::string cmd = "albums " + Utils::to_string(from) + " " + Utils::to_string(nb);
     cmd += " artist_id:" + artist_id + " tags:lyja";
 
     AudioPlayerData data;
@@ -219,10 +219,10 @@ void SqueezeboxDB::getArtistsAlbums(AudioRequest_cb callback, int from, int nb, 
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getArtistsAlbums_cb), data);
 }
-void SqueezeboxDB::getArtistsAlbums_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getArtistsAlbums_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -231,8 +231,8 @@ void SqueezeboxDB::getArtistsAlbums_cb(bool status, string request, string res, 
     int cpt = 0;
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -253,7 +253,7 @@ void SqueezeboxDB::getArtistsAlbums_cb(bool status, string request, string res, 
         if (tk[0] == "artwork_track_id")
         {
             item.Add("cover_id", url_decode2(tk[1]));
-            stringstream aurl;
+            std::stringstream aurl;
             aurl << "http://" << player->host << ":" << player->port_web << "/music/" << item["cover_id"] << "/cover.jpg";
             item.Add("cover_url", aurl.str());
         }
@@ -268,7 +268,7 @@ void SqueezeboxDB::getArtistsAlbums_cb(bool status, string request, string res, 
 
 void SqueezeboxDB::getGenres(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data)
 {
-    string cmd = "genres " + Utils::to_string(from) + " " + Utils::to_string(nb);
+    std::string cmd = "genres " + Utils::to_string(from) + " " + Utils::to_string(nb);
 
     AudioPlayerData data;
     data.callback = callback;
@@ -276,10 +276,10 @@ void SqueezeboxDB::getGenres(AudioRequest_cb callback, int from, int nb, AudioPl
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getGenres_cb), data);
 }
-void SqueezeboxDB::getGenres_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getGenres_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -288,8 +288,8 @@ void SqueezeboxDB::getGenres_cb(bool status, string request, string res, AudioPl
     int cpt = 0;
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -314,9 +314,9 @@ void SqueezeboxDB::getGenres_cb(bool status, string request, string res, AudioPl
     sig.emit(data.get_chain_data());
 }
 
-void SqueezeboxDB::getGenresArtists(AudioRequest_cb callback, int from, int nb, string genre_id, AudioPlayerData user_data)
+void SqueezeboxDB::getGenresArtists(AudioRequest_cb callback, int from, int nb, std::string genre_id, AudioPlayerData user_data)
 {
-    string cmd = "artists " + Utils::to_string(from) + " " + Utils::to_string(nb) + " genre_id:" + genre_id;
+    std::string cmd = "artists " + Utils::to_string(from) + " " + Utils::to_string(nb) + " genre_id:" + genre_id;
 
     AudioPlayerData data;
     data.callback = callback;
@@ -324,10 +324,10 @@ void SqueezeboxDB::getGenresArtists(AudioRequest_cb callback, int from, int nb, 
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getGenresArtists_cb), data);
 }
-void SqueezeboxDB::getGenresArtists_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getGenresArtists_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -336,8 +336,8 @@ void SqueezeboxDB::getGenresArtists_cb(bool status, string request, string res, 
     int cpt = 0;
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -364,7 +364,7 @@ void SqueezeboxDB::getGenresArtists_cb(bool status, string request, string res, 
 
 void SqueezeboxDB::getYears(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data)
 {
-    string cmd = "years " + Utils::to_string(from) + " " + Utils::to_string(nb);
+    std::string cmd = "years " + Utils::to_string(from) + " " + Utils::to_string(nb);
 
     AudioPlayerData data;
     data.callback = callback;
@@ -372,10 +372,10 @@ void SqueezeboxDB::getYears(AudioRequest_cb callback, int from, int nb, AudioPla
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getYears_cb), data);
 }
-void SqueezeboxDB::getYears_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getYears_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -384,8 +384,8 @@ void SqueezeboxDB::getYears_cb(bool status, string request, string res, AudioPla
     int cpt = 0;
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -408,9 +408,9 @@ void SqueezeboxDB::getYears_cb(bool status, string request, string res, AudioPla
     sig.emit(data.get_chain_data());
 }
 
-void SqueezeboxDB::getYearsAlbums(AudioRequest_cb callback, int from, int nb, string year, AudioPlayerData user_data)
+void SqueezeboxDB::getYearsAlbums(AudioRequest_cb callback, int from, int nb, std::string year, AudioPlayerData user_data)
 {
-    string cmd = "albums " + Utils::to_string(from) + " " + Utils::to_string(nb);
+    std::string cmd = "albums " + Utils::to_string(from) + " " + Utils::to_string(nb);
     cmd += " year:" + year + " tags:lyja";
 
     AudioPlayerData data;
@@ -419,10 +419,10 @@ void SqueezeboxDB::getYearsAlbums(AudioRequest_cb callback, int from, int nb, st
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getYearsAlbums_cb), data);
 }
-void SqueezeboxDB::getYearsAlbums_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getYearsAlbums_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -431,8 +431,8 @@ void SqueezeboxDB::getYearsAlbums_cb(bool status, string request, string res, Au
     int cpt = 0;
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -453,7 +453,7 @@ void SqueezeboxDB::getYearsAlbums_cb(bool status, string request, string res, Au
         if (tk[0] == "artwork_track_id")
         {
             item.Add("cover_id", url_decode2(tk[1]));
-            stringstream aurl;
+            std::stringstream aurl;
             aurl << "http://" << player->host << ":" << player->port_web << "/music/" << item["cover_id"] << "/cover.jpg";
             item.Add("cover_url", aurl.str());
         }
@@ -468,7 +468,7 @@ void SqueezeboxDB::getYearsAlbums_cb(bool status, string request, string res, Au
 
 void SqueezeboxDB::getPlaylists(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data)
 {
-    string cmd = "playlists " + Utils::to_string(from) + " " + Utils::to_string(nb);
+    std::string cmd = "playlists " + Utils::to_string(from) + " " + Utils::to_string(nb);
 
     AudioPlayerData data;
     data.callback = callback;
@@ -476,10 +476,10 @@ void SqueezeboxDB::getPlaylists(AudioRequest_cb callback, int from, int nb, Audi
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getPlaylists_cb), data);
 }
-void SqueezeboxDB::getPlaylists_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getPlaylists_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -488,8 +488,8 @@ void SqueezeboxDB::getPlaylists_cb(bool status, string request, string res, Audi
     int cpt = 0;
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -514,13 +514,13 @@ void SqueezeboxDB::getPlaylists_cb(bool status, string request, string res, Audi
     sig.emit(data.get_chain_data());
 }
 
-void SqueezeboxDB::getPlaylistsTracks(AudioRequest_cb callback, int from, int nb, string playlist_id, AudioPlayerData user_data)
+void SqueezeboxDB::getPlaylistsTracks(AudioRequest_cb callback, int from, int nb, std::string playlist_id, AudioPlayerData user_data)
 {
     /* We need to add the current player for gettting playlist tracks
            This is a bug in the squeezebox server
            http://bugs.slimdevices.com/show_bug.cgi?id=16454
          */
-    string cmd = player->id;
+    std::string cmd = player->id;
     cmd += " playlists tracks " + Utils::to_string(from) + " " + Utils::to_string(nb);
     cmd += " playlist_id:" + playlist_id + " tags:galdyorJxuilkmqtTvf";
 
@@ -530,10 +530,10 @@ void SqueezeboxDB::getPlaylistsTracks(AudioRequest_cb callback, int from, int nb
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getPlaylistsTracks_cb), data);
 }
-void SqueezeboxDB::getPlaylistsTracks_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getPlaylistsTracks_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -542,8 +542,8 @@ void SqueezeboxDB::getPlaylistsTracks_cb(bool status, string request, string res
     int cpt = 0;
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -567,7 +567,7 @@ void SqueezeboxDB::getPlaylistsTracks_cb(bool status, string request, string res
         if (tk[0] == "artwork_track_id")
         {
             item.Add("cover_id", url_decode2(tk[1]));
-            stringstream aurl;
+            std::stringstream aurl;
             aurl << "http://" << player->host << ":" << player->port_web << "/music/" << item["cover_id"] << "/cover.jpg";
             item.Add("cover_url", aurl.str());
         }
@@ -592,7 +592,7 @@ void SqueezeboxDB::getPlaylistsTracks_cb(bool status, string request, string res
 
 void SqueezeboxDB::getRadios(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data)
 {
-    string cmd = "radios";
+    std::string cmd = "radios";
     cmd += " " + Utils::to_string(from) + " " + Utils::to_string(nb);
 
     AudioPlayerData data;
@@ -605,10 +605,10 @@ void SqueezeboxDB::getRadios(AudioRequest_cb callback, int from, int nb, AudioPl
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getRadios_cb), data);
 }
 
-void SqueezeboxDB::getRadios_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getRadios_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -616,8 +616,8 @@ void SqueezeboxDB::getRadios_cb(bool status, string request, string res, AudioPl
     Params item;
     for (uint i = 3;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
         split(tmp, tk, ":", 2);
 
         if (tk.size() != 2) continue;
@@ -626,7 +626,7 @@ void SqueezeboxDB::getRadios_cb(bool status, string request, string res, AudioPl
         {
             if (item.Exists("icon"))
             {
-                stringstream aurl;
+                std::stringstream aurl;
                 aurl << "http://" << player->host << ":" << player->port_web << "/" << item["icon"];
                 item.Add("icon", aurl.str());
             }
@@ -645,7 +645,7 @@ void SqueezeboxDB::getRadios_cb(bool status, string request, string res, AudioPl
     {
         if (item.Exists("icon"))
         {
-            stringstream aurl;
+            std::stringstream aurl;
             aurl << "http://" << player->host << ":" << player->port_web << "/" << item["icon"];
             item.Add("icon", aurl.str());
         }
@@ -670,16 +670,16 @@ void SqueezeboxDB::getRadios_cb(bool status, string request, string res, AudioPl
     }
     else
     {
-        string cmd = data.svalue;
+        std::string cmd = data.svalue;
         cmd += " " + Utils::to_string(data.ivalue) + " " + Utils::to_string(data.dvalue);
 
         player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getRadios_cb), data);
     }
 }
 
-void SqueezeboxDB::getRadiosItems(AudioRequest_cb callback, int from, int nb, string radio, string item_id, string search, AudioPlayerData user_data)
+void SqueezeboxDB::getRadiosItems(AudioRequest_cb callback, int from, int nb, std::string radio, std::string item_id, std::string search, AudioPlayerData user_data)
 {
-    string cmd = radio + " items " + Utils::to_string(from) + " " + Utils::to_string(nb);
+    std::string cmd = radio + " items " + Utils::to_string(from) + " " + Utils::to_string(nb);
     if (item_id != "") cmd += " item_id:" + item_id;
     if (search != "") cmd += " search:" + search;
 
@@ -689,10 +689,10 @@ void SqueezeboxDB::getRadiosItems(AudioRequest_cb callback, int from, int nb, st
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getRadiosItems_cb), data);
 }
-void SqueezeboxDB::getRadiosItems_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getRadiosItems_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -701,8 +701,8 @@ void SqueezeboxDB::getRadiosItems_cb(bool status, string request, string res, Au
     int cpt = 0;
     for (uint i = 0;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -724,7 +724,7 @@ void SqueezeboxDB::getRadiosItems_cb(bool status, string request, string res, Au
         if (tk[0] == "type") item.Add("type", url_decode2(tk[1]));
         if (tk[0] == "icon") //Menu icons
         {
-            stringstream aurl;
+            std::stringstream aurl;
             aurl << "http://" << param["host"] << ":9000" << url_decode2(tk[1]);
 
             item.Add("coverart", "1");
@@ -749,7 +749,7 @@ void SqueezeboxDB::getRadiosItems_cb(bool status, string request, string res, Au
 
 void SqueezeboxDB::getRandoms(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data)
 {
-    vector<Params> &result = user_data.vparams;
+    std::vector<Params> &result = user_data.vparams;
     Params p;
 
     p.Add("id", "tracks");
@@ -781,9 +781,9 @@ void SqueezeboxDB::getRandoms(AudioRequest_cb callback, int from, int nb, AudioP
     sig.emit(user_data);
 }
 
-void SqueezeboxDB::setRandomsType(string type)
+void SqueezeboxDB::setRandomsType(std::string type)
 {
-    string cmd, res;
+    std::string cmd, res;
     cmd = param["id"] + " randomplay " + Utils::to_string(type);
 
     player->sendRequest(cmd);
@@ -792,7 +792,7 @@ void SqueezeboxDB::setRandomsType(string type)
 void SqueezeboxDB::getStats(AudioRequest_cb callback, AudioPlayerData user_data)
 {
     //Get total genres
-    string cmd = "info total genres ?";
+    std::string cmd = "info total genres ?";
 
     AudioPlayerData data;
     data.callback = callback;
@@ -800,9 +800,9 @@ void SqueezeboxDB::getStats(AudioRequest_cb callback, AudioPlayerData user_data)
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getStats_genre_cb), data);
 }
-void SqueezeboxDB::getStats_genre_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getStats_genre_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -811,13 +811,13 @@ void SqueezeboxDB::getStats_genre_cb(bool status, string request, string res, Au
         data.get_chain_data().params.Add("genres", tokens[3]);
 
     //Get total artists
-    string cmd = "info total artists ?";
+    std::string cmd = "info total artists ?";
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getStats_artist_cb), data);
 }
-void SqueezeboxDB::getStats_artist_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getStats_artist_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -826,13 +826,13 @@ void SqueezeboxDB::getStats_artist_cb(bool status, string request, string res, A
         data.get_chain_data().params.Add("artists", tokens[3]);
 
     //Get total album
-    string cmd = "info total albums ?";
+    std::string cmd = "info total albums ?";
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getStats_album_cb), data);
 }
-void SqueezeboxDB::getStats_album_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getStats_album_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -841,13 +841,13 @@ void SqueezeboxDB::getStats_album_cb(bool status, string request, string res, Au
         data.get_chain_data().params.Add("albums", tokens[3]);
 
     //Get total tracks
-    string cmd = "info total songs ?";
+    std::string cmd = "info total songs ?";
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getStats_song_cb), data);
 }
-void SqueezeboxDB::getStats_song_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getStats_song_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -856,40 +856,40 @@ void SqueezeboxDB::getStats_song_cb(bool status, string request, string res, Aud
         data.get_chain_data().params.Add("tracks", tokens[3]);
 
     //Get total playlists
-    string cmd = "playlists 0 0";
+    std::string cmd = "playlists 0 0";
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getStats_playlist_cb), data);
 }
-void SqueezeboxDB::getStats_playlist_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getStats_playlist_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
 
     if (tokens.size() == 4)
     {
-        vector<string> tk;
+        std::vector<std::string> tk;
         split(tokens[3], tk, ":");
         if (tk.size() == 2)
             data.get_chain_data().params.Add("playlists", tk[1]);
     }
 
     //Get total years
-    string cmd = "years 0 0";
+    std::string cmd = "years 0 0";
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getStats_year_cb), data);
 }
-void SqueezeboxDB::getStats_year_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getStats_year_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(res, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
 
     if (tokens.size() == 4)
     {
-        vector<string> tk;
+        std::vector<std::string> tk;
         split(tokens[3], tk, ":");
         if (tk.size() == 2)
             data.get_chain_data().params.Add("years", tk[1]);
@@ -900,9 +900,9 @@ void SqueezeboxDB::getStats_year_cb(bool status, string request, string res, Aud
     sig.emit(data.get_chain_data());
 }
 
-void SqueezeboxDB::getSearch(AudioRequest_cb callback, int from, int nb, string search, AudioPlayerData user_data)
+void SqueezeboxDB::getSearch(AudioRequest_cb callback, int from, int nb, std::string search, AudioPlayerData user_data)
 {
-    string cmd = "search " + Utils::to_string(from) + " " + Utils::to_string(nb) + " term:" + url_encode(search);
+    std::string cmd = "search " + Utils::to_string(from) + " " + Utils::to_string(nb) + " term:" + url_encode(search);
 
     AudioPlayerData data;
     data.callback = callback;
@@ -910,7 +910,7 @@ void SqueezeboxDB::getSearch(AudioRequest_cb callback, int from, int nb, string 
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getSearch_cb), data);
 }
-void SqueezeboxDB::getSearch_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getSearch_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
     if (res != "")
     {
@@ -919,8 +919,8 @@ void SqueezeboxDB::getSearch_cb(bool status, string request, string res, AudioPl
         data.dvalue = 0.0;
     }
 
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(data.svalue, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -929,8 +929,8 @@ void SqueezeboxDB::getSearch_cb(bool status, string request, string res, AudioPl
     int cpt = (int)data.dvalue;
     for (uint i = data.ivalue;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -966,9 +966,9 @@ void SqueezeboxDB::getSearch_cb(bool status, string request, string res, AudioPl
     sig.emit(data.get_chain_data());
 }
 
-void SqueezeboxDB::getMusicFolder(AudioRequest_cb callback, int from, int nb, string folder_id, AudioPlayerData user_data)
+void SqueezeboxDB::getMusicFolder(AudioRequest_cb callback, int from, int nb, std::string folder_id, AudioPlayerData user_data)
 {
-    string cmd = "musicfolder " + Utils::to_string(from) + " " + Utils::to_string(nb);
+    std::string cmd = "musicfolder " + Utils::to_string(from) + " " + Utils::to_string(nb);
     if (folder_id != "") cmd += " folder_id:" + folder_id;
 
     AudioPlayerData data;
@@ -977,7 +977,7 @@ void SqueezeboxDB::getMusicFolder(AudioRequest_cb callback, int from, int nb, st
 
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getMusicFolder_cb), data);
 }
-void SqueezeboxDB::getMusicFolder_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getMusicFolder_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
     if (res != "")
     {
@@ -986,8 +986,8 @@ void SqueezeboxDB::getMusicFolder_cb(bool status, string request, string res, Au
         data.dvalue = 0.0;
     }
 
-    vector<Params> &result = data.get_chain_data().vparams;
-    vector<string> tokens;
+    std::vector<Params> &result = data.get_chain_data().vparams;
+    std::vector<std::string> tokens;
     split(data.svalue, tokens);
 
     for_each(tokens.begin(), tokens.end(), UrlDecode());
@@ -996,8 +996,8 @@ void SqueezeboxDB::getMusicFolder_cb(bool status, string request, string res, Au
     int cpt = (int)data.dvalue;
     for (uint i = data.ivalue;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
 
         split(tmp, tk, ":", 2);
 
@@ -1023,9 +1023,9 @@ void SqueezeboxDB::getMusicFolder_cb(bool status, string request, string res, Au
     sig.emit(data.get_chain_data());
 }
 
-void SqueezeboxDB::getTrackInfos(AudioRequest_cb callback, string track_id, AudioPlayerData user_data)
+void SqueezeboxDB::getTrackInfos(AudioRequest_cb callback, std::string track_id, AudioPlayerData user_data)
 {
-    string cmd = "songinfo 0 99999 tags:galdyorJilkmqtTvf track_id:" + track_id;
+    std::string cmd = "songinfo 0 99999 tags:galdyorJilkmqtTvf track_id:" + track_id;
 
     AudioPlayerData data;
     data.callback = callback;
@@ -1034,7 +1034,7 @@ void SqueezeboxDB::getTrackInfos(AudioRequest_cb callback, string track_id, Audi
     player->sendRequest(cmd, sigc::mem_fun(*this, &SqueezeboxDB::getTrackInfos_cb), data);
 }
 
-void SqueezeboxDB::getTrackInfos_cb(bool status, string request, string res, AudioPlayerData data)
+void SqueezeboxDB::getTrackInfos_cb(bool status, std::string request, std::string res, AudioPlayerData data)
 {
     Params p;
     p.Parse(res);
@@ -1043,8 +1043,8 @@ void SqueezeboxDB::getTrackInfos_cb(bool status, string request, string res, Aud
 
     for (int i = 4;i < p.size();i++)
     {
-        string value = p[Utils::to_string(i)];
-        vector<string> tk;
+        std::string value = p[Utils::to_string(i)];
+        std::vector<std::string> tk;
         Utils::split(Utils::url_decode2(value), tk, ":", 2);
 
         if (tk.size() != 2)
@@ -1057,7 +1057,7 @@ void SqueezeboxDB::getTrackInfos_cb(bool status, string request, string res, Aud
         if (tk[0] == "artwork_track_id")
         {
             item.Add("cover_id", url_decode2(tk[1]));
-            stringstream aurl;
+            std::stringstream aurl;
             aurl << "http://" << player->host << ":" << player->port_web << "/music/" << item["cover_id"] << "/cover.jpg";
             item.Add("cover_url", aurl.str());
         }
@@ -1074,4 +1074,6 @@ void SqueezeboxDB::getTrackInfos_cb(bool status, string request, string res, Aud
     AudioRequest_signal sig;
     sig.connect(data.callback);
     sig.emit(data.get_chain_data());
+}
+
 }

--- a/src/bin/calaos_server/Audio/SqueezeboxDB.h
+++ b/src/bin/calaos_server/Audio/SqueezeboxDB.h
@@ -35,39 +35,39 @@ class SqueezeboxDB: public AudioDB
 private:
     Squeezebox *player;
 
-    void getAlbums_cb(bool status, string request, string result, AudioPlayerData data);
-    void getAlbumsTitles_cb(bool status, string request, string result, AudioPlayerData data);
+    void getAlbums_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getAlbumsTitles_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void getArtists_cb(bool status, string request, string result, AudioPlayerData data);
-    void getArtistsAlbums_cb(bool status, string request, string result, AudioPlayerData data);
+    void getArtists_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getArtistsAlbums_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void getGenres_cb(bool status, string request, string result, AudioPlayerData data);
-    void getGenresArtists_cb(bool status, string request, string result, AudioPlayerData data);
+    void getGenres_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getGenresArtists_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void getYears_cb(bool status, string request, string result, AudioPlayerData data);
-    void getYearsAlbums_cb(bool status, string request, string result, AudioPlayerData data);
+    void getYears_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getYearsAlbums_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void getPlaylists_cb(bool status, string request, string result, AudioPlayerData data);
-    void getPlaylistsTracks_cb(bool status, string request, string result, AudioPlayerData data);
+    void getPlaylists_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getPlaylistsTracks_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void getRadios_cb(bool status, string request, string result, AudioPlayerData data);
-    void getRadiosItems_cb(bool status, string request, string result, AudioPlayerData data);
+    void getRadios_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getRadiosItems_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void getRandoms_cb(bool status, string request, string result, AudioPlayerData data);
-    void getRandomType_cb(bool status, string request, string result, AudioPlayerData data);
+    void getRandoms_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getRandomType_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void getSearch_cb(bool status, string request, string result, AudioPlayerData data);
+    void getSearch_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void getMusicFolder_cb(bool status, string request, string result, AudioPlayerData data);
+    void getMusicFolder_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void getStats_genre_cb(bool status, string request, string result, AudioPlayerData data);
-    void getStats_artist_cb(bool status, string request, string result, AudioPlayerData data);
-    void getStats_album_cb(bool status, string request, string result, AudioPlayerData data);
-    void getStats_song_cb(bool status, string request, string result, AudioPlayerData data);
-    void getStats_playlist_cb(bool status, string request, string result, AudioPlayerData data);
-    void getStats_year_cb(bool status, string request, string result, AudioPlayerData data);
+    void getStats_genre_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getStats_artist_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getStats_album_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getStats_song_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getStats_playlist_cb(bool status, std::string request, std::string result, AudioPlayerData data);
+    void getStats_year_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
-    void getTrackInfos_cb(bool status, string request, string result, AudioPlayerData data);
+    void getTrackInfos_cb(bool status, std::string request, std::string result, AudioPlayerData data);
 
 public:
     SqueezeboxDB(Squeezebox *squeezebox, Params &p);
@@ -77,37 +77,37 @@ public:
 
     //Album
     virtual void getAlbums(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData());
-    virtual void getAlbumsTitles(AudioRequest_cb callback, int from, int nb, string album_id, AudioPlayerData user_data = AudioPlayerData());
+    virtual void getAlbumsTitles(AudioRequest_cb callback, int from, int nb, std::string album_id, AudioPlayerData user_data = AudioPlayerData());
 
     //Artist
     virtual void getArtists(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData());
-    virtual void getArtistsAlbums(AudioRequest_cb callback, int from, int nb, string artist_id, AudioPlayerData user_data = AudioPlayerData());
+    virtual void getArtistsAlbums(AudioRequest_cb callback, int from, int nb, std::string artist_id, AudioPlayerData user_data = AudioPlayerData());
 
     //Genre
     virtual void getGenres(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData());
-    virtual void getGenresArtists(AudioRequest_cb callback, int from, int nb, string genre_id, AudioPlayerData user_data = AudioPlayerData());
+    virtual void getGenresArtists(AudioRequest_cb callback, int from, int nb, std::string genre_id, AudioPlayerData user_data = AudioPlayerData());
 
     //Year
     virtual void getYears(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData());
-    virtual void getYearsAlbums(AudioRequest_cb callback, int from, int nb, string year, AudioPlayerData user_data = AudioPlayerData());
+    virtual void getYearsAlbums(AudioRequest_cb callback, int from, int nb, std::string year, AudioPlayerData user_data = AudioPlayerData());
 
     //Playlists
     virtual void getPlaylists(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData());
-    virtual void getPlaylistsTracks(AudioRequest_cb callback, int from, int nb, string playlist_id, AudioPlayerData user_data = AudioPlayerData());
+    virtual void getPlaylistsTracks(AudioRequest_cb callback, int from, int nb, std::string playlist_id, AudioPlayerData user_data = AudioPlayerData());
 
     //Radios
     virtual void getRadios(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData());
-    virtual void getRadiosItems(AudioRequest_cb callback, int from, int nb, string radio, string item_id = "", string search = "", AudioPlayerData user_data = AudioPlayerData());
+    virtual void getRadiosItems(AudioRequest_cb callback, int from, int nb, std::string radio, std::string item_id = "", std::string search = "", AudioPlayerData user_data = AudioPlayerData());
 
     //Random
     virtual void getRandoms(AudioRequest_cb callback, int from, int nb, AudioPlayerData user_data = AudioPlayerData());
-    virtual void setRandomsType(string type);
+    virtual void setRandomsType(std::string type);
     //TODO:Random genre selection with  "<playerid>  randomplaygenrelist"
 
-    virtual void getSearch(AudioRequest_cb callback, int from, int nb, string search, AudioPlayerData user_data = AudioPlayerData());
+    virtual void getSearch(AudioRequest_cb callback, int from, int nb, std::string search, AudioPlayerData user_data = AudioPlayerData());
 
-    virtual void getMusicFolder(AudioRequest_cb callback, int from, int nb, string folder_id = "", AudioPlayerData user_data = AudioPlayerData());
-    virtual void getTrackInfos(AudioRequest_cb callback, string track_id, AudioPlayerData user_data = AudioPlayerData());
+    virtual void getMusicFolder(AudioRequest_cb callback, int from, int nb, std::string folder_id = "", AudioPlayerData user_data = AudioPlayerData());
+    virtual void getTrackInfos(AudioRequest_cb callback, std::string track_id, AudioPlayerData user_data = AudioPlayerData());
 
     //TODO:Favorites
 };

--- a/src/bin/calaos_server/Calaos.cpp
+++ b/src/bin/calaos_server/Calaos.cpp
@@ -23,9 +23,11 @@
 #include <ListeRoom.h>
 #include <ListeRule.h>
 
-using namespace Calaos;
+namespace Utils {
+type_signal_wago signal_wago;
+}
 
-Utils::type_signal_wago Utils::signal_wago;
+namespace Calaos {
 
 int CURL_write_callback_server(void *buffer, size_t size, size_t nmemb, void *stream)
 {
@@ -34,13 +36,13 @@ int CURL_write_callback_server(void *buffer, size_t size, size_t nmemb, void *st
     return size * nmemb;
 }
 
-void Calaos::CallUrl(string url, string post_data)
+void CallUrl(std::string url, std::string post_data)
 {
     FileDownloader *downloader = new FileDownloader(url, post_data, "text/plain", true);
     downloader->Start();
 }
 
-std::string Calaos::get_new_id(std::string prefix)
+std::string get_new_id(std::string prefix)
 {
     int cpt = 0;
     bool found = false;
@@ -58,15 +60,15 @@ std::string Calaos::get_new_id(std::string prefix)
     return ret;
 }
 
-std::string Calaos::get_new_scenario_id()
+std::string get_new_scenario_id()
 {
     int cpt = 0;
     bool found = true;
-    list<Scenario *> autosc = ListeRoom::Instance().getAutoScenarios();
+    std::list<Scenario *> autosc = ListeRoom::Instance().getAutoScenarios();
 
     while (found && autosc.size() > 0)
     {
-        list<Scenario *>::iterator it = autosc.begin();
+        std::list<Scenario *>::iterator it = autosc.begin();
 
         bool found2 = false;
         for (;it != autosc.end() && !found2;it++)
@@ -82,7 +84,7 @@ std::string Calaos::get_new_scenario_id()
             found = false;
     }
 
-    string ret = "scenario_" + Utils::to_string(cpt);
+    std::string ret = "scenario_" + Utils::to_string(cpt);
     return ret;
 }
 
@@ -101,4 +103,6 @@ void StartReadRules::ioRead()
     count_io--;
     if (count_io == 0)
         ListeRule::Instance().ExecuteStartRules();
+}
+
 }

--- a/src/bin/calaos_server/Calaos.h
+++ b/src/bin/calaos_server/Calaos.h
@@ -27,7 +27,6 @@
 
 #include <Ecore_File.h>
 
-using namespace Utils;
 
 namespace Calaos
 {
@@ -39,7 +38,7 @@ typedef struct _BlinkInfo
     int next;
 } BlinkInfo;
 
-void CallUrl(string url, string post_data = "");
+void CallUrl(std::string url, std::string post_data = "");
 #ifndef UTILS
 std::string get_new_id(std::string prefix);
 std::string get_new_scenario_id();

--- a/src/bin/calaos_server/CalaosConfig.cpp
+++ b/src/bin/calaos_server/CalaosConfig.cpp
@@ -21,7 +21,7 @@
 #include "CalaosConfig.h"
 #include <Eet.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 typedef struct _ConfigStateValue
 {
@@ -132,7 +132,7 @@ void Config::LoadConfigIO()
             room_node->Attribute("name") &&
             room_node->Attribute("type"))
         {
-            string name, type;
+            std::string name, type;
             int hits = 0;
 
             name = room_node->Attribute("name");
@@ -152,8 +152,8 @@ void Config::LoadConfigIO()
 
 void Config::SaveConfigIO()
 {
-    string file = Utils::getConfigFile(IO_CONFIG);
-    string tmp = file + "_tmp";
+    std::string file = Utils::getConfigFile(IO_CONFIG);
+    std::string tmp = file + "_tmp";
 
     cInfo() <<  "Saving " << file << "...";
 
@@ -220,7 +220,7 @@ void Config::LoadConfigRule()
             rule_node->Attribute("name") &&
             rule_node->Attribute("type"))
         {
-            string name, type;
+            std::string name, type;
 
             name = rule_node->Attribute("name");
             type = rule_node->Attribute("type");
@@ -237,8 +237,8 @@ void Config::LoadConfigRule()
 
 void Config::SaveConfigRule()
 {
-    string file = Utils::getConfigFile(RULES_CONFIG);
-    string tmp = file + "_tmp";
+    std::string file = Utils::getConfigFile(RULES_CONFIG);
+    std::string tmp = file + "_tmp";
 
     cInfo() <<  "Saving " << file << "...";
 
@@ -267,7 +267,7 @@ void Config::SaveConfigRule()
 void Config::loadStateCache()
 {
     ConfigStateCache *cache;
-    string file = Utils::getCacheFile("iostates.cache");
+    std::string file = Utils::getCacheFile("iostates.cache");
 
     Eet_File *ef = eet_open(file.c_str(), EET_FILE_MODE_READ);
     if (!ef)
@@ -297,8 +297,8 @@ void Config::loadStateCache()
     {
         Eina_Hash_Tuple *t = (Eina_Hash_Tuple *)data;
         ConfigStateValue *state = (ConfigStateValue *)t->data;
-        string skey = state->id;
-        string svalue = state->value;
+        std::string skey = state->id;
+        std::string svalue = state->value;
         SaveValueIO(skey, svalue, false);
     }
     eina_iterator_free(it);
@@ -313,8 +313,8 @@ void Config::loadStateCache()
 void Config::saveStateCache()
 {
     Eet_File *ef;
-    string file = Utils::getCacheFile("iostates.cache");
-    string tmp = file + "_tmp";
+    std::string file = Utils::getCacheFile("iostates.cache");
+    std::string tmp = file + "_tmp";
     ConfigStateCache *cache;
 
     cache = new ConfigStateCache;
@@ -343,7 +343,7 @@ void Config::saveStateCache()
     cInfo() <<  "State cache file written successfully (" << file << ")";
 }
 
-void Config::SaveValueIO(string id, string value, bool save)
+void Config::SaveValueIO(std::string id, std::string value, bool save)
 {
     if (eina_hash_find(cache_states, id.c_str()))
     {
@@ -365,7 +365,7 @@ void Config::SaveValueIO(string id, string value, bool save)
         saveStateCache();
 }
 
-bool Config::ReadValueIO(string id, string &value)
+bool Config::ReadValueIO(std::string id, std::string &value)
 {
     ConfigStateValue *v = (ConfigStateValue *)eina_hash_find(cache_states, id.c_str());
     if (!v)
@@ -374,4 +374,6 @@ bool Config::ReadValueIO(string id, string &value)
     value = v->value;
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/CalaosConfig.h
+++ b/src/bin/calaos_server/CalaosConfig.h
@@ -61,8 +61,8 @@ public:
     void SaveConfigIO();
     void SaveConfigRule();
 
-    void SaveValueIO(string id, string value, bool save = true);
-    bool ReadValueIO(string id, string &value);
+    void SaveValueIO(std::string id, std::string value, bool save = true);
+    bool ReadValueIO(std::string id, std::string &value);
 };
 
 }

--- a/src/bin/calaos_server/DataLogger.cpp
+++ b/src/bin/calaos_server/DataLogger.cpp
@@ -22,7 +22,7 @@
 #include <Eet.h>
 #include <IOBase.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 typedef struct _Calaos_DataLogger_Mean Calaos_DataLogger_Mean;
 typedef struct _Calaos_DataLogger_Values Calaos_DataLogger_Values;
@@ -61,7 +61,7 @@ _hash_values_free_cb(void *data)
 
 DataLogger::DataLogger()
 {
-    string db_file = getCacheFile(CALAOS_EET_DATALOGGER_FILE);
+    std::string db_file = getCacheFile(CALAOS_EET_DATALOGGER_FILE);
 
     eet_init();
     initEetDescriptors();
@@ -174,4 +174,6 @@ void DataLogger::log(IOBase *io)
     eet_data_write(ef, calaos_datalogger_mean_edd, section, mean, EINA_TRUE);
 
     eet_sync(ef);
+}
+
 }

--- a/src/bin/calaos_server/EventManager.cpp
+++ b/src/bin/calaos_server/EventManager.cpp
@@ -29,7 +29,7 @@ EventManager::~EventManager()
 {
     ecore_idle_enterer_del(idler);
     //clear queue
-    eventsQueue = queue<CalaosEvent>();
+    eventsQueue = std::queue<CalaosEvent>();
 }
 
 Eina_Bool EventManager_event_idler(void *data)
@@ -90,7 +90,7 @@ CalaosEvent::CalaosEvent()
 {
 }
 
-string CalaosEvent::typeToString(int type)
+std::string CalaosEvent::typeToString(int type)
 {
     switch (type)
     {
@@ -141,13 +141,13 @@ json_t *CalaosEvent::toJson() const
     return ret;
 }
 
-string CalaosEvent::toString() const
+std::string CalaosEvent::toString() const
 {
-    string ret = typeToString(getType());
+    std::string ret = typeToString(getType());
 
     for (int i = 0;i < evParams.size();i++)
     {
-        string key, val;
+        std::string key, val;
         evParams.get_item(i, key, val);
 
         ret += " ";

--- a/src/bin/calaos_server/EventManager.h
+++ b/src/bin/calaos_server/EventManager.h
@@ -70,9 +70,9 @@ public:
     const Params &getParam() const { return evParams; }
 
     json_t *toJson() const;
-    string toString() const;
+    std::string toString() const;
 
-    static string typeToString(int type);
+    static std::string typeToString(int type);
 
 private:
     int evType = EventUnkown;
@@ -101,7 +101,7 @@ private:
     EventManager();
 
     void appendEvent(const CalaosEvent &ev);
-    queue<CalaosEvent> eventsQueue;
+    std::queue<CalaosEvent> eventsQueue;
     Ecore_Idle_Enterer *idler = nullptr;
 
     friend Eina_Bool EventManager_event_idler(void *data);

--- a/src/bin/calaos_server/HttpClient.cpp
+++ b/src/bin/calaos_server/HttpClient.cpp
@@ -26,7 +26,7 @@
 #include <Ecore.h>
 #include "HttpCodes.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 #ifndef json_array_foreach
 #define json_array_foreach(array, index, value) \
@@ -157,7 +157,7 @@ HttpClient::~HttpClient()
     cDebugDom("network") << this;
 }
 
-int HttpClient::processHeaders(const string &request)
+int HttpClient::processHeaders(const std::string &request)
 {
     size_t nparsed;
 
@@ -201,7 +201,7 @@ int HttpClient::processHeaders(const string &request)
         headers.Add("Cache-Control", "no-cache, must-revalidate");
         headers.Add("Expires", "Mon, 26 Jul 1997 05:00:00 GMT");
         headers.Add("Content-Type", "text/html");
-        string res = buildHttpResponse(HTTP_200, headers, "");
+        std::string res = buildHttpResponse(HTTP_200, headers, "");
         sendToClient(res);
 
         return HTTP_PROCESS_DONE;
@@ -229,12 +229,12 @@ int HttpClient::processHeaders(const string &request)
 
     //decode GET parameters
     paramsGET.clear();
-    vector<string> pars;
+    std::vector<std::string> pars;
     Utils::split(req_url.getQuery(), pars, "&");
 
-    for (const string s: pars)
+    for (const std::string s: pars)
     {
-        vector<string> p;
+        std::vector<std::string> p;
         Utils::split(s, p, "=", 2);
         paramsGET.Add(p[0], p[1]);
     }
@@ -246,7 +246,7 @@ int HttpClient::processHeaders(const string &request)
         headers.Add("Connection", "close");
         headers.Add("Content-Type", "text/html");
         headers.Add("Location", "debug/index.html");
-        string res = buildHttpResponse(HTTP_301, headers, string());
+        std::string res = buildHttpResponse(HTTP_301, headers, std::string());
         sendToClient(res);
 
         return HTTP_PROCESS_DONE;
@@ -256,16 +256,16 @@ int HttpClient::processHeaders(const string &request)
     {
         cDebugDom("network") << "Sending debug pages";
 
-        string path = req_url.getPath();
+        std::string path = req_url.getPath();
         path.erase(0, 7);
 
-        string wwwroot = Utils::get_config_option("debug_wwwroot");
+        std::string wwwroot = Utils::get_config_option("debug_wwwroot");
         if (!ecore_file_is_dir(wwwroot.c_str()))
             wwwroot = Prefix::Instance().dataDirectoryGet() + "/debug";
 
         cDebugDom("network") << "Using www root: " << wwwroot;
 
-        string fileName = wwwroot +
+        std::string fileName = wwwroot +
                           (wwwroot[wwwroot.length() - 1] == '/'?"":"/") + path;
 
         if (!ecore_file_exists(fileName.c_str()))
@@ -275,19 +275,19 @@ int HttpClient::processHeaders(const string &request)
             Params headers;
             headers.Add("Connection", "close");
             headers.Add("Content-Type", "text/html");
-            string res = buildHttpResponse(HTTP_404, headers, HTTP_404_BODY);
+            std::string res = buildHttpResponse(HTTP_404, headers, HTTP_404_BODY);
             sendToClient(res);
 
             return HTTP_PROCESS_DONE;
         }
 
-        string filext = str_to_lower(path.substr(path.find_last_of(".") + 1));
+        std::string filext = str_to_lower(path.substr(path.find_last_of(".") + 1));
 
         Params headers;
         headers.Add("Connection", "Close");
         headers.Add("Content-Type", getMimeType(filext));
         cDebug() << "send file " << fileName << "to Client";
-        string res = buildHttpResponseFromFile(HTTP_200, headers, fileName);
+        std::string res = buildHttpResponseFromFile(HTTP_200, headers, fileName);
         sendToClient(res);
 
         return HTTP_PROCESS_DONE;
@@ -301,7 +301,7 @@ int HttpClient::processHeaders(const string &request)
         headers.Add("Connection", "close");
         headers.Add("Content-Type", "text/html");
         headers.Add("Location", "app/index.html");
-        string res = buildHttpResponse(HTTP_301, headers, string());
+        std::string res = buildHttpResponse(HTTP_301, headers, std::string());
         sendToClient(res);
 
         return HTTP_PROCESS_DONE;
@@ -311,14 +311,14 @@ int HttpClient::processHeaders(const string &request)
     {
         cDebugDom("network") << "Sending webapp pages";
 
-        string path = req_url.getPath();
+        std::string path = req_url.getPath();
         path.erase(0, 5);
 
-        string wwwroot = Utils::get_config_option("wwwroot");
+        std::string wwwroot = Utils::get_config_option("wwwroot");
         if (!ecore_file_is_dir(wwwroot.c_str()))
             wwwroot = Prefix::Instance().dataDirectoryGet() + "/app";
 
-        string fileName = wwwroot +
+        std::string fileName = wwwroot +
                           (wwwroot[wwwroot.length() - 1] == '/'?"":"/") + path;
 
         if (!ecore_file_exists(fileName.c_str()) || ecore_file_is_dir(fileName.c_str()))
@@ -328,19 +328,19 @@ int HttpClient::processHeaders(const string &request)
             Params headers;
             headers.Add("Connection", "close");
             headers.Add("Content-Type", "text/html");
-            string res = buildHttpResponse(HTTP_404, headers, HTTP_404_BODY);
+            std::string res = buildHttpResponse(HTTP_404, headers, HTTP_404_BODY);
             sendToClient(res);
 
             return HTTP_PROCESS_DONE;
         }
 
-        string filext = str_to_lower(path.substr(path.find_last_of(".") + 1));
+        std::string filext = str_to_lower(path.substr(path.find_last_of(".") + 1));
 
         Params headers;
         headers.Add("Connection", "Close");
         headers.Add("Content-Type", getMimeType(filext));
         cDebug() << "send file " << fileName << "to Client";
-        string res = buildHttpResponseFromFile(HTTP_200, headers, fileName);
+        std::string res = buildHttpResponseFromFile(HTTP_200, headers, fileName);
         sendToClient(res);
 
         return HTTP_PROCESS_DONE;
@@ -353,7 +353,7 @@ int HttpClient::processHeaders(const string &request)
         Params headers;
         headers.Add("Connection", "close");
         headers.Add("Content-Type", "text/html");
-        string res = buildHttpResponse(HTTP_404, headers, HTTP_404_BODY);
+        std::string res = buildHttpResponse(HTTP_404, headers, HTTP_404_BODY);
         sendToClient(res);
 
         return HTTP_PROCESS_DONE;
@@ -386,7 +386,7 @@ int HttpClient::processHeaders(const string &request)
         resHeaders.Add("Cache-Control", "no-cache, must-revalidate");
         resHeaders.Add("Expires", "Mon, 26 Jul 1997 05:00:00 GMT");
         resHeaders.Add("Content-Type", "text/html");
-        string res = buildHttpResponse(HTTP_200, resHeaders, "");
+        std::string res = buildHttpResponse(HTTP_200, resHeaders, "");
         sendToClient(res);
 
         return HTTP_PROCESS_DONE;
@@ -432,25 +432,25 @@ void HttpClient::CloseConnection()
     ecore_con_client_del(client_conn);
 }
 
-string HttpClient::buildHttpResponseFromFile(string code, Params &headers, string fileName)
+std::string HttpClient::buildHttpResponseFromFile(std::string code, Params &headers, std::string fileName)
 {
-    ifstream file(fileName);
-    string body((std::istreambuf_iterator<char>(file)),
+    std::ifstream file(fileName);
+    std::string body((std::istreambuf_iterator<char>(file)),
                     std::istreambuf_iterator<char>());
 
     return buildHttpResponse(code, headers, body);
 }
 
-string HttpClient::buildHttpResponse(string code, Params &headers, string body)
+std::string HttpClient::buildHttpResponse(std::string code, Params &headers, std::string body)
 {
-    stringstream res;
+    std::stringstream res;
 
     //HTTP code
     res << code << "\r\n";
 
     for (int i = 0;i < headers.size();i++)
     {
-        string key, value;
+        std::string key, value;
         headers.get_item(i, key, value);
         resHeaders.Add(key, value);
     }
@@ -473,7 +473,7 @@ string HttpClient::buildHttpResponse(string code, Params &headers, string body)
     //headers
     for (int i = 0;i < resHeaders.size();i++)
     {
-        string key, value;
+        std::string key, value;
         resHeaders.get_item(i, key, value);
         res << key << ": " << value << "\r\n";
     }
@@ -486,7 +486,7 @@ string HttpClient::buildHttpResponse(string code, Params &headers, string body)
     return res.str();
 }
 
-void HttpClient::sendToClient(string res)
+void HttpClient::sendToClient(std::string res)
 {
     data_size += res.length();
 
@@ -513,11 +513,11 @@ void HttpClient::handleJsonRequest()
             return;
         }
 
-        jsonApi->sendData.connect([=](const string &data)
+        jsonApi->sendData.connect([=](const std::string &data)
         {
             sendToClient(data);
         });
-        jsonApi->closeConnection.connect([=](int c, const string &r)
+        jsonApi->closeConnection.connect([=](int c, const std::string &r)
         {
             VAR_UNUSED(c);
             VAR_UNUSED(r);
@@ -528,7 +528,7 @@ void HttpClient::handleJsonRequest()
     jsonApi->processApi(bodymessage, paramsGET);
 }
 
-string HttpClient::getMimeType(const string &file_ext)
+std::string HttpClient::getMimeType(const std::string &file_ext)
 {
     if (file_ext == "js")
         return "application/javascript";
@@ -560,4 +560,6 @@ string HttpClient::getMimeType(const string &file_ext)
         return "application/vnd.ms-fontobject";
 
     return "text/plain";
+}
+
 }

--- a/src/bin/calaos_server/HttpClient.h
+++ b/src/bin/calaos_server/HttpClient.h
@@ -29,7 +29,7 @@
 #include "JsonApiHandlerWS.h"
 #include "EcoreTimer.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 class HttpClient: public sigc::trackable
 {
@@ -42,7 +42,7 @@ protected:
 
     bool parse_done = false;
     unsigned char request_method;
-    unordered_map<string, string> request_headers;
+    std::unordered_map<std::string, std::string> request_headers;
 
     int proto_ver;
 
@@ -50,9 +50,9 @@ protected:
 
     //for parsing purposes
     bool has_field = false, has_value = false;
-    string hfield, hvalue;
-    string bodymessage;
-    string parse_url;
+    std::string hfield, hvalue;
+    std::string bodymessage;
+    std::string parse_url;
 
     //headers to send back
     Params resHeaders;
@@ -80,13 +80,13 @@ protected:
         HTTP_PROCESS_WEBSOCKET,     //websocket request
         HTTP_PROCESS_DONE,          //request already processed (for HTTP OPTIONS, or debug.html)
     };
-    int processHeaders(const string &request);
+    int processHeaders(const std::string &request);
 
     void handleJsonRequest();
 
-    void sendToClient(string res);
+    void sendToClient(std::string res);
 
-    string getMimeType(const string &file_ext);
+    std::string getMimeType(const std::string &file_ext);
 
     friend int _parser_begin(http_parser *parser);
     friend int _parser_header_field(http_parser *parser, const char *at, size_t length);
@@ -105,10 +105,12 @@ public:
     /* Called by JsonApiServer whenever data has been written to client */
     virtual void DataWritten(int size);
 
-    string buildHttpResponse(string code, Params &headers, string body);
-    string buildHttpResponseFromFile(string code, Params &headers, string fileName);
+    std::string buildHttpResponse(std::string code, Params &headers, std::string body);
+    std::string buildHttpResponseFromFile(std::string code, Params &headers, std::string fileName);
 
     void setNeedRestart(bool e) { need_restart = e; }
 };
+
+}
 
 #endif

--- a/src/bin/calaos_server/HttpServer.cpp
+++ b/src/bin/calaos_server/HttpServer.cpp
@@ -21,6 +21,8 @@
 #include "HttpServer.h"
 #include "WebSocket.h"
 
+namespace Calaos {
+
 static Eina_Bool _ecore_con_handler_client_add(void *data, int type, Ecore_Con_Event_Client_Add *ev);
 static Eina_Bool _ecore_con_handler_data_get(void *data, int type, Ecore_Con_Event_Client_Data *ev);
 static Eina_Bool _ecore_con_handler_client_del(void *data, int type, Ecore_Con_Event_Client_Del *ev);
@@ -157,7 +159,7 @@ void HttpServer::delConnection(Ecore_Con_Client *client)
             << "Connection from adress "
             << ecore_con_client_ip_get(client) << " closed.";
 
-    map<Ecore_Con_Client *, WebSocket *>::iterator it = connections.find(client);
+    std::map<Ecore_Con_Client *, WebSocket *>::iterator it = connections.find(client);
     if (it == connections.end())
     {
         cCriticalDom("network") << "Can't find corresponding HttpClient !";
@@ -171,13 +173,13 @@ void HttpServer::delConnection(Ecore_Con_Client *client)
 
 void HttpServer::getDataConnection(Ecore_Con_Client *client, void *data, int size)
 {
-    string d((char *)data, size);
+    std::string d((char *)data, size);
 
     cDebugDom("network")
             << "Got data from client at address "
             << ecore_con_client_ip_get(client);
 
-    map<Ecore_Con_Client *, WebSocket *>::iterator it = connections.find(client);
+    std::map<Ecore_Con_Client *, WebSocket *>::iterator it = connections.find(client);
     if (it == connections.end())
     {
         cCriticalDom("network") << "Can't find corresponding HttpClient !";
@@ -195,7 +197,7 @@ void HttpServer::dataWritten(Ecore_Con_Client *client, int size)
             << " to client at address "
             << ecore_con_client_ip_get(client);
 
-    map<Ecore_Con_Client *, WebSocket *>::iterator it = connections.find(client);
+    std::map<Ecore_Con_Client *, WebSocket *>::iterator it = connections.find(client);
     if (it == connections.end())
     {
         cCriticalDom("network") << "Can't find corresponding HttpClient !";
@@ -208,10 +210,12 @@ void HttpServer::dataWritten(Ecore_Con_Client *client, int size)
 
 void HttpServer::disconnectAll()
 {
-    map<Ecore_Con_Client *, WebSocket *>::iterator iter;
+    std::map<Ecore_Con_Client *, WebSocket *>::iterator iter;
     for (iter = connections.begin();iter != connections.end();iter++)
     {
         WebSocket *ws = (*iter).second;
         ws->sendCloseFrame(WebSocketFrame::CloseCodeNormal, "Shutting down", true);
     }
+}
+
 }

--- a/src/bin/calaos_server/HttpServer.h
+++ b/src/bin/calaos_server/HttpServer.h
@@ -26,7 +26,7 @@
 #include "HttpClient.h"
 #include <Ecore_Con.h>
 
-using namespace std;
+namespace Calaos {
 
 class HttpServer
 {
@@ -38,7 +38,7 @@ private:
     Ecore_Event_Handler *event_handler_data_get;
     Ecore_Event_Handler *event_handler_client_write;
 
-    map<Ecore_Con_Client *, WebSocket *> connections;
+    std::map<Ecore_Con_Client *, WebSocket *> connections;
 
     HttpServer(int port); //port to listen
 
@@ -59,4 +59,7 @@ public:
     void getDataConnection(Ecore_Con_Client *client, void *data, int size);
     void dataWritten(Ecore_Con_Client *client, int size);
 };
+
+}
+
 #endif

--- a/src/bin/calaos_server/IO/Blinkstick/BlinkstickOutputLightRGB.cpp
+++ b/src/bin/calaos_server/IO/Blinkstick/BlinkstickOutputLightRGB.cpp
@@ -25,7 +25,7 @@
 #define BLINKSTICK_VENDOR_ID 0x20A0
 #define BLINKSTICK_PRODUCT_ID 0x41E5
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(BlinkstickOutputLightRGB)
 
@@ -149,3 +149,5 @@ bool BlinkstickOutputLightRGB::blinkstickSerialGet(libusb_device *device, unsign
     return false;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Blinkstick/BlinkstickOutputLightRGB.h
+++ b/src/bin/calaos_server/IO/Blinkstick/BlinkstickOutputLightRGB.h
@@ -32,7 +32,7 @@ namespace Calaos
 class BlinkstickOutputLightRGB : public OutputLightRGB
 {
 private:
-    string m_serial;
+    std::string m_serial;
     int m_nbLeds;
     bool blinkstickSerialGet(libusb_device *device, unsigned char *serial, libusb_device_handle **handle);
 

--- a/src/bin/calaos_server/IO/ExternProc.cpp
+++ b/src/bin/calaos_server/IO/ExternProc.cpp
@@ -66,7 +66,7 @@ Eina_Bool ExternProcServer_con_data(void *data, int type, void *event)
         ex->ipcServer != ecore_con_client_server_get(ev->client))
         return ECORE_CALLBACK_PASS_ON;
 
-    string d((char *)ev->data, ev->size);
+    std::string d((char *)ev->data, ev->size);
     ex->processData(d);
 
     return ECORE_CALLBACK_DONE;
@@ -108,7 +108,7 @@ Eina_Bool ExternProcServer_proc_del(void *data, int type, void *event)
     return ECORE_CALLBACK_DONE;
 }
 
-ExternProcServer::ExternProcServer(string pathprefix)
+ExternProcServer::ExternProcServer(std::string pathprefix)
 {
     int pid = getpid();
     sockpath = "/tmp/calaos_proc_";
@@ -161,18 +161,18 @@ void ExternProcServer::terminate()
     ecore_exe_terminate(process_exe);
 }
 
-void ExternProcServer::sendMessage(const string &data)
+void ExternProcServer::sendMessage(const std::string &data)
 {
     for (Ecore_Con_Client *client : clientList)
     {
         ExternProcMessage msg(data);
-        string frame = msg.getRawData();
+        std::string frame = msg.getRawData();
 
         ecore_con_client_send(client, frame.c_str(), frame.size());
     }
 }
 
-void ExternProcServer::processData(const string &data)
+void ExternProcServer::processData(const std::string &data)
 {
     cDebugDom("process") << "Processing frame data " << data.size();
 
@@ -191,9 +191,9 @@ void ExternProcServer::processData(const string &data)
     }
 }
 
-void ExternProcServer::startProcess(const string &process, const string &name, const string &args)
+void ExternProcServer::startProcess(const std::string &process, const std::string &name, const std::string &args)
 {
-    string cmd = process;
+    std::string cmd = process;
     cmd += " --socket \"" + sockpath + "\" --namespace \"" + name + "\" " + args;
 
     cDebugDom("process") << "Starting process: " << cmd;
@@ -205,7 +205,7 @@ ExternProcMessage::ExternProcMessage()
     clear();
 }
 
-ExternProcMessage::ExternProcMessage(string data)
+ExternProcMessage::ExternProcMessage(std::string data)
 {
     payload = data;
     payload_length = data.size();
@@ -222,7 +222,7 @@ void ExternProcMessage::clear()
     state = StateReadHeader;
 }
 
-bool ExternProcMessage::processFrameData(string &data)
+bool ExternProcMessage::processFrameData(std::string &data)
 {
     bool finished = false;
 
@@ -291,9 +291,9 @@ bool ExternProcMessage::processFrameData(string &data)
     return finished;
 }
 
-string ExternProcMessage::getRawData()
+std::string ExternProcMessage::getRawData()
 {
-    string frame;
+    std::string frame;
 
     uint8_t b = static_cast<uint8_t>(opcode);
     frame.push_back(static_cast<char>(b));
@@ -446,10 +446,10 @@ void ExternProcClient::run(int timeoutms)
     }
 }
 
-void ExternProcClient::sendMessage(const string &data)
+void ExternProcClient::sendMessage(const std::string &data)
 {
     ExternProcMessage msg(data);
-    string frame = msg.getRawData();
+    std::string frame = msg.getRawData();
     ssize_t len;
 
     len = send(sockfd, frame.c_str(), frame.size(), 0);

--- a/src/bin/calaos_server/IO/ExternProc.h
+++ b/src/bin/calaos_server/IO/ExternProc.h
@@ -43,15 +43,15 @@ class ExternProcMessage
 {
 public:
     ExternProcMessage();
-    ExternProcMessage(string data);
+    ExternProcMessage(std::string data);
 
     bool isValid() const { return isvalid; }
-    string getPayload() const { return payload; }
+    std::string getPayload() const { return payload; }
 
     void clear();
 
-    bool processFrameData(string &data);
-    string getRawData();
+    bool processFrameData(std::string &data);
+    std::string getRawData();
 
     enum TypeCode
     {
@@ -70,36 +70,36 @@ private:
 
     int opcode;
     uint32_t payload_length;
-    string payload;
+    std::string payload;
     bool isvalid;
 };
 
 class ExternProcServer: public sigc::trackable
 {
 public:
-    ExternProcServer(string pathprefix);
+    ExternProcServer(std::string pathprefix);
     ~ExternProcServer();
 
-    void sendMessage(const string &data);
+    void sendMessage(const std::string &data);
 
-    void startProcess(const string &process, const string &name, const string &args = string());
+    void startProcess(const std::string &process, const std::string &name, const std::string &args = std::string());
     void terminate();
 
-    sigc::signal<void, const string &> messageReceived;
+    sigc::signal<void, const std::string &> messageReceived;
     sigc::signal<void> processExited;
     sigc::signal<void> processConnected;
 
 private:
     Ecore_Con_Server *ipcServer;
     Ecore_Event_Handler *hAdd, *hDel, *hData, *hError, *hProcDel;
-    string sockpath;
-    string recv_buffer;
+    std::string sockpath;
+    std::string recv_buffer;
     ExternProcMessage currentFrame;
     Ecore_Exe *process_exe = nullptr;
 
-    list<Ecore_Con_Client *> clientList;
+    std::list<Ecore_Con_Client *> clientList;
 
-    void processData(const string &data);
+    void processData(const std::string &data);
 
     friend Eina_Bool ExternProcServer_con_add(void *data, int type, void *event);
     friend Eina_Bool ExternProcServer_con_del(void *data, int type, void *event);
@@ -116,7 +116,7 @@ public:
 
     bool connectSocket();
 
-    void sendMessage(const string &data);
+    void sendMessage(const std::string &data);
 
     //setup if called first and if false is returned,
     //process quit
@@ -125,7 +125,7 @@ public:
 
 protected:
     virtual void readTimeout() = 0;
-    virtual void messageReceived(const string &msg) = 0;
+    virtual void messageReceived(const std::string &msg) = 0;
 
     //implement this when adding a file descriptor to the main loop
     //when something happens on this fd, this function is called.
@@ -144,15 +144,15 @@ protected:
     bool processSocketRecv(); //call if something needs to be read from socket
 
 private:
-    string sockpath;
-    string name;
+    std::string sockpath;
+    std::string name;
     int sockfd;
 
-    string recv_buffer;
+    std::string recv_buffer;
 
     ExternProcMessage currentFrame;
 
-    list<int> userFds;
+    std::list<int> userFds;
 };
 
 #define EXTERN_PROC_CLIENT_CTOR(class_name) \

--- a/src/bin/calaos_server/IO/Gpio/GpioCtrl.cpp
+++ b/src/bin/calaos_server/IO/Gpio/GpioCtrl.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "GpioCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 GpioCtrl::GpioCtrl(int _gpionum, double _debounce_time)
 {
@@ -43,9 +43,9 @@ GpioCtrl::~GpioCtrl()
     cDebugDom("input") << "Delete GpioCtrl";
 }
 
-int GpioCtrl::writeFile(string path, string value)
+int GpioCtrl::writeFile(std::string path, std::string value)
 {
-    ofstream ofspath(path.c_str());
+    std::ofstream ofspath(path.c_str());
     cDebug() << "ofstream " << path;
     if (!ofspath.is_open())
     {
@@ -59,9 +59,9 @@ int GpioCtrl::writeFile(string path, string value)
     return true;
 }
 
-int GpioCtrl::readFile(string path, string &value)
+int GpioCtrl::readFile(std::string path, std::string &value)
 {
-    ifstream ifspath(path.c_str());
+    std::ifstream ifspath(path.c_str());
     if (!ifspath.is_open())
     {
         cErrorDom("input") << "Unable to read file " << strerror(errno);
@@ -85,31 +85,31 @@ bool GpioCtrl::unexportGpio()
 }
 
 // Set GPIO direction : "in" or "out"
-bool GpioCtrl::setDirection(string direction)
+bool GpioCtrl::setDirection(std::string direction)
 {
-    string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/direction";
+    std::string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/direction";
     return writeFile(path, direction);
 }
 
 // Set GPIO signal edge : "none", "rising", "falling" or "both"
-bool GpioCtrl::setEdge(string direction)
+bool GpioCtrl::setEdge(std::string direction)
 {
-    string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/edge";
+    std::string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/edge";
     return writeFile(path, direction);
 }
 
 // Set GPIO active low : "1" for active_low "0", for active_high (standard behaviour)
 bool GpioCtrl::setActiveLow(bool active_low)
 {
-    string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/active_low";
+    std::string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/active_low";
     return writeFile(path, active_low ? "1" : "0");
 }
 
 
 bool GpioCtrl::setVal(bool value)
 {
-    string strval;
-    string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/value";
+    std::string strval;
+    std::string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/value";
     strval = Utils::to_string(value);
     cDebugDom("input") << "Set value " << value << " to " << path;
     return writeFile(path, strval);
@@ -117,8 +117,8 @@ bool GpioCtrl::setVal(bool value)
 
 bool GpioCtrl::getVal(bool &value)
 {
-    string strval;
-    string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/value";
+    std::string strval;
+    std::string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/value";
 
     if (!readFile(path, strval))
     {
@@ -190,8 +190,8 @@ void GpioCtrl::emitChange(void)
 
 bool GpioCtrl::setValueChanged(sigc::slot<void> slot)
 {
-    string strval;
-    string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/value";
+    std::string strval;
+    std::string path = "/sys/class/gpio/gpio" + Utils::to_string(gpionum) + "/value";
 
     if (fd == -1)
     {
@@ -220,4 +220,6 @@ bool GpioCtrl::setValueChanged(sigc::slot<void> slot)
     }
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/Gpio/GpioCtrl.h
+++ b/src/bin/calaos_server/IO/Gpio/GpioCtrl.h
@@ -32,9 +32,9 @@ class GpioCtrl
 {
 private:
     int gpionum; // GPIO Number
-    string gpionum_str;
-    int writeFile(string path, string value);
-    int readFile(string path, string &value);
+    std::string gpionum_str;
+    int writeFile(std::string path, std::string value);
+    int readFile(std::string path, std::string &value);
     int fd;
     sigc::connection connection;
     sigc::signal<void> event_signal;
@@ -47,8 +47,8 @@ public:
     ~GpioCtrl();
     bool exportGpio();
     bool unexportGpio();
-    bool setDirection(string direction);
-    bool setEdge(string direction);
+    bool setDirection(std::string direction);
+    bool setEdge(std::string direction);
     bool setActiveLow(bool active_low);
     bool setVal(bool value);
     bool getVal(bool &value);

--- a/src/bin/calaos_server/IO/Gpio/GpioInputSwitch.cpp
+++ b/src/bin/calaos_server/IO/Gpio/GpioInputSwitch.cpp
@@ -23,7 +23,7 @@
 
 #include "GpioInputSwitch.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(GpioInputSwitch)
 
@@ -70,4 +70,6 @@ bool GpioInputSwitch::readValue()
 {
     cInfoDom("Input") << "Read Value : " << val;
     return val;
+}
+
 }

--- a/src/bin/calaos_server/IO/Gpio/GpioInputSwitchLongPress.cpp
+++ b/src/bin/calaos_server/IO/Gpio/GpioInputSwitchLongPress.cpp
@@ -23,7 +23,7 @@
 
 #include "GpioInputSwitchLongPress.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(GpioInputSwitchLongPress)
 
@@ -69,4 +69,4 @@ bool GpioInputSwitchLongPress::readValue()
     return val;
 }
 
-
+}

--- a/src/bin/calaos_server/IO/Gpio/GpioInputSwitchTriple.cpp
+++ b/src/bin/calaos_server/IO/Gpio/GpioInputSwitchTriple.cpp
@@ -23,7 +23,7 @@
 
 #include "GpioInputSwitchTriple.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(GpioInputSwitchTriple)
 
@@ -68,4 +68,6 @@ bool GpioInputSwitchTriple::readValue()
 {
     cInfoDom("Input") << "Read Value : " << val;
     return val;
+}
+
 }

--- a/src/bin/calaos_server/IO/Gpio/GpioOutputShutter.cpp
+++ b/src/bin/calaos_server/IO/Gpio/GpioOutputShutter.cpp
@@ -23,7 +23,7 @@
 
 #include "GpioOutputShutter.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(GpioOutputShutter)
 
@@ -77,4 +77,6 @@ void GpioOutputShutter::setOutputUp(bool enable)
 void GpioOutputShutter::setOutputDown(bool enable)
 {
     gpioctrl_down->setVal(enable);
+}
+
 }

--- a/src/bin/calaos_server/IO/Gpio/GpioOutputShutterSmart.cpp
+++ b/src/bin/calaos_server/IO/Gpio/GpioOutputShutterSmart.cpp
@@ -23,7 +23,7 @@
 
 #include "GpioOutputShutterSmart.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(GpioOutputShutterSmart)
 
@@ -78,4 +78,6 @@ void GpioOutputShutterSmart::setOutputUp(bool enable)
 void GpioOutputShutterSmart::setOutputDown(bool enable)
 {
     gpioctrl_down->setVal(enable);
+}
+
 }

--- a/src/bin/calaos_server/IO/Gpio/GpioOutputSwitch.cpp
+++ b/src/bin/calaos_server/IO/Gpio/GpioOutputSwitch.cpp
@@ -22,7 +22,7 @@
 
 #include "GpioOutputSwitch.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(GpioOutputSwitch)
 
@@ -60,4 +60,6 @@ bool GpioOutputSwitch::set_value_real(bool val)
 {
     gpioctrl->setVal(val);
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/Hue/HueOutputLightRGB.cpp
+++ b/src/bin/calaos_server/IO/Hue/HueOutputLightRGB.cpp
@@ -25,7 +25,7 @@
 #include "UrlDownloader.h"
 #include "Jansson_Addition.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(HueOutputLightRGB)
 
@@ -44,7 +44,7 @@ HueOutputLightRGB::HueOutputLightRGB(Params &p):
     m_idHue = get_param("id_hue");
 
     m_timer = new EcoreTimer(2.0,[=](){
-        string url = "http://" + m_host + "/api/" + m_api + "/lights/" + m_idHue;
+        std::string url = "http://" + m_host + "/api/" + m_api + "/lights/" + m_idHue;
         UrlDownloader *dl = new UrlDownloader(url, true);
         dl->m_signalCompleteData.connect([&](Eina_Binbuf *downloadedData, int status)
     {
@@ -123,7 +123,7 @@ void HueOutputLightRGB::setColorReal(const ColorValue &c, bool s)
 
 void HueOutputLightRGB::setOff()
 {
-    string url = "http://" + m_host + "/api/" + m_api + "/lights/" + m_idHue + "/state";
+    std::string url = "http://" + m_host + "/api/" + m_api + "/lights/" + m_idHue + "/state";
     UrlDownloader *dl = new UrlDownloader(url, true);
     dl->bodyDataSet("{\"on\":false}");
     dl->m_signalCompleteData.connect([&](Eina_Binbuf *downloadedData, int status)
@@ -137,9 +137,9 @@ void HueOutputLightRGB::setOff()
 
 void HueOutputLightRGB::setColor(const ColorValue &c)
 {
-    string url = "http://" + m_host + "/api/" + m_api + "/lights/" + m_idHue + "/state";
+    std::string url = "http://" + m_host + "/api/" + m_api + "/lights/" + m_idHue + "/state";
     UrlDownloader *dl = new UrlDownloader(url, true);
-    string ccolor = "{\"on\":true,"
+    std::string ccolor = "{\"on\":true,"
                    "\"sat\":"  + Utils::to_string((int)(c.getHSVSaturation() * 255.0 / 100.0)) +
                    ",\"bri\":" + Utils::to_string((int)(c.getHSLLightness() * 255.0 / 100.0)) +
                    ",\"hue\":" + Utils::to_string((int)(c.getHSLHue() * 65535.0 / 360.0)) + "}";
@@ -151,4 +151,6 @@ void HueOutputLightRGB::setColor(const ColorValue &c)
     });
 
     dl->httpPut();
+}
+
 }

--- a/src/bin/calaos_server/IO/Hue/HueOutputLightRGB.h
+++ b/src/bin/calaos_server/IO/Hue/HueOutputLightRGB.h
@@ -30,9 +30,9 @@ namespace Calaos
 class HueOutputLightRGB : public OutputLightRGB
 {
 private:
-    string m_host;
-    string m_api;
-    string m_idHue;
+    std::string m_host;
+    std::string m_api;
+    std::string m_idHue;
     EcoreTimer *m_timer;
 
     void setOff();

--- a/src/bin/calaos_server/IO/IODoc.cpp
+++ b/src/bin/calaos_server/IO/IODoc.cpp
@@ -20,28 +20,28 @@
  ******************************************************************************/
 #include "IODoc.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 IODoc::IODoc()
 {
 }
 
-void IODoc::friendlyNameSet(const string &friendlyName)
+void IODoc::friendlyNameSet(const std::string &friendlyName)
 {
     m_name = friendlyName;
 }
 
-void IODoc::descriptionSet(const string &description)
+void IODoc::descriptionSet(const std::string &description)
 {
     m_description = description;
 }
 
-void IODoc::descriptionBaseSet(const string &description)
+void IODoc::descriptionBaseSet(const std::string &description)
 {
     m_description_base = description;
 }
 
-void IODoc::linkAdd(const string &description, const string &link)
+void IODoc::linkAdd(const std::string &description, const std::string &link)
 {
     Params p;
     p.Add("description", description);
@@ -49,7 +49,7 @@ void IODoc::linkAdd(const string &description, const string &link)
     m_links.push_back(p);
 }
 
-void IODoc::paramAdd(const string &name, const string &description, ParamType type, bool mandatory, const string defaultval, bool readonly)
+void IODoc::paramAdd(const std::string &name, const std::string &description, ParamType type, bool mandatory, const std::string defaultval, bool readonly)
 {   
     Params param;
     param.Add("name", name);
@@ -62,7 +62,7 @@ void IODoc::paramAdd(const string &name, const string &description, ParamType ty
     m_parameters[name] = param;
 }
 
-void IODoc::paramAddInt(const string &name, const string &description, int min, int max, bool mandatory, int defval, bool readonly)
+void IODoc::paramAddInt(const std::string &name, const std::string &description, int min, int max, bool mandatory, int defval, bool readonly)
 {
     Params param;
     param.Add("name", name);
@@ -76,7 +76,7 @@ void IODoc::paramAddInt(const string &name, const string &description, int min, 
     m_parameters[name] = param;
 }
 
-void IODoc::paramAddFloat(const string &name, const string &description, bool mandatory, double min, double max, double defval, bool readonly)
+void IODoc::paramAddFloat(const std::string &name, const std::string &description, bool mandatory, double min, double max, double defval, bool readonly)
 {
     Params param;
     param.Add("name", name);
@@ -90,7 +90,7 @@ void IODoc::paramAddFloat(const string &name, const string &description, bool ma
     m_parameters[name] = param;
 }
 
-void IODoc::paramAddList(const string &name, const string &description, bool mandatory, const Params &keyvalues, const string &defkey, bool readonly)
+void IODoc::paramAddList(const std::string &name, const std::string &description, bool mandatory, const Params &keyvalues, const std::string &defkey, bool readonly)
 {
     Params param;
     param.Add("name", name);
@@ -103,7 +103,7 @@ void IODoc::paramAddList(const string &name, const string &description, bool man
     param_list_value[name] = keyvalues;
 }
 
-void IODoc::conditionAdd(const string &name, const string &description)
+void IODoc::conditionAdd(const std::string &name, const std::string &description)
 {
     Params p;
     p.Add("name", name);
@@ -111,7 +111,7 @@ void IODoc::conditionAdd(const string &name, const string &description)
     m_conditions[name] = p;
 }
 
-void IODoc::actionAdd(const string &name, const string &description)
+void IODoc::actionAdd(const std::string &name, const std::string &description)
 {
     Params p;
     p.Add("name", name);
@@ -119,12 +119,12 @@ void IODoc::actionAdd(const string &name, const string &description)
     m_actions[name] = p;
 }
 
-void IODoc::aliasAdd(string alias)
+void IODoc::aliasAdd(std::string alias)
 {
     m_aliases.push_back(alias);
 }
 
-bool IODoc::isAlias(string alias)
+bool IODoc::isAlias(std::string alias)
 {
     for (auto s: m_aliases)
     {
@@ -139,7 +139,7 @@ json_t *IODoc::genDocJson()
 {
     json_t *ret = json_object();
 
-    string desc;
+    std::string desc;
     if (!m_description.empty())
         desc += m_description;
     if (!m_description_base.empty())
@@ -182,10 +182,10 @@ json_t *IODoc::genDocJson()
     return ret;
 }
 
-string IODoc::genDocMd(const string iotype)
+std::string IODoc::genDocMd(const std::string iotype)
 {
-    string doc ="";
-    string name = m_name;
+    std::string doc ="";
+    std::string name = m_name;
 
     if (m_name.empty())
     {
@@ -280,7 +280,7 @@ string IODoc::genDocMd(const string iotype)
     return doc;
 }
 
-string IODoc::typeToString(ParamType t)
+std::string IODoc::typeToString(ParamType t)
 {
     switch (t)
     {
@@ -295,7 +295,7 @@ string IODoc::typeToString(ParamType t)
     return "unknown";
 }
 
-IODoc::ParamType IODoc::typeFromString(const string &t)
+IODoc::ParamType IODoc::typeFromString(const std::string &t)
 {
     if (t == "string") return TYPE_STRING;
     else if (t == "bool") return TYPE_BOOL;
@@ -304,4 +304,6 @@ IODoc::ParamType IODoc::typeFromString(const string &t)
     else if (t == "list") return TYPE_LIST;
 
     return TYPE_UNKOWN;
+}
+
 }

--- a/src/bin/calaos_server/IO/IODoc.h
+++ b/src/bin/calaos_server/IO/IODoc.h
@@ -24,6 +24,8 @@
 #include "Calaos.h"
 #include <Params.h>
 
+namespace Calaos {
+
 class IODoc
 {
 public:
@@ -39,32 +41,32 @@ public:
         TYPE_LIST,
     } ParamType;
 
-    void friendlyNameSet(const string &friendlyName);
-    void descriptionSet(const string &description);
-    void descriptionBaseSet(const string &description);
-    void linkAdd(const string &description, const string &link);
-    void paramAdd(const string &name, const string &description, ParamType type, bool mandatory, const string defaultval = string(), bool readonly = false);
-    void paramAddInt(const string &name, const string &description, int min, int max, bool mandatory, int defval = 0, bool readonly = false);
-    void paramAddFloat(const string &name, const string &description, bool mandatory, double min, double max, double defval = 0, bool readonly = false);
-    void paramAddList(const string &name, const string &description, bool mandatory, const Params &keyvalues, const string &defkey = string(), bool readonly = false);
-    void conditionAdd(const string &name, const string &description);
-    void actionAdd(const string &name, const string &description);
-    void aliasAdd(string alias);
+    void friendlyNameSet(const std::string &friendlyName);
+    void descriptionSet(const std::string &description);
+    void descriptionBaseSet(const std::string &description);
+    void linkAdd(const std::string &description, const std::string &link);
+    void paramAdd(const std::string &name, const std::string &description, ParamType type, bool mandatory, const std::string defaultval = std::string(), bool readonly = false);
+    void paramAddInt(const std::string &name, const std::string &description, int min, int max, bool mandatory, int defval = 0, bool readonly = false);
+    void paramAddFloat(const std::string &name, const std::string &description, bool mandatory, double min, double max, double defval = 0, bool readonly = false);
+    void paramAddList(const std::string &name, const std::string &description, bool mandatory, const Params &keyvalues, const std::string &defkey = std::string(), bool readonly = false);
+    void conditionAdd(const std::string &name, const std::string &description);
+    void actionAdd(const std::string &name, const std::string &description);
+    void aliasAdd(std::string alias);
 
-    bool isAlias(string alias);
+    bool isAlias(std::string alias);
 
     json_t *genDocJson();
-    string genDocMd(const string iotype);
+    std::string genDocMd(const std::string iotype);
 
 private:
-    string m_name;
-    string m_description_base;
-    string m_description;
+    std::string m_name;
+    std::string m_description_base;
+    std::string m_description;
 
-    vector<string> m_aliases;
-    vector<Params> m_links;
+    std::vector<std::string> m_aliases;
+    std::vector<Params> m_links;
 
-    typedef unordered_map<string, Params> ParamMap;
+   typedef std::unordered_map<std::string, Params> ParamMap;
 
     ParamMap m_parameters;
     ParamMap m_conditions;
@@ -73,9 +75,10 @@ private:
     //for parameter of type list. This contains a map of all key/values for the list of possible parameter values
     ParamMap param_list_value;
 
-    string typeToString(ParamType t);
-    ParamType typeFromString(const string &t);
+    std::string typeToString(ParamType t);
+    ParamType typeFromString(const std::string &t);
 };
 
+}
 
 #endif /* S_IODOC_H */

--- a/src/bin/calaos_server/IO/IOFactory.cpp
+++ b/src/bin/calaos_server/IO/IOFactory.cpp
@@ -21,9 +21,9 @@
 #include <IOFactory.h>
 #include <Ecore_File.h>
 
-using namespace Calaos;
+namespace Calaos {
 
-Registrar::Registrar(string type, function<IOBase *(Params &)> classFunc)
+Registrar::Registrar(std::string type, std::function<IOBase *(Params &)> classFunc)
 {
     IOFactory::Instance().RegisterClass(type, classFunc);
 }
@@ -67,19 +67,19 @@ IOBase *IOFactory::CreateIO(TiXmlElement *node)
     return io;
 }
 
-void IOFactory::genDocIO(string docPath)
+void IOFactory::genDocIO(std::string docPath)
 {
     Params p;
 
     json_t *j = json_object();
 
-    string mdPath = docPath + "/io_doc.md";
-    string jsonPath = docPath + "/io_doc.json";
+    std::string mdPath = docPath + "/io_doc.md";
+    std::string jsonPath = docPath + "/io_doc.json";
 
-    ofstream mdFile(mdPath, ofstream::out);
-    ofstream jsonFile(jsonPath, ofstream::out);
+    std::ofstream mdFile(mdPath, std::ofstream::out);
+    std::ofstream jsonFile(jsonPath, std::ofstream::out);
 
-    map<string, function<IOBase *(Params &)>> list(ioFunctionRegistry.begin(), ioFunctionRegistry.end());
+    std::map<std::string, std::function<IOBase *(Params &)>> list(ioFunctionRegistry.begin(), ioFunctionRegistry.end());
     for ( auto it = list.begin(); it != list.end(); ++it )
     {
         p.Add("type", origNameMap[it->first]);
@@ -98,7 +98,7 @@ void IOFactory::genDocIO(string docPath)
     mdFile.close();
 }
 
-void IOFactory::genDoc(string path)
+void IOFactory::genDoc(std::string path)
 {
     if (!ecore_file_exists(path.c_str()))
     {
@@ -115,3 +115,4 @@ void IOFactory::genDoc(string path)
     genDocIO(path);
 }
 
+}

--- a/src/bin/calaos_server/IO/IOFactory.h
+++ b/src/bin/calaos_server/IO/IOFactory.h
@@ -32,13 +32,13 @@ namespace Calaos
 class Registrar
 {
 public:
-    Registrar(string type, function<IOBase *(Params &)> classFunc);
+    Registrar(std::string type, std::function<IOBase *(Params &)> classFunc);
 };
 
 #define REGISTER_FACTORY(NAME, TYPE, RETURNCLASS) \
-static Registrar NAME##_reg_##RETURNCLASS(#NAME, \
-    function<RETURNCLASS *(Params &)>( \
-        [](Params &_p) -> RETURNCLASS * { return new TYPE(_p); } ));
+  static Calaos::Registrar NAME##_reg_##RETURNCLASS(#NAME,      \
+      std::function<RETURNCLASS *(Params &)>( \
+        [](Params &_p) -> Calaos::RETURNCLASS * { return new TYPE(_p); } ));
 
 #define REGISTER_IO_USERTYPE(NAME, TYPE) REGISTER_FACTORY(NAME, TYPE, IOBase)
 #define REGISTER_IO(TYPE) REGISTER_IO_USERTYPE(TYPE, TYPE)
@@ -48,26 +48,26 @@ class IOFactory
 private:
     IOFactory() {}
 
-    unordered_map<string, function<IOBase *(Params &)>> ioFunctionRegistry;
-    unordered_map<string, string> origNameMap;
+    std::unordered_map<std::string, std::function<IOBase *(Params &)>> ioFunctionRegistry;
+    std::unordered_map<std::string, std::string> origNameMap;
 
 public:
 
     void readParams(TiXmlElement *node, Params &p);
 
-    IOBase *CreateIO(string type, Params &params);
+    IOBase *CreateIO(std::string type, Params &params);
     IOBase *CreateIO(TiXmlElement *node);
 
-    void RegisterClass(string type, function<IOBase *(Params &)> classFunc)
+    void RegisterClass(std::string type, std::function<IOBase *(Params &)> classFunc)
     {
-        string orig = type;
+        std::string orig = type;
         std::transform(type.begin(), type.end(), type.begin(), Utils::to_lower());
         origNameMap[type] = orig;
         ioFunctionRegistry[type] = classFunc;
     }
 
-    void genDoc(string path);
-    void genDocIO(string docPath);
+    void genDoc(std::string path);
+    void genDocIO(std::string docPath);
 
     static IOFactory &Instance()
     {

--- a/src/bin/calaos_server/IO/InPlageHoraire.cpp
+++ b/src/bin/calaos_server/IO/InPlageHoraire.cpp
@@ -22,7 +22,7 @@
 #include "ListeRule.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(InPlageHoraire)
 REGISTER_IO_USERTYPE(TimeRange, InPlageHoraire)
@@ -71,7 +71,7 @@ void InPlageHoraire::hasChanged()
     if (!isEnabled()) return;
 
     bool val = false;
-    vector<TimeRange> *plage = NULL;
+    std::vector<TimeRange> *plage = NULL;
 
     struct tm *ctime = NULL;
     tzset(); //Force reload of timezone data
@@ -120,7 +120,7 @@ void InPlageHoraire::hasChanged()
     }
 }
 
-void InPlageHoraire::LoadRange(TiXmlElement *node, vector<TimeRange> &plage)
+void InPlageHoraire::LoadRange(TiXmlElement *node, std::vector<TimeRange> &plage)
 {
     TiXmlHandle docHandle(node);
     TiXmlElement *cnode = docHandle.FirstChildElement().ToElement();
@@ -129,13 +129,13 @@ void InPlageHoraire::LoadRange(TiXmlElement *node, vector<TimeRange> &plage)
         TimeRange h;
         if (cnode->Attribute("start_type"))
         {
-            from_string(string(cnode->Attribute("start_type")), h.start_type);
+            from_string(std::string(cnode->Attribute("start_type")), h.start_type);
             if (h.start_type < 0 || h.start_type > 3)
                 h.start_type = TimeRange::HTYPE_NORMAL;
         }
         if (cnode->Attribute("start_offset"))
         {
-            from_string(string(cnode->Attribute("start_offset")), h.start_offset);
+            from_string(std::string(cnode->Attribute("start_offset")), h.start_offset);
             if (h.start_offset < 0) h.start_offset = -1;
             if (h.start_offset > 0) h.start_offset = 1;
         }
@@ -145,13 +145,13 @@ void InPlageHoraire::LoadRange(TiXmlElement *node, vector<TimeRange> &plage)
 
         if (cnode->Attribute("end_type"))
         {
-            from_string(string(cnode->Attribute("end_type")), h.end_type);
+            from_string(std::string(cnode->Attribute("end_type")), h.end_type);
             if (h.end_type < 0 || h.end_type > 3)
                 h.end_type = TimeRange::HTYPE_NORMAL;
         }
         if (cnode->Attribute("end_offset"))
         {
-            from_string(string(cnode->Attribute("end_offset")), h.end_offset);
+            from_string(std::string(cnode->Attribute("end_offset")), h.end_offset);
             if (h.end_offset < 0) h.end_offset = -1;
             if (h.end_offset > 0) h.end_offset = 1;
         }
@@ -159,7 +159,7 @@ void InPlageHoraire::LoadRange(TiXmlElement *node, vector<TimeRange> &plage)
         if (cnode->Attribute("end_min")) h.emin = cnode->Attribute("end_min");
         if (cnode->Attribute("end_sec")) h.esec = cnode->Attribute("end_sec");
 
-        stringstream sstart, sstop;
+        std::stringstream sstart, sstop;
         if (h.start_type == TimeRange::HTYPE_NORMAL)
         {
             sstart << h.shour << ":" << h.smin << ":" << h.ssec;
@@ -259,13 +259,13 @@ bool InPlageHoraire::LoadFromXml(TiXmlElement *pnode)
     //try to load months
     if (pnode->Attribute("months"))
     {
-        string m = pnode->Attribute("months");
+        std::string m = pnode->Attribute("months");
         //reverse to have a left to right months representation
         std::reverse(m.begin(), m.end());
 
         try
         {
-            bitset<12> mset(m);
+            std::bitset<12> mset(m);
             months = mset;
         }
         catch(...)
@@ -298,11 +298,11 @@ bool InPlageHoraire::LoadFromXml(TiXmlElement *pnode)
     return true;
 }
 
-void InPlageHoraire::SaveRange(TiXmlElement *node, string day, vector<TimeRange> &plage)
+void InPlageHoraire::SaveRange(TiXmlElement *node, std::string day, std::vector<TimeRange> &plage)
 {
     if (plage.size() <= 0) return; //don't create node if empty
 
-    TiXmlElement *day_node = new TiXmlElement(string("calaos:") + day);
+    TiXmlElement *day_node = new TiXmlElement(std::string("calaos:") + day);
     node->LinkEndChild(day_node);
 
     for (uint i = 0;i < plage.size();i++)
@@ -361,15 +361,15 @@ bool InPlageHoraire::SaveToXml(TiXmlElement *node)
 
     for (int i = 0;i < get_params().size();i++)
     {
-        string key, val;
+        std::string key, val;
         get_params().get_item(i, key, val);
         cnode->SetAttribute(key, val);
     }
 
     //Save months
-    stringstream ssmonth;
+    std::stringstream ssmonth;
     ssmonth << months;
-    string str = ssmonth.str();
+    std::string str = ssmonth.str();
     std::reverse(str.begin(), str.end());
 
     cnode->SetAttribute("months", str);
@@ -383,4 +383,6 @@ bool InPlageHoraire::SaveToXml(TiXmlElement *node)
     SaveRange(cnode, "dimanche", plg_sunday);
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/InPlageHoraire.h
+++ b/src/bin/calaos_server/IO/InPlageHoraire.h
@@ -33,16 +33,16 @@ class InPlageHoraire : public IOBase
 protected:
     bool value;
 
-    vector<TimeRange> plg_monday;
-    vector<TimeRange> plg_tuesday;
-    vector<TimeRange> plg_wednesday;
-    vector<TimeRange> plg_thursday;
-    vector<TimeRange> plg_friday;
-    vector<TimeRange> plg_saturday;
-    vector<TimeRange> plg_sunday;
+    std::vector<TimeRange> plg_monday;
+    std::vector<TimeRange> plg_tuesday;
+    std::vector<TimeRange> plg_wednesday;
+    std::vector<TimeRange> plg_thursday;
+    std::vector<TimeRange> plg_friday;
+    std::vector<TimeRange> plg_saturday;
+    std::vector<TimeRange> plg_sunday;
 
-    void LoadRange(TiXmlElement *node, vector<TimeRange> &plage);
-    void SaveRange(TiXmlElement *node, string day, vector<TimeRange> &plage);
+    void LoadRange(TiXmlElement *node, std::vector<TimeRange> &plage);
+    void SaveRange(TiXmlElement *node, std::string day, std::vector<TimeRange> &plage);
 
 public:
     InPlageHoraire(Params &p);
@@ -53,7 +53,7 @@ public:
 
     //Here we store months when plagehoraire is active
     enum { JANUARY = 0, FEBRUARY, MARCH, APRIL, MAY, JUNE, JULY, AUGUST, SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER };
-    bitset<12> months;
+    std::bitset<12> months;
 
     void AddMonday(TimeRange &horaire) { plg_monday.push_back(horaire); }
     void AddTuesday(TimeRange &horaire) { plg_tuesday.push_back(horaire); }
@@ -63,21 +63,21 @@ public:
     void AddSaturday(TimeRange &horaire) { plg_saturday.push_back(horaire); }
     void AddSunday(TimeRange &horaire) { plg_sunday.push_back(horaire); }
 
-    vector<TimeRange> &getMonday() { return plg_monday; }
-    vector<TimeRange> &getTuesday() { return plg_tuesday; }
-    vector<TimeRange> &getWednesday() { return plg_wednesday; }
-    vector<TimeRange> &getThursday() { return plg_thursday; }
-    vector<TimeRange> &getFriday() { return plg_friday; }
-    vector<TimeRange> &getSaturday() { return plg_saturday; }
-    vector<TimeRange> &getSunday() { return plg_sunday; }
+    std::vector<TimeRange> &getMonday() { return plg_monday; }
+    std::vector<TimeRange> &getTuesday() { return plg_tuesday; }
+    std::vector<TimeRange> &getWednesday() { return plg_wednesday; }
+    std::vector<TimeRange> &getThursday() { return plg_thursday; }
+    std::vector<TimeRange> &getFriday() { return plg_friday; }
+    std::vector<TimeRange> &getSaturday() { return plg_saturday; }
+    std::vector<TimeRange> &getSunday() { return plg_sunday; }
 
-    void setMonday(vector<TimeRange> &h) { plg_monday = h; }
-    void setTuesday(vector<TimeRange> &h) { plg_tuesday = h; }
-    void setWednesday(vector<TimeRange> &h) { plg_wednesday = h; }
-    void setThursday(vector<TimeRange> &h) { plg_thursday = h; }
-    void setFriday(vector<TimeRange> &h) { plg_friday = h; }
-    void setSaturday(vector<TimeRange> &h) { plg_saturday = h; }
-    void setSunday(vector<TimeRange> &h) { plg_sunday = h; }
+    void setMonday(std::vector<TimeRange> &h) { plg_monday = h; }
+    void setTuesday(std::vector<TimeRange> &h) { plg_tuesday = h; }
+    void setWednesday(std::vector<TimeRange> &h) { plg_wednesday = h; }
+    void setThursday(std::vector<TimeRange> &h) { plg_thursday = h; }
+    void setFriday(std::vector<TimeRange> &h) { plg_friday = h; }
+    void setSaturday(std::vector<TimeRange> &h) { plg_saturday = h; }
+    void setSunday(std::vector<TimeRange> &h) { plg_sunday = h; }
 
     void clear();
 

--- a/src/bin/calaos_server/IO/InputAnalog.cpp
+++ b/src/bin/calaos_server/IO/InputAnalog.cpp
@@ -23,7 +23,7 @@
 #include "Ecore.h"
 #include "CalaosConfig.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 InputAnalog::InputAnalog(Params &p):
     IOBase(p, IOBase::IO_INPUT),
@@ -54,7 +54,7 @@ InputAnalog::InputAnalog(Params &p):
 
     readConfig();
 
-    string v;
+    std::string v;
     if (Config::Instance().ReadValueIO(get_param("id"), v) &&
         Utils::is_of_type<double>(v))
         Utils::from_string(v, value);
@@ -174,4 +174,6 @@ bool InputAnalog::set_value(double v)
     emitChange();
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/InputString.cpp
+++ b/src/bin/calaos_server/IO/InputString.cpp
@@ -20,8 +20,7 @@
  ******************************************************************************/
 #include "InputString.h"
 
-using namespace Calaos;
-using namespace Utils;
+namespace Calaos {
 
 InputString::InputString(Params &p):
     IOBase(p, IOBase::IO_INPUT)
@@ -49,9 +48,10 @@ void InputString::emitChange()
     EmitSignalIO();
 }
 
-string InputString::get_value_string()
+std::string InputString::get_value_string()
 {
     readValue();
     return value;
 }
 
+}

--- a/src/bin/calaos_server/IO/InputString.h
+++ b/src/bin/calaos_server/IO/InputString.h
@@ -30,7 +30,7 @@ namespace Calaos
 class InputString : public IOBase
 {
 protected:
-    string value;
+    std::string value;
     double frequency;
     void readConfig();
 
@@ -43,7 +43,7 @@ public:
 
     DATA_TYPE get_type() { return TSTRING; }
 
-    string get_value_string();
+    std::string get_value_string();
 };
 
 }

--- a/src/bin/calaos_server/IO/InputSwitch.cpp
+++ b/src/bin/calaos_server/IO/InputSwitch.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "InputSwitch.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 InputSwitch::InputSwitch(Params &p):
     IOBase(p, IOBase::IO_INPUT),
@@ -61,4 +61,6 @@ void InputSwitch::emitChanges()
 
     cInfoDom("input") << get_param("id") << ": " << value;
     EmitSignalIO();
+}
+
 }

--- a/src/bin/calaos_server/IO/InputSwitchLongPress.cpp
+++ b/src/bin/calaos_server/IO/InputSwitchLongPress.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "InputSwitchLongPress.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 InputSwitchLongPress::InputSwitchLongPress(Params &p):
     IOBase(p, IOBase::IO_INPUT),
@@ -98,4 +98,6 @@ bool InputSwitchLongPress::set_value(double v)
     emitChange();
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/InputSwitchTriple.cpp
+++ b/src/bin/calaos_server/IO/InputSwitchTriple.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "InputSwitchTriple.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 InputSwitchTriple::InputSwitchTriple(Params &p):
     IOBase(p, IOBase::IO_INPUT),
@@ -107,3 +107,4 @@ bool InputSwitchTriple::set_value(double v)
     return true;
 }
 
+}

--- a/src/bin/calaos_server/IO/InputTemp.cpp
+++ b/src/bin/calaos_server/IO/InputTemp.cpp
@@ -23,7 +23,7 @@
 #include "ListeRule.h"
 #include "CalaosConfig.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 InputTemp::InputTemp(Params &p):
     IOBase(p, IOBase::IO_INPUT),
@@ -80,7 +80,7 @@ InputTemp::InputTemp(Params &p):
     else
         precision = 2;
 
-    string v;
+    std::string v;
     if (Config::Instance().ReadValueIO(get_param("id"), v) &&
         Utils::is_of_type<double>(v))
         Utils::from_string(v, value);
@@ -136,4 +136,6 @@ bool InputTemp::set_value(double v)
     emitChange();
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/InputTime.cpp
+++ b/src/bin/calaos_server/IO/InputTime.cpp
@@ -22,8 +22,7 @@
 #include "ListeRule.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
-using namespace Utils;
+namespace Calaos {
 
 REGISTER_IO(InputTime)
 
@@ -123,4 +122,6 @@ void InputTime::hasChanged()
                              { { "id", get_param("id") },
                                { "state", val?"true":"false" } });
     }
+}
+
 }

--- a/src/bin/calaos_server/IO/InputTimer.cpp
+++ b/src/bin/calaos_server/IO/InputTimer.cpp
@@ -22,7 +22,7 @@
 #include "ListeRule.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(InputTimer)
 
@@ -65,7 +65,7 @@ InputTimer::~InputTimer()
     cDebugDom("input");
 }
 
-bool InputTimer::set_value(string command)
+bool InputTimer::set_value(std::string command)
 {
     if (!isEnabled()) return true;
 
@@ -88,8 +88,8 @@ bool InputTimer::set_value(string command)
     else
     {
         //set the time
-        vector<string> valSplit;
-        vector<string>::reverse_iterator it;
+        std::vector<std::string> valSplit;
+        std::vector<std::string>::reverse_iterator it;
         split(command, valSplit, ":");
         int i = 0;
 
@@ -185,5 +185,7 @@ void InputTimer::TimerDone()
 
 void InputTimer::hasChanged()
 {
+
+}
 
 }

--- a/src/bin/calaos_server/IO/InputTimer.h
+++ b/src/bin/calaos_server/IO/InputTimer.h
@@ -34,7 +34,7 @@ protected:
     int hour, minute, second, ms;
 
     EcoreTimer *timer;
-    string value;
+    std::string value;
     bool start;
 
     void StartTimer();
@@ -47,10 +47,10 @@ public:
 
     //Input
     virtual DATA_TYPE get_type() { return TSTRING; }
-    virtual string get_value_string() { return value; }
+    virtual std::string get_value_string() { return value; }
 
     //Output
-    virtual bool set_value(string val);
+    virtual bool set_value(std::string val);
 
     virtual void hasChanged();
 };

--- a/src/bin/calaos_server/IO/IntValue.cpp
+++ b/src/bin/calaos_server/IO/IntValue.cpp
@@ -22,7 +22,7 @@
 #include "CalaosConfig.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO_USERTYPE(InternalInt, Internal)
 REGISTER_IO_USERTYPE(InternalBool, Internal)
@@ -127,7 +127,7 @@ bool Internal::set_value(double val)
     return true;
 }
 
-bool Internal::set_value(string val)
+bool Internal::set_value(std::string val)
 {
     if (!isEnabled()) return true;
 
@@ -151,7 +151,7 @@ bool Internal::set_value(string val)
         }
         else if (val.compare(0, 4, "inc ") == 0)
         {
-            string t = val;
+            std::string t = val;
             t.erase(0, 4);
 
             double step = 1.0;
@@ -162,7 +162,7 @@ bool Internal::set_value(string val)
         }
         else if (val.compare(0, 4, "dec ") == 0)
         {
-            string t = val;
+            std::string t = val;
             t.erase(0, 4);
 
             double step = 1.0;
@@ -200,7 +200,7 @@ bool Internal::set_value(string val)
     {
         if (val.compare(0, 8, "impulse ") == 0)
         {
-            string tmp = val;
+            std::string tmp = val;
             tmp.erase(0, 8);
             // classic impulse, output goes false after <time> miliseconds
             if (Utils::is_of_type<int>(tmp))
@@ -248,7 +248,7 @@ bool Internal::set_value(string val)
     return true;
 }
 
-void Internal::impulse_extended(string pattern)
+void Internal::impulse_extended(std::string pattern)
 {
     /* Extended impulse to do blinking.
          * It uses a pattern like this one:
@@ -264,7 +264,7 @@ void Internal::impulse_extended(string pattern)
     cInfoDom("output") << get_param("id") << ": got extended impulse action, parsing blinking pattern...";
 
     //Parse the string
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(pattern, tokens);
 
     bool state = true;
@@ -376,7 +376,7 @@ void Internal::LoadFromConfig()
 {
     if (get_param("save") != "true") return;
 
-    string saved_value;
+    std::string saved_value;
     if (!Config::Instance().ReadValueIO(get_param("id"), saved_value))
     {
         saved_value = get_param("value");
@@ -409,11 +409,13 @@ bool Internal::SaveToXml(TiXmlElement *node)
 
     for (int i = 0;i < get_params().size();i++)
     {
-        string key, value;
+        std::string key, value;
         get_params().get_item(i, key, value);
         if (key == "value" && get_param("save") != "true") continue;
         cnode->SetAttribute(key, value);
     }
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/IntValue.h
+++ b/src/bin/calaos_server/IO/IntValue.h
@@ -33,14 +33,14 @@ class Internal : public IOBase
 protected:
     bool bvalue;
     double dvalue;
-    string svalue;
+    std::string svalue;
 
     EcoreTimer *timer = NULL;
 
-    vector<BlinkInfo> blinks;
+    std::vector<BlinkInfo> blinks;
     int current_blink;
 
-    void impulse_extended(string pattern);
+    void impulse_extended(std::string pattern);
     void TimerImpulseExtended();
 
     void Save(); //save value to file
@@ -60,11 +60,11 @@ public:
 
     virtual bool get_value_bool() { return bvalue; }
     virtual double get_value_double() { return dvalue; }
-    virtual string get_value_string() { return svalue; }
+    virtual std::string get_value_string() { return svalue; }
 
     virtual bool set_value(bool val);
     virtual bool set_value(double val);
-    virtual bool set_value(string val);
+    virtual bool set_value(std::string val);
 
     virtual bool SaveToXml(TiXmlElement *node);
 };

--- a/src/bin/calaos_server/IO/KNX/KNXCtrl.h
+++ b/src/bin/calaos_server/IO/KNX/KNXCtrl.h
@@ -24,6 +24,8 @@
 #include "Calaos.h"
 #include "ExternProc.h"
 
+namespace Calaos {
+
 class KNXValue
 {
 public:
@@ -62,14 +64,14 @@ public:
     void setEis(int e) { eis = e; }
 
     json_t *toJson() const;
-    string toString() const;
+    std::string toString() const;
     bool toBool() const;
     float toFloat() const;
     int toInt() const;
     char toChar() const;
 
     static KNXValue fromJson(json_t *jval);
-    static KNXValue fromString(const string &val, int eis = 0);
+    static KNXValue fromString(const std::string &val, int eis = 0);
     static KNXValue fromBool(bool val, int eis = 0);
     static KNXValue fromFloat(float val, int eis = 0);
     static KNXValue fromInt(int val, int eis = 0);
@@ -82,32 +84,34 @@ private:
     int value_int = 0;
     float value_float = 0.0;
     unsigned char value_char = 0;
-    string value_string;
+    std::string value_string;
 };
 
 class KNXCtrl: public sigc::trackable
 {
 private:
-    KNXCtrl(const string host);
+    KNXCtrl(const std::string host);
 
     ExternProcServer *process;
     ExternProcServer *processMonitor;
 
-    unordered_map<string, KNXValue> knxCache;
+    std::unordered_map<std::string, KNXValue> knxCache;
 
-    void processNewMessage(const string &msg);
+    void processNewMessage(const std::string &msg);
 
 public:
-    static shared_ptr<KNXCtrl> Instance(const string &host);
+    static std::shared_ptr<KNXCtrl> Instance(const std::string &host);
     ~KNXCtrl();
 
-    // void valueChanged(const string &group_addr, const KNXValue &value)
-    sigc::signal<void, const string &, const KNXValue &> valueChanged;
+    // void valueChanged(const std::string &group_addr, const KNXValue &value)
+    sigc::signal<void, const std::string &, const KNXValue &> valueChanged;
 
-    KNXValue getValue(const string &group_addr);
+    KNXValue getValue(const std::string &group_addr);
 
-    void writeValue(const string &group_addr, const KNXValue &value);
-    void readValue(const string &group_addr, int eis = 0);
+    void writeValue(const std::string &group_addr, const KNXValue &value);
+    void readValue(const std::string &group_addr, int eis = 0);
 };
 
+}
+  
 #endif // KNXCTRL_H

--- a/src/bin/calaos_server/IO/KNX/KNXExternProc_cli.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXExternProc_cli.cpp
@@ -21,6 +21,8 @@
 #include "KNXExternProc_main.h"
 #include <time.h>
 
+namespace Calaos {
+
 class EibNetMuxObj
 {
 public:
@@ -333,4 +335,6 @@ KNXValue KNXValue::fromJson(json_t *jval)
     v.value_string = p["value_string"];
 
     return v;
+}
+
 }

--- a/src/bin/calaos_server/IO/KNX/KNXExternProc_main.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXExternProc_main.cpp
@@ -20,6 +20,7 @@
  ******************************************************************************/
 #include "KNXExternProc_main.h"
 
+namespace Calaos {
 void KNXProcess::readTimeout()
 {
     connectEibNetMux(); //try reconnecting to eibnetmux
@@ -290,4 +291,6 @@ void KNXProcess::writeKnxValue(const string &group_addr, const KNXValue &value)
     free(data);
 }
 
-EXTERN_PROC_CLIENT_MAIN(KNXProcess)
+}
+
+EXTERN_PROC_CLIENT_MAIN(Calaoss::KNXProcess)

--- a/src/bin/calaos_server/IO/KNX/KNXInputAnalog.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXInputAnalog.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "KNXCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(KNXInputAnalog)
 
@@ -36,11 +36,11 @@ KNXInputAnalog::KNXInputAnalog(Params &p):
     ioDoc->paramAdd("knx_group", _("KNX Group address, Ex: x/y/z"), IODoc::TYPE_STRING, true);
     ioDoc->paramAddInt("eis", _("KNX EIS (Data type)"), 0, 15, false, KNXValue::EIS_Value_Int);
 
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
 
     //KNXCtrl::Instance(get_param("host"))->readValue(knx_group, );
 
-    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const string group_addr, const KNXValue &)
+    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const std::string group_addr, const KNXValue &)
     {
         if (group_addr != get_param("knx_group")) return;
         readValue();
@@ -55,7 +55,7 @@ KNXInputAnalog::~KNXInputAnalog()
 
 void KNXInputAnalog::readValue()
 {
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
     int eis;
     Utils::from_string(get_param("eis"), eis);
 
@@ -67,4 +67,6 @@ void KNXInputAnalog::readValue()
         value = val.toInt();
         emitChange();
     }
+}
+
 }

--- a/src/bin/calaos_server/IO/KNX/KNXInputSwitch.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXInputSwitch.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "KNXCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(KNXInputSwitch)
 
@@ -35,11 +35,11 @@ KNXInputSwitch::KNXInputSwitch(Params &p):
     ioDoc->linkAdd("eibnetmux", _("http://eibnetmux.sourceforge.net"));
     ioDoc->paramAdd("knx_group", _("KNX Group address, Ex: x/y/z"), IODoc::TYPE_STRING, true);
 
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
 
     //KNXCtrl::Instance(get_param("host"))->readValue(knx_group, KNXValue::EIS_Switch_OnOff);
 
-    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const string group_addr, const KNXValue &)
+    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const std::string group_addr, const KNXValue &)
     {
         if (group_addr != get_param("knx_group")) return;
         hasChanged();
@@ -54,9 +54,11 @@ KNXInputSwitch::~KNXInputSwitch()
 
 bool KNXInputSwitch::readValue()
 {
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
 
     KNXValue val = KNXCtrl::Instance(get_param("host"))->getValue(knx_group);
 
     return val.toBool();
+}
+
 }

--- a/src/bin/calaos_server/IO/KNX/KNXInputSwitchLongPress.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXInputSwitchLongPress.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "KNXCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(KNXInputSwitchLongPress)
 
@@ -35,11 +35,11 @@ KNXInputSwitchLongPress::KNXInputSwitchLongPress(Params &p):
     ioDoc->linkAdd("eibnetmux", _("http://eibnetmux.sourceforge.net"));
     ioDoc->paramAdd("knx_group", _("KNX Group address, Ex: x/y/z"), IODoc::TYPE_STRING, true);
 
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
 
     //KNXCtrl::Instance(get_param("host"))->readValue(knx_group, KNXValue::EIS_Switch_OnOff);
 
-    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const string group_addr, const KNXValue &)
+    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const std::string group_addr, const KNXValue &)
     {
         if (group_addr != get_param("knx_group")) return;
         hasChanged();
@@ -54,9 +54,11 @@ KNXInputSwitchLongPress::~KNXInputSwitchLongPress()
 
 bool KNXInputSwitchLongPress::readValue()
 {
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
 
     KNXValue val = KNXCtrl::Instance(get_param("host"))->getValue(knx_group);
 
     return val.toBool();
+}
+
 }

--- a/src/bin/calaos_server/IO/KNX/KNXInputSwitchTriple.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXInputSwitchTriple.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "KNXCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(KNXInputSwitchTriple)
 
@@ -35,11 +35,11 @@ KNXInputSwitchTriple::KNXInputSwitchTriple(Params &p):
     ioDoc->linkAdd("eibnetmux", _("http://eibnetmux.sourceforge.net"));
     ioDoc->paramAdd("knx_group", _("KNX Group address, Ex: x/y/z"), IODoc::TYPE_STRING, true);
 
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
 
     //KNXCtrl::Instance(get_param("host"))->readValue(knx_group, KNXValue::EIS_Switch_OnOff);
 
-    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const string group_addr, const KNXValue &)
+    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const std::string group_addr, const KNXValue &)
     {
         if (group_addr != get_param("knx_group")) return;
         hasChanged();
@@ -54,9 +54,11 @@ KNXInputSwitchTriple::~KNXInputSwitchTriple()
 
 bool KNXInputSwitchTriple::readValue()
 {
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
 
     KNXValue val = KNXCtrl::Instance(get_param("host"))->getValue(knx_group);
 
     return val.toBool();
+}
+
 }

--- a/src/bin/calaos_server/IO/KNX/KNXInputTemp.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXInputTemp.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "KNXCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(KNXInputTemp)
 
@@ -36,11 +36,11 @@ KNXInputTemp::KNXInputTemp(Params &p):
     ioDoc->paramAdd("knx_group", _("KNX Group address, Ex: x/y/z"), IODoc::TYPE_STRING, true);
     ioDoc->paramAddInt("eis", _("KNX EIS (Data type)"), 0, 15, false, KNXValue::EIS_Value_Int);
 
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
 
     //KNXCtrl::Instance(get_param("host"))->readValue(knx_group, );
 
-    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const string group_addr, const KNXValue &)
+    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const std::string group_addr, const KNXValue &)
     {
         if (group_addr != get_param("knx_group")) return;
         readValue();
@@ -55,7 +55,7 @@ KNXInputTemp::~KNXInputTemp()
 
 void KNXInputTemp::readValue()
 {
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
     int eis;
     Utils::from_string(get_param("eis"), eis);
 
@@ -67,4 +67,6 @@ void KNXInputTemp::readValue()
         value = val.toInt();
         emitChange();
     }
+}
+
 }

--- a/src/bin/calaos_server/IO/KNX/KNXOutputAnalog.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXOutputAnalog.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "KNXCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(KNXOutputAnalog)
 
@@ -36,11 +36,11 @@ KNXOutputAnalog::KNXOutputAnalog(Params &p):
     ioDoc->paramAdd("knx_group", _("KNX Group address, Ex: x/y/z"), IODoc::TYPE_STRING, true);
     ioDoc->paramAddInt("eis", _("KNX EIS (Data type)"), 0, 15, false, KNXValue::EIS_Value_Int);
 
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
 
     //KNXCtrl::Instance(get_param("host"))->readValue(knx_group, );
 
-    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const string group_addr, const KNXValue &val)
+    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const std::string group_addr, const KNXValue &val)
     {
         if (group_addr != get_param("knx_group")) return;
 
@@ -67,6 +67,8 @@ void KNXOutputAnalog::set_value_real(double val)
     Utils::from_string(get_param("eis"), eis);
     KNXValue kval = KNXValue::fromFloat(val, eis);
 
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
     KNXCtrl::Instance(get_param("host"))->writeValue(knx_group, kval);
+}
+
 }

--- a/src/bin/calaos_server/IO/KNX/KNXOutputLight.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXOutputLight.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "KNXCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(KNXOutputLight)
 
@@ -37,17 +37,17 @@ KNXOutputLight::KNXOutputLight(Params &p):
     ioDoc->linkAdd("eibnetmux", _("http://eibnetmux.sourceforge.net"));
     ioDoc->paramAdd("knx_group", _("KNX Group address, Ex: x/y/z"), IODoc::TYPE_STRING, true);
 
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
 
     //KNXCtrl::Instance(get_param("host"))->readValue(knx_group, KNXValue::EIS_Switch_OnOff);
 
-    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const string group_addr, const KNXValue &val)
+    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const std::string group_addr, const KNXValue &val)
     {
         if (group_addr != get_param("knx_group")) return;
         if (val.toBool())
-            set_value(string("set_state true"));
+            set_value(std::string("set_state true"));
         else
-            set_value(string("set_state false"));
+            set_value(std::string("set_state false"));
     });
 
     cInfoDom("input") << "knx_group: " << knx_group;
@@ -61,8 +61,10 @@ bool KNXOutputLight::set_value_real(bool val)
 {
     KNXValue kval = KNXValue::fromInt(val?1:0, 1);
 
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
     KNXCtrl::Instance(get_param("host"))->writeValue(knx_group, kval);
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/KNX/KNXOutputLightDimmer.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXOutputLightDimmer.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "KNXCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(KNXOutputLightDimmer)
 
@@ -37,11 +37,11 @@ KNXOutputLightDimmer::KNXOutputLightDimmer(Params &p):
     ioDoc->linkAdd("eibnetmux", _("http://eibnetmux.sourceforge.net"));
     ioDoc->paramAdd("knx_group", _("KNX Group address, Ex: x/y/z"), IODoc::TYPE_STRING, true);
 
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
 
     //KNXCtrl::Instance(get_param("host"))->readValue(knx_group, KNXValue::EIS_Switch_OnOff);
 
-    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const string group_addr, const KNXValue &v)
+    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const std::string group_addr, const KNXValue &v)
     {
         if (group_addr != get_param("knx_group")) return;
         KNXValue val = v;
@@ -62,8 +62,10 @@ bool KNXOutputLightDimmer::set_value_real(int val)
 {
     KNXValue kval = KNXValue::fromInt(val, KNXValue::EIS_Dim_UpDown);
 
-    string knx_group = get_param("knx_group");
+    std::string knx_group = get_param("knx_group");
     KNXCtrl::Instance(get_param("host"))->writeValue(knx_group, kval);
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/KNX/KNXOutputLightRGB.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXOutputLightRGB.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "KNXCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(KNXOutputLightRGB)
 
@@ -41,7 +41,7 @@ KNXOutputLightRGB::KNXOutputLightRGB(Params &p):
 
     //KNXCtrl::Instance(get_param("host"))->readValue(knx_group, KNXValue::EIS_Switch_OnOff);
 
-    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const string group_addr, const KNXValue &v)
+    KNXCtrl::Instance(get_param("host"))->valueChanged.connect([=](const std::string group_addr, const KNXValue &v)
     {
 //        if (group_addr != get_param("knx_group")) return;
 //        KNXValue val = v;
@@ -58,9 +58,9 @@ KNXOutputLightRGB::~KNXOutputLightRGB()
 
 void KNXOutputLightRGB::setColorReal(const ColorValue &c, bool s)
 {
-    string knx_group_red = get_param("knx_group_red");
-    string knx_group_green = get_param("knx_group_green");
-    string knx_group_blue = get_param("knx_group_blue");
+    std::string knx_group_red = get_param("knx_group_red");
+    std::string knx_group_green = get_param("knx_group_green");
+    std::string knx_group_blue = get_param("knx_group_blue");
 
     int r = 0, g = 0, b = 0;
     if (s)
@@ -77,4 +77,6 @@ void KNXOutputLightRGB::setColorReal(const ColorValue &c, bool s)
     KNXCtrl::Instance(get_param("host"))->writeValue(knx_group_green, kval);
     kval = KNXValue::fromInt(b, KNXValue::EIS_Dim_UpDown);
     KNXCtrl::Instance(get_param("host"))->writeValue(knx_group_blue, kval);
+}
+
 }

--- a/src/bin/calaos_server/IO/KNX/KNXOutputShutter.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXOutputShutter.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "KNXCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(KNXOutputShutter)
 
@@ -45,7 +45,7 @@ void KNXOutputShutter::setOutputUp(bool enable)
 {
     KNXValue kval = KNXValue::fromInt(enable?1:0, 1);
 
-    string knx_group = get_param("knx_group_up");
+    std::string knx_group = get_param("knx_group_up");
     KNXCtrl::Instance(get_param("host"))->writeValue(knx_group, kval);
 }
 
@@ -53,6 +53,8 @@ void KNXOutputShutter::setOutputDown(bool enable)
 {
     KNXValue kval = KNXValue::fromInt(enable?1:0, 1);
 
-    string knx_group = get_param("knx_group_down");
+    std::string knx_group = get_param("knx_group_down");
     KNXCtrl::Instance(get_param("host"))->writeValue(knx_group, kval);
+}
+
 }

--- a/src/bin/calaos_server/IO/KNX/KNXOutputShutterSmart.cpp
+++ b/src/bin/calaos_server/IO/KNX/KNXOutputShutterSmart.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "KNXCtrl.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(KNXOutputShutterSmart)
 
@@ -45,7 +45,7 @@ void KNXOutputShutterSmart::setOutputUp(bool enable)
 {
     KNXValue kval = KNXValue::fromInt(enable?1:0, 1);
 
-    string knx_group = get_param("knx_group_up");
+    std::string knx_group = get_param("knx_group_up");
     KNXCtrl::Instance(get_param("host"))->writeValue(knx_group, kval);
 }
 
@@ -53,6 +53,8 @@ void KNXOutputShutterSmart::setOutputDown(bool enable)
 {
     KNXValue kval = KNXValue::fromInt(enable?1:0, 1);
 
-    string knx_group = get_param("knx_group_down");
+    std::string knx_group = get_param("knx_group_down");
     KNXCtrl::Instance(get_param("host"))->writeValue(knx_group, kval);
+}
+
 }

--- a/src/bin/calaos_server/IO/LAN/PingInputSwitch.cpp
+++ b/src/bin/calaos_server/IO/LAN/PingInputSwitch.cpp
@@ -22,7 +22,7 @@
 #include "IOFactory.h"
 #include "EcoreTimer.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(PingInputSwitch)
 
@@ -66,12 +66,12 @@ bool PingInputSwitch::readValue()
 
 void PingInputSwitch::doPing()
 {
-    string host = get_param("host");
-    string timeoutVal = "";
+    std::string host = get_param("host");
+    std::string timeoutVal = "";
     if (Utils::is_of_type<int>(get_param("timeout")))
         timeoutVal = "-W " + get_param("timeout");
 
-    string cmd = "ping -c 1 " + timeoutVal + " " + host;
+    std::string cmd = "ping -c 1 " + timeoutVal + " " + host;
     cDebugDom("input") << "Starting ping: " << cmd;
 
     ping_exe = ecore_exe_run(cmd.c_str(), this);
@@ -102,4 +102,6 @@ Eina_Bool PingInputSwitch_proc_del(void *data, int type, void *event)
     in->hasChanged();
 
     return ECORE_CALLBACK_RENEW;
+}
+
 }

--- a/src/bin/calaos_server/IO/LAN/PingInputSwitch.h
+++ b/src/bin/calaos_server/IO/LAN/PingInputSwitch.h
@@ -24,7 +24,7 @@
 #include "InputSwitch.h"
 #include <Ecore.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 class PingInputSwitch: public InputSwitch
 {
@@ -44,4 +44,6 @@ public:
     virtual ~PingInputSwitch();
 };
 
+}
+  
 #endif // PINGINPUTSWITCH_H

--- a/src/bin/calaos_server/IO/LAN/WOLOutputBool.cpp
+++ b/src/bin/calaos_server/IO/LAN/WOLOutputBool.cpp
@@ -21,7 +21,7 @@
 #include "WOLOutputBool.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WOLOutputBool)
 
@@ -102,7 +102,7 @@ bool WOLOutputBool::set_value(bool val)
     return true;
 }
 
-bool WOLOutputBool::set_value(string val)
+bool WOLOutputBool::set_value(std::string val)
 {
     return set_value(val == "true");
 }
@@ -119,7 +119,7 @@ void WOLOutputBool::doWakeOnLan()
         return h;
     };
 
-    string addr = get_param("address");
+    std::string addr = get_param("address");
     Utils::replace_str(addr, ":", "");
     Utils::replace_str(addr, "-", "");
     Utils::replace_str(addr, ".", "");
@@ -141,11 +141,11 @@ void WOLOutputBool::doWakeOnLan()
         return;
     }
 
-    vector<uint8_t> address;
+    std::vector<uint8_t> address;
     for (int i = 0;i < 12;i += 2)
         address.push_back((parseHex(addr[i]) << 4) | uint8_t(parseHex(addr[i + 1])));
 
-    vector<uint8_t> magicPacket;
+    std::vector<uint8_t> magicPacket;
     magicPacket.reserve(6 + 6 * 16);
 
     // First 6bytes, 0xFF
@@ -185,4 +185,6 @@ void WOLOutputBool::timerTimeout()
                            { "state", "false" } });
 
     DELETE_NULL(timerState);
+}
+
 }

--- a/src/bin/calaos_server/IO/LAN/WOLOutputBool.h
+++ b/src/bin/calaos_server/IO/LAN/WOLOutputBool.h
@@ -26,7 +26,7 @@
 #include <Ecore_Con.h>
 #include "EcoreTimer.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 class WOLOutputBool: public IOBase
 {
@@ -55,7 +55,9 @@ public:
 
     virtual bool set_value(bool val);
     virtual bool get_value_bool() { return value; }
-    virtual bool set_value(string val);
+    virtual bool set_value(std::string val);
 };
 
+}
+  
 #endif // PINGINPUTSWITCH_H

--- a/src/bin/calaos_server/IO/LimitlessLED/Milight.cpp
+++ b/src/bin/calaos_server/IO/LimitlessLED/Milight.cpp
@@ -26,9 +26,9 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-using namespace Calaos;
+namespace Calaos {
 
-Milight::Milight(string h, int p):
+Milight::Milight(std::string h, int p):
     host(h),
     port(p)
 {
@@ -151,4 +151,6 @@ ushort Milight::calcMilightColor(const ColorValue &color)
     cDebugDom("milight") << "HSL Hue: " << color.getHSLHue();
     ushort mcolor = (256 + 176 - (int)(color.getHSLHue() / 360.0 * 255.0)) % 256;
     return mcolor + 0xFA;
+}
+
 }

--- a/src/bin/calaos_server/IO/LimitlessLED/Milight.h
+++ b/src/bin/calaos_server/IO/LimitlessLED/Milight.h
@@ -26,11 +26,13 @@
 #include "Calaos.h"
 #include <Ecore_Con.h>
 
+namespace Calaos {
+
 class Milight
 {
 public:
 
-    Milight(string host, int port);
+    Milight(std::string host, int port);
     ~Milight();
 
     void sendOnCommand(int zone);
@@ -50,11 +52,13 @@ public:
 private:
 
     Ecore_Con_Server *udp_sender = nullptr;
-    string host;
+    std::string host;
     int port = DEFAULT_MILIGHT_PORT;
 
     void sendCommand(uint8_t code, uint8_t param);
 
 };
+
+}
 
 #endif

--- a/src/bin/calaos_server/IO/LimitlessLED/MilightOutputDimmer.cpp
+++ b/src/bin/calaos_server/IO/LimitlessLED/MilightOutputDimmer.cpp
@@ -23,7 +23,7 @@
 #include "IOFactory.h"
 #include "MySensors.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsOutputDimmer)
 
@@ -56,4 +56,6 @@ bool MySensorsOutputDimmer::set_value_real(int val)
     MySensorsController::Instance(get_params()).setValue(nodeId, sensorId, dataType, Utils::to_string(val));
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/LimitlessLED/MilightOutputLightRGB.cpp
+++ b/src/bin/calaos_server/IO/LimitlessLED/MilightOutputLightRGB.cpp
@@ -21,7 +21,7 @@
 #include "MilightOutputLightRGB.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MilightOutputLightRGB)
 
@@ -75,4 +75,6 @@ void MilightOutputLightRGB::setColorReal(const ColorValue &c, bool s)
             milight->sendBrightnessCommand(zone, int(v) + 1);
         });
     }
+}
+
 }

--- a/src/bin/calaos_server/IO/LimitlessLED/MilightOutputLightRGB.h
+++ b/src/bin/calaos_server/IO/LimitlessLED/MilightOutputLightRGB.h
@@ -31,7 +31,7 @@ class MilightOutputLightRGB : public OutputLightRGB
 {
 private:
     int port = DEFAULT_MILIGHT_PORT;
-    string host;
+    std::string host;
     int zone = 0;
 
     Milight *milight;

--- a/src/bin/calaos_server/IO/MySensors/MySensors.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensors.cpp
@@ -20,7 +20,9 @@
  ******************************************************************************/
 #include "MySensors.h"
 
-string MySensors::DataType2String(int dataType)
+namespace MySensors {
+
+std::string DataType2String(int dataType)
 {
     switch (dataType)
     {
@@ -68,10 +70,10 @@ string MySensors::DataType2String(int dataType)
     case V_CALAOS: return "V_CALAOS";
     }
 
-    return string();
+    return std::string();
 }
 
-int MySensors::String2DataType(string dataType)
+int String2DataType(std::string dataType)
 {
     if (dataType == "V_TEMP") return V_TEMP;
     else if (dataType == "V_HUM") return V_HUM;
@@ -118,3 +120,5 @@ int MySensors::String2DataType(string dataType)
     return V_ERROR;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/MySensors/MySensors.h
+++ b/src/bin/calaos_server/IO/MySensors/MySensors.h
@@ -136,8 +136,8 @@ enum InternalType
     I_GATEWAY_READY = 14,       // Send by gateway to controller when startup is complete.
 };
 
-string DataType2String(int dataType);
-int String2DataType(string dataType);
+std::string DataType2String(int dataType);
+int String2DataType(std::string dataType);
 
 }
 #endif

--- a/src/bin/calaos_server/IO/MySensors/MySensorsController.h
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsController.h
@@ -55,7 +55,7 @@ private:
 
     MySensorsController(const Params &p);
 
-    string gatewayVersion;
+    std::string gatewayVersion;
 
     //gateway configuration
     //Can be serial with gateway="serial" or TCP with gateway="tcp"
@@ -65,9 +65,9 @@ private:
 
     //Keep values of sensors in cache
     //Key in hash is <node_id>
-    std::unordered_map<string, MySensorsNode> hashSensors;
+    std::unordered_map<std::string, MySensorsNode> hashSensors;
 
-    std::unordered_map<string, sigc::signal<void>> sensorsCb;
+    std::unordered_map<std::string, sigc::signal<void>> sensorsCb;
 
     //serial
     int serialfd = 0;
@@ -78,7 +78,7 @@ private:
 
     Ecore_Fd_Handler *serial_handler = nullptr;
 
-    string dataBuffer;
+    std::string dataBuffer;
 
     //tcp connection
     Ecore_Event_Handler *ehandler_add;
@@ -95,18 +95,18 @@ private:
     void serialError();
     void openSerialLater(double time = 2.0); //default 2s
 
-    void writeData(const string &data);
-    void readNewData(const string &data);
-    void processMessage(string msg);
-    void sendMessage(string node_id, string sensor_id, int msgType, int ack, int subType, string payload);
+    void writeData(const std::string &data);
+    void readNewData(const std::string &data);
+    void processMessage(std::string msg);
+    void sendMessage(std::string node_id, std::string sensor_id, int msgType, int ack, int subType, std::string payload);
 
     int getNextFreeId();
 
-    void processRequestId(string node_id, string sensor_id);
-    void processTime(string node_id, string sensor_id);
-    void processNodeInfos(string node_id, string sensor_id, string key, string payload);
-    void processSensorUpdate(string node_id, string sensor_id, int subtype, string payload);
-    void processSensorRequest(string node_id, string sensor_id, int subtype, string payload);
+    void processRequestId(std::string node_id, std::string sensor_id);
+    void processTime(std::string node_id, std::string sensor_id);
+    void processNodeInfos(std::string node_id, std::string sensor_id, std::string key, std::string payload);
+    void processSensorUpdate(std::string node_id, std::string sensor_id, int subtype, std::string payload);
+    void processSensorRequest(std::string node_id, std::string sensor_id, int subtype, std::string payload);
 
 public:
     static MySensorsController &Instance(const Params &p)
@@ -116,10 +116,10 @@ public:
     }
     ~MySensorsController();
 
-    string getValue(string nodeid, string sensorid, string key = "payload");
-    void setValue(string nodeid, string sensorid, int dataType, string payload);
+    std::string getValue(std::string nodeid, std::string sensorid, std::string key = "payload");
+    void setValue(std::string nodeid, std::string sensorid, int dataType, std::string payload);
 
-    void registerIO(string nodeid, string sensorid, sigc::slot<void> callback);
+    void registerIO(std::string nodeid, std::string sensorid, sigc::slot<void> callback);
 
     Eina_Bool _serialHandler(Ecore_Fd_Handler *handler);
 

--- a/src/bin/calaos_server/IO/MySensors/MySensorsInputAnalog.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsInputAnalog.cpp
@@ -22,7 +22,7 @@
 #include "MySensorsController.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsInputAnalog)
 
@@ -44,8 +44,8 @@ MySensorsInputAnalog::MySensorsInputAnalog(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     MySensorsController::Instance(get_params()).registerIO(nodeId, sensorId, [=]()
     {
@@ -62,10 +62,10 @@ MySensorsInputAnalog::~MySensorsInputAnalog()
 void MySensorsInputAnalog::readValue()
 {
     // Read the value
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
-    string sv = MySensorsController::Instance(get_params()).getValue(nodeId, sensorId);
+    std::string sv = MySensorsController::Instance(get_params()).getValue(nodeId, sensorId);
     double v;
     if (sv.empty() || !Utils::is_of_type<double>(sv))
         return;
@@ -78,3 +78,5 @@ void MySensorsInputAnalog::readValue()
     }
 }
 
+
+}

--- a/src/bin/calaos_server/IO/MySensors/MySensorsInputString.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsInputString.cpp
@@ -22,7 +22,7 @@
 #include "MySensorsController.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsInputString)
 
@@ -44,16 +44,16 @@ MySensorsInputString::MySensorsInputString(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     MySensorsController::Instance(get_params()).registerIO(nodeId, sensorId, [=]()
     {
         // Read the value
-        string nId = get_param("node_id");
-        string sId = get_param("sensor_id");
+        std::string nId = get_param("node_id");
+        std::string sId = get_param("sensor_id");
 
-        string v = MySensorsController::Instance(get_params()).getValue(nId, sId);
+        std::string v = MySensorsController::Instance(get_params()).getValue(nId, sId);
 
         if (v != current)
         {
@@ -73,4 +73,6 @@ MySensorsInputString::~MySensorsInputString()
 void MySensorsInputString::readValue()
 {
     value = current;
+}
+
 }

--- a/src/bin/calaos_server/IO/MySensors/MySensorsInputString.h
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsInputString.h
@@ -32,7 +32,7 @@ class MySensorsInputString : public InputString
 protected:
     virtual void readValue();
 
-    string current;
+    std::string current;
 
 public:
     MySensorsInputString(Params &p);

--- a/src/bin/calaos_server/IO/MySensors/MySensorsInputSwitch.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsInputSwitch.cpp
@@ -22,7 +22,7 @@
 #include "MySensorsController.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsInputSwitch)
 
@@ -44,8 +44,8 @@ MySensorsInputSwitch::MySensorsInputSwitch(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     MySensorsController::Instance(get_params()).registerIO(nodeId, sensorId, [=]()
     {
@@ -63,12 +63,14 @@ MySensorsInputSwitch::~MySensorsInputSwitch()
 bool MySensorsInputSwitch::readValue()
 {
     // Read the value
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
-    string sv = MySensorsController::Instance(get_params()).getValue(nodeId, sensorId);
+    std::string sv = MySensorsController::Instance(get_params()).getValue(nodeId, sensorId);
 
     return sv == "true" || sv == "1";
 }
 
 
+
+}

--- a/src/bin/calaos_server/IO/MySensors/MySensorsInputSwitchLongPress.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsInputSwitchLongPress.cpp
@@ -22,7 +22,7 @@
 #include "MySensorsController.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsInputSwitchLongPress)
 
@@ -44,8 +44,8 @@ MySensorsInputSwitchLongPress::MySensorsInputSwitchLongPress(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     MySensorsController::Instance(get_params()).registerIO(nodeId, sensorId, [=]()
     {
@@ -63,12 +63,14 @@ MySensorsInputSwitchLongPress::~MySensorsInputSwitchLongPress()
 bool MySensorsInputSwitchLongPress::readValue()
 {
     // Read the value
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
-    string sv = MySensorsController::Instance(get_params()).getValue(nodeId, sensorId);
+    std::string sv = MySensorsController::Instance(get_params()).getValue(nodeId, sensorId);
 
     return sv == "true" || sv == "1";
 }
 
 
+
+}

--- a/src/bin/calaos_server/IO/MySensors/MySensorsInputSwitchTriple.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsInputSwitchTriple.cpp
@@ -22,7 +22,7 @@
 #include "MySensorsController.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsInputSwitchTriple)
 
@@ -44,8 +44,8 @@ MySensorsInputSwitchTriple::MySensorsInputSwitchTriple(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     MySensorsController::Instance(get_params()).registerIO(nodeId, sensorId, [=]()
     {
@@ -63,12 +63,14 @@ MySensorsInputSwitchTriple::~MySensorsInputSwitchTriple()
 bool MySensorsInputSwitchTriple::readValue()
 {
     // Read the value
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
-    string sv = MySensorsController::Instance(get_params()).getValue(nodeId, sensorId);
+    std::string sv = MySensorsController::Instance(get_params()).getValue(nodeId, sensorId);
 
     return sv == "true" || sv == "1";
 }
 
 
+
+}

--- a/src/bin/calaos_server/IO/MySensors/MySensorsInputTemp.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsInputTemp.cpp
@@ -22,7 +22,7 @@
 #include "MySensorsController.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsInputTemp)
 
@@ -44,8 +44,8 @@ MySensorsInputTemp::MySensorsInputTemp(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     MySensorsController::Instance(get_params()).registerIO(nodeId, sensorId, [=]()
     {
@@ -62,10 +62,10 @@ MySensorsInputTemp::~MySensorsInputTemp()
 void MySensorsInputTemp::readValue()
 {
     // Read the value
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
-    string sv = MySensorsController::Instance(get_params()).getValue(nodeId, sensorId);
+    std::string sv = MySensorsController::Instance(get_params()).getValue(nodeId, sensorId);
     double v;
     if (sv.empty() || !Utils::is_of_type<double>(sv))
         return;
@@ -78,3 +78,5 @@ void MySensorsInputTemp::readValue()
     }
 }
 
+
+}

--- a/src/bin/calaos_server/IO/MySensors/MySensorsOutputAnalog.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsOutputAnalog.cpp
@@ -23,7 +23,7 @@
 #include "IOFactory.h"
 #include "MySensors.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsOutputAnalog)
 
@@ -46,8 +46,8 @@ MySensorsOutputAnalog::MySensorsOutputAnalog(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     MySensorsController::Instance(get_params()).registerIO(nodeId, sensorId, [=]() { /*nothing*/ });
     cInfoDom("output") << "node_id: " << nodeId << " sensor_id: " << sensorId;
@@ -60,8 +60,8 @@ MySensorsOutputAnalog::~MySensorsOutputAnalog()
 
 void MySensorsOutputAnalog::set_value_real(double val)
 {
-    string nodeId = get_param("node_id_down");
-    string sensorId = get_param("sensor_id_down");
+    std::string nodeId = get_param("node_id_down");
+    std::string sensorId = get_param("sensor_id_down");
 
     int dataType = MySensors::V_DIMMER;
     if (MySensors::String2DataType(get_param("data_type")) != MySensors::V_ERROR)
@@ -70,3 +70,5 @@ void MySensorsOutputAnalog::set_value_real(double val)
     MySensorsController::Instance(get_params()).setValue(nodeId, sensorId, dataType, Utils::to_string(val));
 }
 
+
+}

--- a/src/bin/calaos_server/IO/MySensors/MySensorsOutputDimmer.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsOutputDimmer.cpp
@@ -23,7 +23,7 @@
 #include "IOFactory.h"
 #include "MySensors.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsOutputDimmer)
 
@@ -46,8 +46,8 @@ MySensorsOutputDimmer::MySensorsOutputDimmer(Params &_p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     MySensorsController::Instance(get_params()).registerIO(nodeId, sensorId, [=]() { /*nothing*/ });
     cInfoDom("output") << "node_id: " << nodeId << " sensor_id: " << sensorId;
@@ -60,8 +60,8 @@ MySensorsOutputDimmer::~MySensorsOutputDimmer()
 
 bool MySensorsOutputDimmer::set_value_real(int val)
 {
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     int dataType = MySensors::V_DIMMER;
     if (MySensors::String2DataType(get_param("data_type")) != MySensors::V_ERROR)
@@ -70,4 +70,6 @@ bool MySensorsOutputDimmer::set_value_real(int val)
     MySensorsController::Instance(get_params()).setValue(nodeId, sensorId, dataType, Utils::to_string(val));
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/MySensors/MySensorsOutputLight.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsOutputLight.cpp
@@ -23,7 +23,7 @@
 #include "MySensors.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsOutputLight)
 
@@ -46,8 +46,8 @@ MySensorsOutputLight::MySensorsOutputLight(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     MySensorsController::Instance(get_params()).registerIO(nodeId, sensorId, [=]() { /*nothing*/ });
 
@@ -65,8 +65,8 @@ void MySensorsOutputLight::readValue()
 
 bool MySensorsOutputLight::set_value_real(bool val)
 {
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     int dataType = MySensors::V_LIGHT;
     if (MySensors::String2DataType(get_param("data_type")) != MySensors::V_ERROR)
@@ -77,3 +77,5 @@ bool MySensorsOutputLight::set_value_real(bool val)
     return true;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/MySensors/MySensorsOutputLightRGB.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsOutputLightRGB.cpp
@@ -23,7 +23,7 @@
 #include "IOFactory.h"
 #include "MySensors.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsOutputLightRGB)
 
@@ -50,12 +50,12 @@ MySensorsOutputLightRGB::MySensorsOutputLightRGB(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeId_r = get_param("node_id_red");
-    string sensorId_r = get_param("sensor_id_red");
-    string nodeId_g = get_param("node_id_green");
-    string sensorId_g = get_param("sensor_id_green");
-    string nodeId_b = get_param("node_id_blue");
-    string sensorId_b = get_param("sensor_id_blue");
+    std::string nodeId_r = get_param("node_id_red");
+    std::string sensorId_r = get_param("sensor_id_red");
+    std::string nodeId_g = get_param("node_id_green");
+    std::string sensorId_g = get_param("sensor_id_green");
+    std::string nodeId_b = get_param("node_id_blue");
+    std::string sensorId_b = get_param("sensor_id_blue");
 
     MySensorsController::Instance(get_params()).registerIO(nodeId_r, sensorId_r, [=]() { /*nothing*/ });
     MySensorsController::Instance(get_params()).registerIO(nodeId_g, sensorId_g, [=]() { /*nothing*/ });
@@ -72,12 +72,12 @@ MySensorsOutputLightRGB::~MySensorsOutputLightRGB()
 
 void MySensorsOutputLightRGB::setColorReal(const ColorValue &c, bool s)
 {
-    string nodeId_r = get_param("node_id_red");
-    string sensorId_r = get_param("sensor_id_red");
-    string nodeId_g = get_param("node_id_green");
-    string sensorId_g = get_param("sensor_id_green");
-    string nodeId_b = get_param("node_id_blue");
-    string sensorId_b = get_param("sensor_id_blue");
+    std::string nodeId_r = get_param("node_id_red");
+    std::string sensorId_r = get_param("sensor_id_red");
+    std::string nodeId_g = get_param("node_id_green");
+    std::string sensorId_g = get_param("sensor_id_green");
+    std::string nodeId_b = get_param("node_id_blue");
+    std::string sensorId_b = get_param("sensor_id_blue");
 
     int dataType = MySensors::V_DIMMER;
     if (MySensors::String2DataType(get_param("data_type")) != MySensors::V_ERROR)
@@ -96,3 +96,5 @@ void MySensorsOutputLightRGB::setColorReal(const ColorValue &c, bool s)
     MySensorsController::Instance(get_params()).setValue(nodeId_b, sensorId_b, dataType, Utils::to_string(b));
 }
 
+
+}

--- a/src/bin/calaos_server/IO/MySensors/MySensorsOutputShutter.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsOutputShutter.cpp
@@ -23,7 +23,7 @@
 #include "IOFactory.h"
 #include "MySensors.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsOutputShutter)
 
@@ -48,10 +48,10 @@ MySensorsOutputShutter::MySensorsOutputShutter(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeIdUp = get_param("node_id_up");
-    string sensorIdUp = get_param("sensor_id_up");
-    string nodeIdDown = get_param("node_id_up");
-    string sensorIdDown = get_param("sensor_id_up");
+    std::string nodeIdUp = get_param("node_id_up");
+    std::string sensorIdUp = get_param("sensor_id_up");
+    std::string nodeIdDown = get_param("node_id_up");
+    std::string sensorIdDown = get_param("sensor_id_up");
 
     MySensorsController::Instance(get_params()).registerIO(nodeIdUp, sensorIdUp, [=]() { /*nothing*/ });
     MySensorsController::Instance(get_params()).registerIO(nodeIdDown, sensorIdDown, [=]() { /*nothing*/ });
@@ -66,8 +66,8 @@ MySensorsOutputShutter::~MySensorsOutputShutter()
 
 void MySensorsOutputShutter::setOutputUp(bool enable)
 {
-    string nodeId = get_param("node_id_up");
-    string sensorId = get_param("sensor_id_up");
+    std::string nodeId = get_param("node_id_up");
+    std::string sensorId = get_param("sensor_id_up");
 
     int dataType = MySensors::V_LIGHT;
     if (MySensors::String2DataType(get_param("data_type")) != MySensors::V_ERROR)
@@ -78,8 +78,8 @@ void MySensorsOutputShutter::setOutputUp(bool enable)
 
 void MySensorsOutputShutter::setOutputDown(bool enable)
 {
-    string nodeId = get_param("node_id_down");
-    string sensorId = get_param("sensor_id_down");
+    std::string nodeId = get_param("node_id_down");
+    std::string sensorId = get_param("sensor_id_down");
 
     int dataType = MySensors::V_LIGHT;
     if (MySensors::String2DataType(get_param("data_type")) != MySensors::V_ERROR)
@@ -88,3 +88,5 @@ void MySensorsOutputShutter::setOutputDown(bool enable)
     MySensorsController::Instance(get_params()).setValue(nodeId, sensorId, dataType, Utils::to_string(enable));
 }
 
+
+}

--- a/src/bin/calaos_server/IO/MySensors/MySensorsOutputShutterSmart.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsOutputShutterSmart.cpp
@@ -23,7 +23,7 @@
 #include "IOFactory.h"
 #include "MySensors.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsOutputShutterSmart)
 
@@ -48,10 +48,10 @@ MySensorsOutputShutterSmart::MySensorsOutputShutterSmart(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeIdUp = get_param("node_id_up");
-    string sensorIdUp = get_param("sensor_id_up");
-    string nodeIdDown = get_param("node_id_up");
-    string sensorIdDown = get_param("sensor_id_up");
+    std::string nodeIdUp = get_param("node_id_up");
+    std::string sensorIdUp = get_param("sensor_id_up");
+    std::string nodeIdDown = get_param("node_id_up");
+    std::string sensorIdDown = get_param("sensor_id_up");
 
     MySensorsController::Instance(get_params()).registerIO(nodeIdUp, sensorIdUp, [=]() { /*nothing*/ });
     MySensorsController::Instance(get_params()).registerIO(nodeIdDown, sensorIdDown, [=]() { /*nothing*/ });
@@ -66,8 +66,8 @@ MySensorsOutputShutterSmart::~MySensorsOutputShutterSmart()
 
 void MySensorsOutputShutterSmart::setOutputUp(bool enable)
 {
-    string nodeId = get_param("node_id_up");
-    string sensorId = get_param("sensor_id_up");
+    std::string nodeId = get_param("node_id_up");
+    std::string sensorId = get_param("sensor_id_up");
 
     int dataType = MySensors::V_LIGHT;
     if (MySensors::String2DataType(get_param("data_type")) != MySensors::V_ERROR)
@@ -78,8 +78,8 @@ void MySensorsOutputShutterSmart::setOutputUp(bool enable)
 
 void MySensorsOutputShutterSmart::setOutputDown(bool enable)
 {
-    string nodeId = get_param("node_id_down");
-    string sensorId = get_param("sensor_id_down");
+    std::string nodeId = get_param("node_id_down");
+    std::string sensorId = get_param("sensor_id_down");
 
     int dataType = MySensors::V_LIGHT;
     if (MySensors::String2DataType(get_param("data_type")) != MySensors::V_ERROR)
@@ -88,3 +88,5 @@ void MySensorsOutputShutterSmart::setOutputDown(bool enable)
     MySensorsController::Instance(get_params()).setValue(nodeId, sensorId, dataType, Utils::to_string(enable));
 }
 
+
+}

--- a/src/bin/calaos_server/IO/MySensors/MySensorsOutputString.cpp
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsOutputString.cpp
@@ -23,7 +23,7 @@
 #include "IOFactory.h"
 #include "MySensors.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(MySensorsOutputString)
 
@@ -46,8 +46,9 @@ MySensorsOutputString::MySensorsOutputString(Params &p):
                     IODoc::TYPE_STRING, true, "/dev/ttyUSB0");
     ioDoc->paramAdd("host", _("IP address of the tcp gateway if relevant"), IODoc::TYPE_STRING, true);
 
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     MySensorsController::Instance(get_params()).registerIO(nodeId, sensorId, [=]() { /*nothing*/ });
     cInfoDom("output") << "node_id: " << nodeId << " sensor_id: " << sensorId;
@@ -58,14 +59,16 @@ MySensorsOutputString::~MySensorsOutputString()
     cInfoDom("output");
 }
 
-void MySensorsOutputString::set_value_real(string val)
+void MySensorsOutputString::set_value_real(std::string val)
 {
-    string nodeId = get_param("node_id");
-    string sensorId = get_param("sensor_id");
+    std::string nodeId = get_param("node_id");
+    std::string sensorId = get_param("sensor_id");
 
     int dataType = MySensors::V_VAR1;
     if (MySensors::String2DataType(get_param("data_type")) != MySensors::V_ERROR)
         dataType = MySensors::String2DataType(get_param("data_type"));
 
     MySensorsController::Instance(get_params()).setValue(nodeId, sensorId, dataType, val);
+}
+
 }

--- a/src/bin/calaos_server/IO/MySensors/MySensorsOutputString.h
+++ b/src/bin/calaos_server/IO/MySensors/MySensorsOutputString.h
@@ -29,7 +29,7 @@ namespace Calaos
 class MySensorsOutputString : public OutputString
 {
 protected:
-    virtual void set_value_real(string val);
+    virtual void set_value_real(std::string val);
 
 public:
     MySensorsOutputString(Params &p);

--- a/src/bin/calaos_server/IO/OLA/OLACtrl.cpp
+++ b/src/bin/calaos_server/IO/OLA/OLACtrl.cpp
@@ -21,7 +21,8 @@
 #include "OLACtrl.h"
 #include "Prefix.h"
 
-OLACtrl::OLACtrl(const string &universe)
+namespace Calaos {
+OLACtrl::OLACtrl(const std::string &universe)
 {
     cDebugDom("ola") << "new OLACtrl: " << universe;
     process = new ExternProcServer("ola");
@@ -52,7 +53,7 @@ void OLACtrl::setValue(int channel, int value)
     json_object_set_new(jdata, "value", json_integer(value * 255 / 100));
     json_array_append_new(jroot, jdata);
 
-    string res = jansson_to_string(jroot);
+    std::string res = jansson_to_string(jroot);
 
     if (!res.empty())
         process->sendMessage(res);
@@ -79,7 +80,7 @@ void OLACtrl::setColor(const ColorValue &color, int channel_red, int channel_gre
     json_object_set_new(jdata, "value", json_integer(color.getBlue()));
     json_array_append_new(jroot, jdata);
 
-    string res = jansson_to_string(jroot);
+    std::string res = jansson_to_string(jroot);
 
     if (!res.empty())
         process->sendMessage(res);
@@ -87,14 +88,16 @@ void OLACtrl::setColor(const ColorValue &color, int channel_red, int channel_gre
     cDebugDom("ola") << "Sending: " << res;
 }
 
-shared_ptr<OLACtrl> OLACtrl::Instance(const string &universe)
+std::shared_ptr<OLACtrl> OLACtrl::Instance(const std::string &universe)
 {
-    static map<string, shared_ptr<OLACtrl>> mapInst;
+    static std::map<std::string, std::shared_ptr<OLACtrl>> mapInst;
     auto it = mapInst.find(universe);
     if (it != mapInst.end())
         return it->second;
 
-    shared_ptr<OLACtrl> inst(new OLACtrl(universe));
+    std::shared_ptr<OLACtrl> inst(new OLACtrl(universe));
     mapInst[universe] = std::move(inst);
     return mapInst[universe];
+}
+
 }

--- a/src/bin/calaos_server/IO/OLA/OLACtrl.h
+++ b/src/bin/calaos_server/IO/OLA/OLACtrl.h
@@ -24,20 +24,24 @@
 #include "Calaos.h"
 #include "ExternProc.h"
 
+namespace Calaos {
 class OLACtrl: public sigc::trackable
 {
 private:
-    OLACtrl(const string &universe);
+    OLACtrl(const std::string &universe);
 
     ExternProcServer *process;
-    string exe;
+    std::string exe;
 
 public:
-    static shared_ptr<OLACtrl> Instance(const string &universe);
+    static std::shared_ptr<OLACtrl> Instance(const std::string &universe);
     ~OLACtrl();
 
     void setValue(int channel, int value); //0-100
     void setColor(const ColorValue &color, int channel_red, int channel_green, int channel_blue);
 };
 
+}
+
 #endif // OLACTRL_H
+

--- a/src/bin/calaos_server/IO/OLA/OLAExternProc_main.cpp
+++ b/src/bin/calaos_server/IO/OLA/OLAExternProc_main.cpp
@@ -24,6 +24,7 @@
 #include <ola/Logging.h>
 #include <ola/StreamingClient.h>
 
+namespace Calaos {
 class OLAProcess: public ExternProcClient
 {
 public:
@@ -124,4 +125,7 @@ int OLAProcess::procMain()
     return 0;
 }
 
-EXTERN_PROC_CLIENT_MAIN(OLAProcess)
+}
+
+EXTERN_PROC_CLIENT_MAIN(Calaos::OLAProcess)
+

--- a/src/bin/calaos_server/IO/OLA/OLAOutputLightDimmer.cpp
+++ b/src/bin/calaos_server/IO/OLA/OLAOutputLightDimmer.cpp
@@ -22,6 +22,7 @@
 #include "IOFactory.h"
 #include "OLACtrl.h"
 
+namespace Calaos {
 REGISTER_IO(OLAOutputLightDimmer)
 
 OLAOutputLightDimmer::OLAOutputLightDimmer(Params &p):
@@ -47,4 +48,6 @@ bool OLAOutputLightDimmer::set_value_real(int val)
     OLACtrl::Instance(get_param("universe"))->setValue(channel, val);
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/OLA/OLAOutputLightDimmer.h
+++ b/src/bin/calaos_server/IO/OLA/OLAOutputLightDimmer.h
@@ -23,7 +23,7 @@
 
 #include "OutputLightDimmer.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 class OLAOutputLightDimmer: public OutputLightDimmer
 {
@@ -34,5 +34,7 @@ private:
 public:
     OLAOutputLightDimmer(Params &p);
 };
+
+}
 
 #endif // OLAOUTPUTLIGHTDIMMER_H

--- a/src/bin/calaos_server/IO/OLA/OLAOutputLightRGB.cpp
+++ b/src/bin/calaos_server/IO/OLA/OLAOutputLightRGB.cpp
@@ -22,6 +22,7 @@
 #include "IOFactory.h"
 #include "OLACtrl.h"
 
+namespace Calaos {
 REGISTER_IO(OLAOutputLightRGB)
 
 OLAOutputLightRGB::OLAOutputLightRGB(Params &p):
@@ -58,4 +59,6 @@ void OLAOutputLightRGB::setColorReal(const ColorValue &c, bool s)
                                                            channel_red,
                                                            channel_green,
                                                            channel_blue);
+}
+
 }

--- a/src/bin/calaos_server/IO/OLA/OLAOutputLightRGB.h
+++ b/src/bin/calaos_server/IO/OLA/OLAOutputLightRGB.h
@@ -23,7 +23,7 @@
 
 #include "OutputLightRGB.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 class OLAOutputLightRGB: public OutputLightRGB
 {
@@ -33,5 +33,7 @@ private:
 public:
     OLAOutputLightRGB(Params &p);
 };
+
+}
 
 #endif // OLAOUTPUTLIGHTRGB_H

--- a/src/bin/calaos_server/IO/OneWire/OWCtrl.cpp
+++ b/src/bin/calaos_server/IO/OneWire/OWCtrl.cpp
@@ -21,7 +21,8 @@
 #include "OWCtrl.h"
 #include "Prefix.h"
 
-OwCtrl::OwCtrl(const string &args)
+namespace Calaos {
+OwCtrl::OwCtrl(const std::string &args)
 {
     cDebugDom("1wire") << "new OWCtrl: " << args;
     process = new ExternProcServer("1wire");
@@ -47,36 +48,36 @@ OwCtrl::~OwCtrl()
     delete process;
 }
 
-string OwCtrl::getValue(string owid)
+std::string OwCtrl::getValue(std::string owid)
 {
     return mapValues[owid];
 }
 
-string OwCtrl::getType(string owid)
+std::string OwCtrl::getType(std::string owid)
 {
     return mapTypes[owid];
 }
 
-shared_ptr<OwCtrl> OwCtrl::Instance(const string &args)
+std::shared_ptr<OwCtrl> OwCtrl::Instance(const std::string &args)
 {
-    static map<string, shared_ptr<OwCtrl>> mapInst;
+    static std::map<std::string, std::shared_ptr<OwCtrl>> mapInst;
     auto it = mapInst.find(args);
     if (it != mapInst.end())
         return it->second;
 
-    shared_ptr<OwCtrl> inst(new OwCtrl(args));
+    std::shared_ptr<OwCtrl> inst(new OwCtrl(args));
     mapInst[args] = std::move(inst);
     return mapInst[args];
 }
 
-void OwCtrl::processNewMessage(const string &msg)
+void OwCtrl::processNewMessage(const std::string &msg)
 {
     Json jroot;
     try
     {
         jroot = Json::parse(msg);
         if (!jroot.is_array())
-            throw (invalid_argument(string("Json is not an array: ") + msg));
+           throw (std::invalid_argument(std::string("Json is not an array: ") + msg));
     }
     catch (const std::exception &e)
     {
@@ -89,11 +90,13 @@ void OwCtrl::processNewMessage(const string &msg)
         if (it.find("id") != it.end())
         {
             if (it.find("value") != it.end())
-                mapValues[it["id"].get<string>()] = it["value"].get<string>();
+                mapValues[it["id"].get<std::string>()] = it["value"].get<std::string>();
             if (it.find("type") != it.end())
-                mapTypes[it["id"].get<string>()] = it["type"].get<string>();
+                mapTypes[it["id"].get<std::string>()] = it["type"].get<std::string>();
         }
     }
 
     valueChanged.emit();
+}
+
 }

--- a/src/bin/calaos_server/IO/OneWire/OWCtrl.h
+++ b/src/bin/calaos_server/IO/OneWire/OWCtrl.h
@@ -24,26 +24,30 @@
 #include "Calaos.h"
 #include "ExternProc.h"
 
+namespace Calaos {
+
 class OwCtrl: public sigc::trackable
 {
 private:    
-    OwCtrl(const string &args);
+    OwCtrl(const std::string &args);
 
     ExternProcServer *process;
-    std::unordered_map<string, string> mapValues;
-    std::unordered_map<string, string> mapTypes;
-    string exe;
+    std::unordered_map<std::string, std::string> mapValues;
+    std::unordered_map<std::string, std::string> mapTypes;
+    std::string exe;
 
-    void processNewMessage(const string &msg);
+    void processNewMessage(const std::string &msg);
 
 public:
-    static shared_ptr<OwCtrl> Instance(const string &args);
+    static std::shared_ptr<OwCtrl> Instance(const std::string &args);
     ~OwCtrl();
 
-    string getValue(string owid);
-    string getType(string owid);
+    std::string getValue(std::string owid);
+    std::string getType(std::string owid);
 
     sigc::signal<void> valueChanged;
 };
+
+}
 
 #endif

--- a/src/bin/calaos_server/IO/OneWire/OWExternProc_main.cpp
+++ b/src/bin/calaos_server/IO/OneWire/OWExternProc_main.cpp
@@ -28,6 +28,8 @@
 # include <owcapi.h>
 #endif
 
+namespace Calaos {
+
 class OWProcess: public ExternProcClient
 {
 public:
@@ -42,13 +44,13 @@ public:
 protected:
 
     //OW specific functions
-    string getValue(const string &path, const string &param);
-    list<string> scanDevices();
+    std::string getValue(const std::string &path, const std::string &param);
+    std::list<std::string> scanDevices();
     void sendValues();
 
     //needs to be reimplemented
     virtual void readTimeout();
-    virtual void messageReceived(const string &msg);
+    virtual void messageReceived(const std::string &msg);
 
 private:
     bool use_w1;
@@ -61,9 +63,9 @@ OWProcess::~OWProcess()
 #endif
 }
 
-string OWProcess::getValue(const string &path, const string &param)
+std::string OWProcess::getValue(const std::string &path, const std::string &param)
 {
-    string value;
+    std::string value;
 
     if (use_w1)
     {
@@ -71,8 +73,8 @@ string OWProcess::getValue(const string &path, const string &param)
         if (param == "type")
             return "temperature";
 
-        ifstream f;
-        string fvalue = "/sys/bus/w1/devices/" + path + "/w1_slave";
+        std::ifstream f;
+        std::string fvalue = "/sys/bus/w1/devices/" + path + "/w1_slave";
 
         f.open(fvalue);
         if (!f.is_open())
@@ -82,14 +84,14 @@ string OWProcess::getValue(const string &path, const string &param)
         // b3 01 4b 46 7f ff 0d 10 9a : crc=9a YES
         // b3 01 4b 46 7f ff 0d 10 9a t=27187
 
-        string line;
+        std::string line;
         while(!f.eof())
         {
             getline(f, line);
             if (!line.empty())
             {
                 // CRC is OK
-                if (line.find("YES") != string::npos)
+                if (line.find("YES") != std::string::npos)
                 {
                     // get next line and search for t=
                     size_t pos;
@@ -97,7 +99,7 @@ string OWProcess::getValue(const string &path, const string &param)
                     if (!line.empty())
                     {
                         pos = line.find("t=");
-                        if (pos != string::npos)
+                        if (pos != std::string::npos)
                         {
                             pos += 2;
                             line.erase(0, pos);
@@ -120,7 +122,7 @@ string OWProcess::getValue(const string &path, const string &param)
 
 #if HAVE_LIBOWCAPI
 
-    string p = path + "/" + param;
+    std::string p = path + "/" + param;
     char *res;
     size_t len;
 
@@ -141,20 +143,20 @@ string OWProcess::getValue(const string &path, const string &param)
 
 }
 
-list<string> OWProcess::scanDevices()
+std::list<std::string> OWProcess::scanDevices()
 {
 
-    list<string> listDevices;
+    std::list<std::string> listDevices;
 
     if (use_w1)
     {
-        ifstream f;
-        string fslaves = "/sys/bus/w1/devices/w1_bus_master1/w1_master_slaves";
+        std::ifstream f;
+        std::string fslaves = "/sys/bus/w1/devices/w1_bus_master1/w1_master_slaves";
 
         f.open(fslaves);
         if (!f.is_open())
             return listDevices;
-        string line;
+        std::string line;
         while(!f.eof())
         {
             getline(f, line);
@@ -175,11 +177,11 @@ list<string> OWProcess::scanDevices()
     if (ret < 0)
         return listDevices;
 
-    vector<string> tok;
-    Utils::split(string(dir_buffer), tok, ",");
+    std::vector<std::string> tok;
+    Utils::split(std::string(dir_buffer), tok, ",");
     free(dir_buffer);
 
-    for (const string &s: tok)
+    for (const std::string &s: tok)
     {
         if ((s[0] > '0' && s[0] < '9') ||
             (s[0] > 'A' && s[0] < 'F'))
@@ -200,10 +202,10 @@ list<string> OWProcess::scanDevices()
 void OWProcess::readTimeout()
 {
     //read all devices and send a json with all data
-    list<string> l = scanDevices();
+    std::list<std::string> l = scanDevices();
 
     Json jdata;
-    for (const string &dev: l)
+    for (const std::string &dev: l)
     {
         jdata.push_back({ { "id" , dev },
                           { "value", getValue(dev, "temperature") },
@@ -214,12 +216,12 @@ void OWProcess::readTimeout()
     sendMessage(jdata.dump());
 }
 
-void OWProcess::messageReceived(const string &msg)
+void OWProcess::messageReceived(const std::string &msg)
 {
     //actually we don't need to do anything here for OW IO.
     //calaos_server will not send us any data
     //for debug print
-    cout << "Message received: " << msg << endl;
+    std::cout << "Message received: " << msg << std::endl;
 }
 
 bool OWProcess::setup(int &argc, char **&argv)
@@ -238,13 +240,13 @@ bool OWProcess::setup(int &argc, char **&argv)
     if (argvOptionCheck(argv, argv + argc, "--help") ||
         argvOptionCheck(argv, argv + argc, "-h"))
     {
-        cout << "This tool is for calaos internal use only. However it may be useful " <<
+        std::cout << "This tool is for calaos internal use only. However it may be useful " <<
                 "for debugging purpose. It's designed to scan One Wire devices and print " <<
-                "detected devices and their temperatures on screen" << endl << endl;
-        cout << "    Usage : " << argv[0] << " [--use-w1] [--scan] <owfs_args>" << endl;
-        cout << "         --use-w1    : Force the use of w1 kernel module for one wire detection." << endl;
-        cout << "         --scan      : scan hardware and detect OneWire devices." << endl;
-        cout << "         <owfs_args> : List of arguments used by OWFS during init (e.g. -u for usb devices)." << endl;
+                "detected devices and their temperatures on screen" << std::endl << std::endl;
+        std::cout << "    Usage : " << argv[0] << " [--use-w1] [--scan] <owfs_args>" << std::endl;
+        std::cout << "         --use-w1    : Force the use of w1 kernel module for one wire detection." << std::endl;
+        std::cout << "         --scan      : scan hardware and detect OneWire devices." << std::endl;
+        std::cout << "         <owfs_args> : List of arguments used by OWFS during init (e.g. -u for usb devices)." << std::endl;
         return false;
     }
 
@@ -265,9 +267,9 @@ bool OWProcess::setup(int &argc, char **&argv)
         }
     }
 
-    string owargs;
+    std::string owargs;
     for (int i = 1;i < argc;i++)
-        owargs += string(argv[i]) + " ";
+        owargs += std::string(argv[i]) + " ";
 
     cDebug() << "Args: " << owargs;
 
@@ -289,14 +291,14 @@ bool OWProcess::setup(int &argc, char **&argv)
 
     if (scan_devices)
     {
-        cout << "Scanning for 1wire devices... ";
-        list<string> l = scanDevices();
-        cout << "found " << l.size() << " devices." << endl;
-        for (const string &dev: l)
+        std::cout << "Scanning for 1wire devices... ";
+        std::list<std::string> l = scanDevices();
+        std::cout << "found " << l.size() << " devices." << std::endl;
+        for (const std::string &dev: l)
         {
-            cout << "Device: " << dev
+            std::cout << "Device: " << dev
                  << " (" << getValue(dev, "type") << ")"
-                 << " --> value: " << getValue(dev, "temperature") << endl;
+                 << " --> value: " << getValue(dev, "temperature") << std::endl;
         }
         return false;
     }
@@ -313,4 +315,7 @@ int OWProcess::procMain()
     return 0;
 }
 
-EXTERN_PROC_CLIENT_MAIN(OWProcess)
+
+}
+
+EXTERN_PROC_CLIENT_MAIN(Calaos::OWProcess)

--- a/src/bin/calaos_server/IO/OneWire/OWTemp.cpp
+++ b/src/bin/calaos_server/IO/OneWire/OWTemp.cpp
@@ -26,8 +26,8 @@
 #include "OWTemp.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
 
+namespace Calaos {
 REGISTER_IO(OWTemp)
 
 OWTemp::OWTemp(Params &p):
@@ -48,7 +48,7 @@ OWTemp::OWTemp(Params &p):
     ow_args = get_param("ow_args");
 
     // Prepend --use-w1 to owfs args if existing in conf
-    string args;
+    std::string args;
     if (get_param("use_w1") == "true")
       args += "--use-w1 ";
     args += ow_args;
@@ -62,7 +62,7 @@ OWTemp::OWTemp(Params &p):
 
 void OWTemp::readValue()
 {
-    string v = OwCtrl::Instance(ow_args)->getValue(ow_id);
+    std::string v = OwCtrl::Instance(ow_args)->getValue(ow_id);
     if (v.empty() || !Utils::is_of_type<double>(v))
         return;
 
@@ -75,4 +75,6 @@ void OWTemp::readValue()
         emitChange();
         cDebugDom("input") << ow_id << ": value: " << val;
     }
+}
+
 }

--- a/src/bin/calaos_server/IO/OneWire/OWTemp.h
+++ b/src/bin/calaos_server/IO/OneWire/OWTemp.h
@@ -24,18 +24,20 @@
 #include "InputTemp.h"
 #include "EcoreTimer.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 class OWTemp : public InputTemp
 {
 protected:
-    string ow_id;
-    string ow_args;
+    std::string ow_id;
+    std::string ow_args;
 
     virtual void readValue();
 
 public:
     OWTemp(Params &p);
 };
+
+}
 
 #endif

--- a/src/bin/calaos_server/IO/OutputAnalog.cpp
+++ b/src/bin/calaos_server/IO/OutputAnalog.cpp
@@ -20,8 +20,8 @@
  ******************************************************************************/
 #include "OutputAnalog.h"
 
-using namespace Calaos;
-using namespace Utils;
+
+namespace Calaos {
 
 OutputAnalog::OutputAnalog(Params &p):
     IOBase(p, IOBase::IO_OUTPUT),
@@ -122,7 +122,7 @@ bool OutputAnalog::set_value(double val)
     return true;
 }
 
-bool OutputAnalog::set_value(string val)
+bool OutputAnalog::set_value(std::string val)
 {
     if (!isEnabled()) return true;
 
@@ -144,7 +144,7 @@ bool OutputAnalog::set_value(string val)
     }
     else if (val.compare(0, 4, "inc ") == 0)
     {
-        string t = val;
+        std::string t = val;
         t.erase(0, 4);
 
         double step = 1.0;
@@ -155,7 +155,7 @@ bool OutputAnalog::set_value(string val)
     }
     else if (val.compare(0, 4, "dec ") == 0)
     {
-        string t = val;
+        std::string t = val;
         t.erase(0, 4);
 
         double step = 1.0;
@@ -179,3 +179,5 @@ bool OutputAnalog::set_value(string val)
     return true;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/OutputAnalog.h
+++ b/src/bin/calaos_server/IO/OutputAnalog.h
@@ -40,7 +40,7 @@ protected:
 
     void readConfig();
 
-    void WagoReadCallback(bool status, UWord address, int count, vector<UWord> &values);
+    void WagoReadCallback(bool status, UWord address, int count, std::vector<UWord> &values);
     void WagoWriteCallback(bool status, UWord address, UWord value);
 
     void emitChange();
@@ -54,7 +54,7 @@ public:
 
     virtual bool set_value(double val);
     virtual double get_value_double();
-    virtual bool set_value(string val);
+    virtual bool set_value(std::string val);
 };
 
 }

--- a/src/bin/calaos_server/IO/OutputFake.cpp
+++ b/src/bin/calaos_server/IO/OutputFake.cpp
@@ -21,7 +21,7 @@
 #include "OutputFake.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(OutputFake)
 
@@ -58,4 +58,6 @@ bool OutputFake::set_value(bool val)
     EmitSignalIO();
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/OutputLight.cpp
+++ b/src/bin/calaos_server/IO/OutputLight.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "OutputLight.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 OutputLight::OutputLight(Params &p):
     IOBase(p, IOBase::IO_OUTPUT),
@@ -88,13 +88,13 @@ bool OutputLight::_set_value(bool val)
     return false;
 }
 
-bool OutputLight::set_value(string val)
+bool OutputLight::set_value(std::string val)
 {
     if (!isEnabled()) return true;
 
     if (val.compare(0, 8,"impulse ") == 0)
     {
-        string tmp = val;
+        std::string tmp = val;
         tmp.erase(0, 8);
         // classic impulse, WODigital goes false after <time> miliseconds
         if (is_of_type<int>(tmp))
@@ -160,7 +160,7 @@ void OutputLight::TimerImpulse()
     DELETE_NULL(timer);
 }
 
-void OutputLight::impulse_extended(string pattern)
+void OutputLight::impulse_extended(std::string pattern)
 {
     /* Extended impulse to do blinking.
          * It uses a pattern like this one:
@@ -176,7 +176,7 @@ void OutputLight::impulse_extended(string pattern)
     cInfoDom("output") << get_param("id") << ": got extended impulse action, parsing blinking pattern...";
 
     //Parse the string
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(pattern, tokens);
 
     bool state = true;
@@ -261,3 +261,5 @@ void OutputLight::TimerImpulseExtended()
                            (sigc::slot<void>)sigc::mem_fun(*this, &OutputLight::TimerImpulseExtended) );
 }
 
+
+}

--- a/src/bin/calaos_server/IO/OutputLight.h
+++ b/src/bin/calaos_server/IO/OutputLight.h
@@ -32,7 +32,7 @@ class OutputLight : public IOBase
 private:
     EcoreTimer *timer = nullptr;
 
-    vector<BlinkInfo> blinks;
+    std::vector<BlinkInfo> blinks;
     int current_blink;
 
     void TimerImpulse();
@@ -44,7 +44,7 @@ private:
     void impulse(int time);
 
     // extended impulse using pattern
-    void impulse_extended(string pattern);
+    void impulse_extended(std::string pattern);
 
 protected:
     bool value;
@@ -68,7 +68,7 @@ public:
 
     virtual bool set_value(bool val);
     virtual bool get_value_bool() { return value; }
-    virtual bool set_value(string val);
+    virtual bool set_value(std::string val);
 };
 
 }

--- a/src/bin/calaos_server/IO/OutputLightDimmer.cpp
+++ b/src/bin/calaos_server/IO/OutputLightDimmer.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "OutputLightDimmer.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 OutputLightDimmer::OutputLightDimmer(Params &p):
     IOBase(p, IOBase::IO_OUTPUT),
@@ -186,7 +186,7 @@ bool OutputLightDimmer::set_value(std::string val)
         //only toggle after a press and if long press is not detected
         if (!press_detected && stop_after_press)
         {
-            ret = set_value(string("toggle"));
+            ret = set_value(std::string("toggle"));
         }
 
         stop_after_press = false;
@@ -200,7 +200,7 @@ bool OutputLightDimmer::set_value(std::string val)
     }
     else if (val.compare(0, 8, "impulse ") == 0)
     {
-        string tmp = val;
+        std::string tmp = val;
         tmp.erase(0, 8);
         // classic impulse, WODigital goes false after <time> miliseconds
         if (is_of_type<int>(tmp))
@@ -334,7 +334,7 @@ void OutputLightDimmer::HoldPress_cb()
         }
     }
 
-    string cmd = "set ";
+    std::string cmd = "set ";
     cmd += Utils::to_string(v);
     set_value(cmd);
 }
@@ -359,7 +359,7 @@ void OutputLightDimmer::TimerImpulse()
     DELETE_NULL(impulseTimer);
 }
 
-void OutputLightDimmer::impulse_extended(string pattern)
+void OutputLightDimmer::impulse_extended(std::string pattern)
 {
     /* Extended impulse to do blinking.
          * It uses a pattern like this one:
@@ -376,8 +376,8 @@ void OutputLightDimmer::impulse_extended(string pattern)
                        << ": got extended impulse action, parsing blinking pattern...";
 
     //Parse the string
-    vector<string> tokens;
-    split(pattern, tokens);
+    std::vector<std::string> tokens;
+    Utils::split(pattern, tokens);
 
     bool state = true;
     int loop = -1;
@@ -491,4 +491,6 @@ bool OutputLightDimmer::check_condition_value(std::string cvalue, bool equal)
     }
 
     return false;
+}
+
 }

--- a/src/bin/calaos_server/IO/OutputLightDimmer.h
+++ b/src/bin/calaos_server/IO/OutputLightDimmer.h
@@ -37,7 +37,7 @@ protected:
     EcoreTimer *hold_timer = nullptr;
     EcoreTimer *impulseTimer = nullptr;
 
-    vector<BlinkInfo> blinks;
+    std::vector<BlinkInfo> blinks;
     int current_blink;
 
     std::string cmd_state;
@@ -59,7 +59,7 @@ protected:
     void impulse(int time);
 
     // extended impulse using pattern
-    void impulse_extended(string pattern);
+    void impulse_extended(std::string pattern);
 
     void HoldPress_cb();
 

--- a/src/bin/calaos_server/IO/OutputLightRGB.cpp
+++ b/src/bin/calaos_server/IO/OutputLightRGB.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "OutputLightRGB.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 OutputLightRGB::OutputLightRGB(Params &p):
     IOBase(p, IOBase::IO_OUTPUT),
@@ -348,4 +348,6 @@ bool OutputLightRGB::check_condition_value(std::string cvalue, bool equal)
     }
 
     return false;
+}
+
 }

--- a/src/bin/calaos_server/IO/OutputLightRGB.h
+++ b/src/bin/calaos_server/IO/OutputLightRGB.h
@@ -68,7 +68,7 @@ public:
 
     virtual std::string get_command_string() { return cmd_state; }
 
-    virtual bool check_condition_value(string cvalue, bool equal);
+    virtual bool check_condition_value(std::string cvalue, bool equal);
 };
 
 }

--- a/src/bin/calaos_server/IO/OutputShutter.cpp
+++ b/src/bin/calaos_server/IO/OutputShutter.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "OutputShutter.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 OutputShutter::OutputShutter(Params &p):
     IOBase(p, IOBase::IO_OUTPUT),
@@ -371,7 +371,7 @@ void OutputShutter::TimerEnd()
         state_volet = "false";
     }
 
-    string t = cmd_state;
+    std::string t = cmd_state;
     Stop();
     cmd_state = t;
 
@@ -414,4 +414,6 @@ bool OutputShutter::check_condition_value(std::string cvalue, bool equal)
     }
 
     return false;
+}
+
 }

--- a/src/bin/calaos_server/IO/OutputShutter.h
+++ b/src/bin/calaos_server/IO/OutputShutter.h
@@ -87,7 +87,7 @@ public:
 
     virtual std::string get_command_string() { return cmd_state; }
 
-    virtual bool check_condition_value(string cvalue, bool equal);
+    virtual bool check_condition_value(std::string cvalue, bool equal);
 };
 
 }

--- a/src/bin/calaos_server/IO/OutputShutterSmart.cpp
+++ b/src/bin/calaos_server/IO/OutputShutterSmart.cpp
@@ -21,7 +21,7 @@
 #include "OutputShutterSmart.h"
 #include "CalaosConfig.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 OutputShutterSmart::OutputShutterSmart(Params &p):
     IOBase(p, IOBase::IO_OUTPUT),
@@ -66,7 +66,7 @@ OutputShutterSmart::OutputShutterSmart(Params &p):
 
     cInfoDom("output") << "OutputShutterSmart::OutputShutterSmart(" << get_param("id") << "): Reading initial value";
 
-    string initpos;
+    std::string initpos;
     if (!Config::Instance().ReadValueIO(get_param("id"), initpos))
         cErrorDom("output") << "OutputShutterSmart::OutputShutterSmart(" << get_param("id") << "): Reading initial value failed!";
     else
@@ -555,7 +555,7 @@ void OutputShutterSmart::TimerEnd()
     else if (sens == VDOWN)
         old_sens = VDOWN;
 
-    string t = cmd_state;
+    std::string t = cmd_state;
     Stop();
     cmd_state = t;
 
@@ -658,4 +658,6 @@ bool OutputShutterSmart::check_condition_value(std::string cvalue, bool equal)
     }
 
     return false;
+}
+
 }

--- a/src/bin/calaos_server/IO/OutputShutterSmart.h
+++ b/src/bin/calaos_server/IO/OutputShutterSmart.h
@@ -98,7 +98,7 @@ public:
 
     virtual std::string get_command_string() { return cmd_state; }
 
-    virtual bool check_condition_value(string cvalue, bool equal);
+    virtual bool check_condition_value(std::string cvalue, bool equal);
 };
 
 }

--- a/src/bin/calaos_server/IO/OutputString.cpp
+++ b/src/bin/calaos_server/IO/OutputString.cpp
@@ -20,8 +20,7 @@
  ******************************************************************************/
 #include "OutputString.h"
 
-using namespace Calaos;
-using namespace Utils;
+namespace Calaos {
 
 OutputString::OutputString(Params &p):
     IOBase(p, IOBase::IO_OUTPUT),
@@ -51,7 +50,7 @@ void OutputString::emitChange()
                            { "state", value } });
 }
 
-bool OutputString::set_value(string val)
+bool OutputString::set_value(std::string val)
 {
     if (!isEnabled()) return true;
 
@@ -66,3 +65,5 @@ bool OutputString::set_value(string val)
     return true;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/OutputString.h
+++ b/src/bin/calaos_server/IO/OutputString.h
@@ -30,12 +30,12 @@ namespace Calaos
 class OutputString : public IOBase
 {
 protected:
-    string value;
+    std::string value;
 
     void readConfig();
 
     void emitChange();
-    virtual void set_value_real(string val) = 0;
+    virtual void set_value_real(std::string val) = 0;
 
 public:
     OutputString(Params &p);
@@ -43,7 +43,7 @@ public:
 
     DATA_TYPE get_type() { return TSTRING; }
 
-    bool set_value(string val);
+    bool set_value(std::string val);
 };
 
 }

--- a/src/bin/calaos_server/IO/Scenario.cpp
+++ b/src/bin/calaos_server/IO/Scenario.cpp
@@ -23,7 +23,7 @@
 #include "EcoreTimer.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(Scenario)
 
@@ -39,7 +39,7 @@ Scenario::Scenario(Params &p):
     ioDoc->conditionAdd("true", _("Event triggered when scenario is started"));
     ioDoc->actionAdd("changed", _("Event triggered on any change"));
 
-    ioDoc->paramAdd("auto_scenario", _("Internal use only for Auto Scenario. read only."), IODoc::TYPE_STRING, false, string(), true);
+    ioDoc->paramAdd("auto_scenario", _("Internal use only for Auto Scenario. read only."), IODoc::TYPE_STRING, false, std::string(), true);
 
     cInfoDom("output") << "Scenario::Scenario(" << get_param("id") << "): Ok";
 
@@ -138,4 +138,6 @@ json_t *Scenario::toJson()
     json_object_set_new(jret, "steps", jsteps);
 
     return jret;
+}
+
 }

--- a/src/bin/calaos_server/IO/Wago/WIAnalog.cpp
+++ b/src/bin/calaos_server/IO/Wago/WIAnalog.cpp
@@ -22,7 +22,7 @@
 #include <WagoMap.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WIAnalog)
 REGISTER_IO_USERTYPE(WagoInputAnalog, WIAnalog)
@@ -66,7 +66,7 @@ WIAnalog::~WIAnalog()
     cDebugDom("input");
 }
 
-void WIAnalog::WagoReadCallback(bool status, UWord addr, int count, vector<UWord> &values)
+void WIAnalog::WagoReadCallback(bool status, UWord addr, int count, std::vector<UWord> &values)
 {
     if (!status)
     {
@@ -109,4 +109,6 @@ void WIAnalog::readValue()
     Utils::from_string(get_param("var"), address);
 
     WagoMap::Instance(host, port).read_words((UWord)address, 1, sigc::mem_fun(*this, &WIAnalog::WagoReadCallback));
+}
+
 }

--- a/src/bin/calaos_server/IO/Wago/WIAnalog.h
+++ b/src/bin/calaos_server/IO/Wago/WIAnalog.h
@@ -39,7 +39,7 @@ protected:
 
     virtual void readValue();
 
-    void WagoReadCallback(bool status, UWord address, int count, vector<UWord> &values);
+    void WagoReadCallback(bool status, UWord address, int count, std::vector<UWord> &values);
 
 public:
     WIAnalog(Params &p);

--- a/src/bin/calaos_server/IO/Wago/WIDigitalBP.cpp
+++ b/src/bin/calaos_server/IO/Wago/WIDigitalBP.cpp
@@ -22,7 +22,7 @@
 #include <WagoMap.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WIDigitalBP)
 REGISTER_IO_USERTYPE(WIDigital, WIDigitalBP)
@@ -87,7 +87,7 @@ void WIDigitalBP::ReceiveFromWago(std::string ip, int addr, bool val, std::strin
     }
 }
 
-void WIDigitalBP::WagoReadCallback(bool status, UWord addr, int count, vector<bool> &values)
+void WIDigitalBP::WagoReadCallback(bool status, UWord addr, int count, std::vector<bool> &values)
 {
     if (!status)
     {
@@ -133,3 +133,5 @@ bool WIDigitalBP::readValue()
     return udp_value;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Wago/WIDigitalBP.h
+++ b/src/bin/calaos_server/IO/Wago/WIDigitalBP.h
@@ -39,7 +39,7 @@ protected:
     bool udp_value;
     bool initial;
 
-    void WagoReadCallback(bool status, UWord address, int count, vector<bool> &values);
+    void WagoReadCallback(bool status, UWord address, int count, std::vector<bool> &values);
 
     virtual bool readValue();
 

--- a/src/bin/calaos_server/IO/Wago/WIDigitalLong.cpp
+++ b/src/bin/calaos_server/IO/Wago/WIDigitalLong.cpp
@@ -22,7 +22,7 @@
 #include <WagoMap.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WIDigitalLong)
 REGISTER_IO_USERTYPE(WagoInputSwitchLongPress, WIDigitalLong)
@@ -73,7 +73,7 @@ void WIDigitalLong::ReceiveFromWago(std::string ip, int addr, bool val, std::str
     }
 }
 
-void WIDigitalLong::WagoReadCallback(bool status, UWord addr, int nb, vector<bool> &values)
+void WIDigitalLong::WagoReadCallback(bool status, UWord addr, int nb, std::vector<bool> &values)
 {
     if (!status)
     {
@@ -98,3 +98,5 @@ bool WIDigitalLong::readValue()
     return udp_value;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Wago/WIDigitalLong.h
+++ b/src/bin/calaos_server/IO/Wago/WIDigitalLong.h
@@ -38,7 +38,7 @@ protected:
 
     bool udp_value;
 
-    void WagoReadCallback(bool status, UWord address, int count, vector<bool> &values);
+    void WagoReadCallback(bool status, UWord address, int count, std::vector<bool> &values);
 
     virtual bool readValue();
 

--- a/src/bin/calaos_server/IO/Wago/WIDigitalTriple.cpp
+++ b/src/bin/calaos_server/IO/Wago/WIDigitalTriple.cpp
@@ -22,7 +22,7 @@
 #include <WagoMap.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WIDigitalTriple)
 REGISTER_IO_USERTYPE(WagoInputSwitchTriple, WIDigitalTriple)
@@ -73,7 +73,7 @@ void WIDigitalTriple::ReceiveFromWago(std::string ip, int addr, bool val, std::s
     }
 }
 
-void WIDigitalTriple::WagoReadCallback(bool status, UWord addr, int nb, vector<bool> &values)
+void WIDigitalTriple::WagoReadCallback(bool status, UWord addr, int nb, std::vector<bool> &values)
 {
     if (!status)
     {
@@ -98,3 +98,5 @@ bool WIDigitalTriple::readValue()
     return udp_value;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Wago/WIDigitalTriple.h
+++ b/src/bin/calaos_server/IO/Wago/WIDigitalTriple.h
@@ -39,7 +39,7 @@ protected:
 
     bool udp_value;
 
-    void WagoReadCallback(bool status, UWord address, int count, vector<bool> &values);
+    void WagoReadCallback(bool status, UWord address, int count, std::vector<bool> &values);
 
     virtual bool readValue();
 

--- a/src/bin/calaos_server/IO/Wago/WITemp.cpp
+++ b/src/bin/calaos_server/IO/Wago/WITemp.cpp
@@ -22,7 +22,7 @@
 #include <WagoMap.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WITemp)
 REGISTER_IO_USERTYPE(WagoInputTemp, WITemp)
@@ -62,7 +62,7 @@ WITemp::~WITemp()
     cDebugDom("input") << get_param("id") << ": Ok";
 }
 
-void WITemp::WagoReadCallback(bool status, UWord addr, int count, vector<UWord> &values)
+void WITemp::WagoReadCallback(bool status, UWord addr, int count, std::vector<UWord> &values)
 {
     if (!status)
     {
@@ -97,4 +97,6 @@ void WITemp::WagoReadCallback(bool status, UWord addr, int count, vector<UWord> 
 void WITemp::readValue()
 {
     WagoMap::Instance(host, port).read_words((UWord)address, 1, sigc::mem_fun(*this, &WITemp::WagoReadCallback));
+}
+
 }

--- a/src/bin/calaos_server/IO/Wago/WITemp.h
+++ b/src/bin/calaos_server/IO/Wago/WITemp.h
@@ -37,7 +37,7 @@ protected:
 
     bool start;
 
-    void WagoReadCallback(bool status, UWord address, int count, vector<UWord> &values);
+    void WagoReadCallback(bool status, UWord address, int count, std::vector<UWord> &values);
 
     virtual void readValue();
 

--- a/src/bin/calaos_server/IO/Wago/WOAnalog.cpp
+++ b/src/bin/calaos_server/IO/Wago/WOAnalog.cpp
@@ -22,8 +22,7 @@
 #include <WagoMap.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
-using namespace Utils;
+namespace Calaos {
 
 REGISTER_IO(WOAnalog)
 REGISTER_IO_USERTYPE(WagoOutputAnalog, WOAnalog)
@@ -63,7 +62,7 @@ WOAnalog::~WOAnalog()
     cDebugDom("output");
 }
 
-void WOAnalog::WagoReadCallback(bool status, UWord addr, int count, vector<UWord> &values)
+void WOAnalog::WagoReadCallback(bool status, UWord addr, int count, std::vector<UWord> &values)
 {
     if (!status)
     {
@@ -103,4 +102,6 @@ void WOAnalog::set_value_real(double val)
         Utils::from_string(get_param("port"), port);
 
     WagoMap::Instance(host, port).write_single_word((UWord)address, val, sigc::mem_fun(*this, &WOAnalog::WagoWriteCallback));
+}
+
 }

--- a/src/bin/calaos_server/IO/Wago/WOAnalog.h
+++ b/src/bin/calaos_server/IO/Wago/WOAnalog.h
@@ -36,7 +36,7 @@ private:
 
     virtual void set_value_real(double val);
 
-    void WagoReadCallback(bool status, UWord address, int count, vector<UWord> &values);
+    void WagoReadCallback(bool status, UWord address, int count, std::vector<UWord> &values);
     void WagoWriteCallback(bool status, UWord address, UWord value);
 
 public:

--- a/src/bin/calaos_server/IO/Wago/WODali.cpp
+++ b/src/bin/calaos_server/IO/Wago/WODali.cpp
@@ -22,7 +22,7 @@
 #include <WagoMap.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WODali)
 REGISTER_IO_USERTYPE(WagoOutputDimmer, WODali)
@@ -55,7 +55,7 @@ WODali::WODali(Params &_p):
     if (!get_params().Exists("line")) set_param("line", "1");
     if (!get_params().Exists("fade_time")) set_param("fade_time", "1");
 
-    string cmd = "WAGO_DALI_GET " + get_param("line") + " " + get_param("address");
+    std::string cmd = "WAGO_DALI_GET " + get_param("line") + " " + get_param("address");
     WagoMap::Instance(host, port).SendUDPCommand(cmd, sigc::mem_fun(*this, &WODali::WagoUDPCommand_cb));
 
     Calaos::StartReadRules::Instance().addIO();
@@ -69,7 +69,7 @@ WODali::~WODali()
 
 bool WODali::set_value_real(int val)
 {
-    string cmd = "WAGO_DALI_SET " + get_param("line") + " " + get_param("group") +
+    std::string cmd = "WAGO_DALI_SET " + get_param("line") + " " + get_param("group") +
                  " " + get_param("address") + " " + Utils::to_string(val) +
                  " " + get_param("fade_time");
     WagoMap::Instance(host, port).SendUDPCommand(cmd);
@@ -77,7 +77,7 @@ bool WODali::set_value_real(int val)
     return true;
 }
 
-void WODali::WagoUDPCommand_cb(bool status, string command, string result)
+void WODali::WagoUDPCommand_cb(bool status, std::string command, std::string result)
 {
     if (!status)
     {
@@ -87,9 +87,9 @@ void WODali::WagoUDPCommand_cb(bool status, string command, string result)
         return;
     }
 
-    if (command.find("WAGO_DALI_GET") != string::npos)
+    if (command.find("WAGO_DALI_GET") != std::string::npos)
     {
-        vector<string> tokens;
+        std::vector<std::string> tokens;
         split(result, tokens);
         if (tokens.size() >= 3)
         {
@@ -110,4 +110,6 @@ void WODali::WagoUDPCommand_cb(bool status, string command, string result)
     }
 
     Calaos::StartReadRules::Instance().ioRead();
+}
+
 }

--- a/src/bin/calaos_server/IO/Wago/WODali.h
+++ b/src/bin/calaos_server/IO/Wago/WODali.h
@@ -35,7 +35,7 @@ private:
 
     virtual bool set_value_real(int val);
 
-    void WagoUDPCommand_cb(bool status, string command, string result);
+    void WagoUDPCommand_cb(bool status, std::string command, std::string result);
 
 public:
     WODali(Params &p);

--- a/src/bin/calaos_server/IO/Wago/WODaliRVB.cpp
+++ b/src/bin/calaos_server/IO/Wago/WODaliRVB.cpp
@@ -22,7 +22,7 @@
 #include <WagoMap.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WODaliRVB)
 REGISTER_IO_USERTYPE(WagoOutputDimmerRGB, WODaliRVB)
@@ -65,7 +65,7 @@ WODaliRVB::WODaliRVB(Params &_p):
     WagoMap::Instance(host, port);
 
     //reqd initial state
-    string cmd;
+    std::string cmd;
     cmd = "WAGO_DALI_GET " + get_param("rline") + " " + get_param("raddress");
     WagoMap::Instance(host, port).SendUDPCommand(cmd, sigc::mem_fun(*this, &WODaliRVB::WagoUDPCommandRed_cb));
     cmd = "WAGO_DALI_GET " + get_param("gline") + " " + get_param("gaddress");
@@ -85,7 +85,7 @@ WODaliRVB::~WODaliRVB()
     cDebugDom("output");
 }
 
-void WODaliRVB::WagoUDPCommandRed_cb(bool status, string command, string result)
+void WODaliRVB::WagoUDPCommandRed_cb(bool status, std::string command, std::string result)
 {
     if (!status)
     {
@@ -95,7 +95,7 @@ void WODaliRVB::WagoUDPCommandRed_cb(bool status, string command, string result)
         return;
     }
 
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(result, tokens);
     if (tokens.size() >= 3)
     {
@@ -106,7 +106,7 @@ void WODaliRVB::WagoUDPCommandRed_cb(bool status, string command, string result)
     Calaos::StartReadRules::Instance().ioRead();
 }
 
-void WODaliRVB::WagoUDPCommandGreen_cb(bool status, string command, string result)
+void WODaliRVB::WagoUDPCommandGreen_cb(bool status, std::string command, std::string result)
 {
     if (!status)
     {
@@ -116,7 +116,7 @@ void WODaliRVB::WagoUDPCommandGreen_cb(bool status, string command, string resul
         return;
     }
 
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(result, tokens);
     if (tokens.size() >= 3)
     {
@@ -127,7 +127,7 @@ void WODaliRVB::WagoUDPCommandGreen_cb(bool status, string command, string resul
     Calaos::StartReadRules::Instance().ioRead();
 }
 
-void WODaliRVB::WagoUDPCommandBlue_cb(bool status, string command, string result)
+void WODaliRVB::WagoUDPCommandBlue_cb(bool status, std::string command, std::string result)
 {
     if (!status)
     {
@@ -137,7 +137,7 @@ void WODaliRVB::WagoUDPCommandBlue_cb(bool status, string command, string result
         return;
     }
 
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(result, tokens);
     if (tokens.size() >= 3)
     {
@@ -159,7 +159,7 @@ void WODaliRVB::checkReadState()
     stateUpdated(c, red != 0 || green != 0 || blue != 0);
 }
 
-void WODaliRVB::WagoUDPCommand_cb(bool status, string command, string)
+void WODaliRVB::WagoUDPCommand_cb(bool status, std::string command, std::string)
 {
     if (!status)
     {
@@ -179,7 +179,7 @@ void WODaliRVB::setColorReal(const ColorValue &c, bool s)
         b = c.getBlue();
     }
 
-    string cmd = "WAGO_DALI_SET " + get_param("rline") + " " + get_param("rgroup") +
+    std::string cmd = "WAGO_DALI_SET " + get_param("rline") + " " + get_param("rgroup") +
                  " " + get_param("raddress") + " " + Utils::to_string((r * 100) / 255) +
                  " " + get_param("rfade_time");
     WagoMap::Instance(host, port).SendUDPCommand(cmd);
@@ -195,3 +195,5 @@ void WODaliRVB::setColorReal(const ColorValue &c, bool s)
     WagoMap::Instance(host, port).SendUDPCommand(cmd);
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Wago/WODaliRVB.h
+++ b/src/bin/calaos_server/IO/Wago/WODaliRVB.h
@@ -35,10 +35,10 @@ private:
 
     int red = -1, green = -1, blue = -1;
 
-    void WagoUDPCommandRed_cb(bool status, string command, string result);
-    void WagoUDPCommandGreen_cb(bool status, string command, string result);
-    void WagoUDPCommandBlue_cb(bool status, string command, string result);
-    void WagoUDPCommand_cb(bool status, string command, string result);
+    void WagoUDPCommandRed_cb(bool status, std::string command, std::string result);
+    void WagoUDPCommandGreen_cb(bool status, std::string command, std::string result);
+    void WagoUDPCommandBlue_cb(bool status, std::string command, std::string result);
+    void WagoUDPCommand_cb(bool status, std::string command, std::string result);
 
     void checkReadState();
 

--- a/src/bin/calaos_server/IO/Wago/WODigital.cpp
+++ b/src/bin/calaos_server/IO/Wago/WODigital.cpp
@@ -22,7 +22,7 @@
 #include <IOFactory.h>
 #include <WagoMap.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WODigital)
 REGISTER_IO_USERTYPE(WagoOutputLight, WODigital)
@@ -75,7 +75,7 @@ WODigital::~WODigital()
     cDebugDom("output");
 }
 
-void WODigital::WagoReadCallback(bool status, UWord addr, int count, vector<bool> &values)
+void WODigital::WagoReadCallback(bool status, UWord addr, int count, std::vector<bool> &values)
 {
     if (!status)
     {
@@ -128,3 +128,5 @@ bool WODigital::set_value_real(bool val)
     return true;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Wago/WODigital.h
+++ b/src/bin/calaos_server/IO/Wago/WODigital.h
@@ -37,7 +37,7 @@ private:
 
     bool start;
 
-    void WagoReadCallback(bool status, UWord address, int count, vector<bool> &values);
+    void WagoReadCallback(bool status, UWord address, int count, std::vector<bool> &values);
     void WagoWriteCallback(bool status, UWord address, bool value);
 
 protected:

--- a/src/bin/calaos_server/IO/Wago/WOVolet.cpp
+++ b/src/bin/calaos_server/IO/Wago/WOVolet.cpp
@@ -22,7 +22,7 @@
 #include <WagoMap.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WOVolet)
 REGISTER_IO_USERTYPE(WagoOutputShutter, WOVolet)
@@ -94,4 +94,6 @@ void WOVolet::WagoWriteCallback(bool status, UWord address, bool value)
         cErrorDom("output") << get_param("id") << ": Failed to write value";
         return;
     }
+}
+
 }

--- a/src/bin/calaos_server/IO/Wago/WOVoletSmart.cpp
+++ b/src/bin/calaos_server/IO/Wago/WOVoletSmart.cpp
@@ -22,7 +22,7 @@
 #include <WagoMap.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WOVoletSmart)
 REGISTER_IO_USERTYPE(WagoOutputShutterSmart, WOVoletSmart)
@@ -96,4 +96,6 @@ void WOVoletSmart::WagoWriteCallback(bool status, UWord address, bool value)
         cErrorDom("output") << get_param("id") << ": Failed to write value";
         return;
     }
+}
+
 }

--- a/src/bin/calaos_server/IO/Wago/WagoCtrl.cpp
+++ b/src/bin/calaos_server/IO/Wago/WagoCtrl.cpp
@@ -20,8 +20,8 @@
  ******************************************************************************/
 #include <WagoCtrl.h>
 
-using namespace Utils;
 
+namespace Calaos {
 WagoCtrl::WagoCtrl(std::string h, int p):
     host(h),
     port(p)
@@ -90,7 +90,7 @@ bool WagoCtrl::is_connected()
         return false;
 }
 
-bool WagoCtrl::read_bits(UWord address, int nb, vector<bool> &values)
+  bool WagoCtrl::read_bits(Utils::UWord address, int nb, std::vector<bool> &values)
 {
     if (!is_connected()) return false;
 
@@ -116,7 +116,7 @@ bool WagoCtrl::read_bits(UWord address, int nb, vector<bool> &values)
     }
 }
 
-bool WagoCtrl::write_single_bit(UWord address, bool val)
+bool WagoCtrl::write_single_bit(Utils::UWord address, bool val)
 {
     if (!is_connected()) return false;
 
@@ -138,9 +138,9 @@ bool WagoCtrl::write_single_bit(UWord address, bool val)
     }
 }
 
-bool WagoCtrl::read_single_output_bit(UWord address)
+bool WagoCtrl::read_single_output_bit(Utils::UWord address)
 {
-    vector<bool> v;
+    std::vector<bool> v;
 
     if (!read_bits(address + 0x200, 1, v))
         return false;
@@ -151,7 +151,7 @@ bool WagoCtrl::read_single_output_bit(UWord address)
     return false;
 }
 
-bool WagoCtrl::write_multiple_bits(UWord address, int nb, vector<bool> &values)
+bool WagoCtrl::write_multiple_bits(Utils::UWord address, int nb, std::vector<bool> &values)
 {
     if (!is_connected()) return false;
 
@@ -177,7 +177,7 @@ bool WagoCtrl::write_multiple_bits(UWord address, int nb, vector<bool> &values)
     }
 }
 
-bool WagoCtrl::read_words(UWord address, int nb, vector<UWord> &values)
+bool WagoCtrl::read_words(Utils::UWord address, int nb, std::vector<Utils::UWord> &values)
 {
     if (!is_connected()) return false;
 
@@ -201,7 +201,7 @@ bool WagoCtrl::read_words(UWord address, int nb, vector<UWord> &values)
     }
 }
 
-bool WagoCtrl::write_single_word(UWord address, UWord val)
+bool WagoCtrl::write_single_word(Utils::UWord address, Utils::UWord val)
 {
     if (!is_connected()) return false;
 
@@ -219,7 +219,7 @@ bool WagoCtrl::write_single_word(UWord address, UWord val)
     }
 }
 
-bool WagoCtrl::write_multiple_words(UWord address, int nb, vector<UWord> &values)
+bool WagoCtrl::write_multiple_words(Utils::UWord address, int nb, std::vector<Utils::UWord> &values)
 {
     if (!is_connected()) return false;
 
@@ -241,4 +241,6 @@ bool WagoCtrl::write_multiple_words(UWord address, int nb, vector<UWord> &values
         cInfoDom("wago") << "WagoCtrl::write_multiple_words(): Ok";
         return true;
     }
+}
+
 }

--- a/src/bin/calaos_server/IO/Wago/WagoCtrl.h
+++ b/src/bin/calaos_server/IO/Wago/WagoCtrl.h
@@ -24,6 +24,8 @@
 #include <Utils.h>
 #include <mbus.h>
 
+namespace Calaos {
+
 class WagoCtrl
 {
 protected:
@@ -43,20 +45,22 @@ public:
     bool is_connected();
 
     //bits
-    bool read_bits(Utils::UWord address, int nb, vector<bool> &values);
+    bool read_bits(Utils::UWord address, int nb, std::vector<bool> &values);
     bool write_single_bit(Utils::UWord address, bool val);
     bool read_single_output_bit(Utils::UWord address);
-    bool write_multiple_bits(Utils::UWord address, int nb, vector<bool> &values);
+    bool write_multiple_bits(Utils::UWord address, int nb, std::vector<bool> &values);
 
     //Words
-    bool read_words(Utils::UWord address, int nb, vector<Utils::UWord> &values);
+    bool read_words(Utils::UWord address, int nb, std::vector<Utils::UWord> &values);
     bool write_single_word(Utils::UWord address, Utils::UWord val);
-    bool write_multiple_words(Utils::UWord address, int nb, vector<Utils::UWord> &values);
+    bool write_multiple_words(Utils::UWord address, int nb, std::vector<Utils::UWord> &values);
 
     void set_host(std::string &h) { host = h; }
     std::string get_host() { return host; }
     void set_port(int p) { port = p; }
     int get_port() { return port; }
 };
+
+}
 
 #endif

--- a/src/bin/calaos_server/IO/Wago/WagoExternProc_main.cpp
+++ b/src/bin/calaos_server/IO/Wago/WagoExternProc_main.cpp
@@ -22,6 +22,7 @@
 
 #include "WagoCtrl.h"
 
+namespace Calaos {
 class WagoProcess: public ExternProcClient
 {
 public:
@@ -35,12 +36,12 @@ public:
 protected:
 
     WagoCtrl *wago = nullptr;
-    string wago_host;
+    std::string wago_host;
     int wago_port = 502;
 
     //needs to be reimplemented
     virtual void readTimeout();
-    virtual void messageReceived(const string &msg);
+    virtual void messageReceived(const std::string &msg);
 };
 
 void WagoProcess::readTimeout()
@@ -52,7 +53,7 @@ void WagoProcess::readTimeout()
     }
 }
 
-void WagoProcess::messageReceived(const string &msg)
+void WagoProcess::messageReceived(const std::string &msg)
 {
     json_error_t jerr;
     json_t *jroot = json_loads(msg.c_str(), 0, &jerr);
@@ -65,7 +66,7 @@ void WagoProcess::messageReceived(const string &msg)
         return;
     }
 
-    string res;
+    std::string res;
 
     Params jsonData;
     jansson_decode_object(jroot, jsonData);
@@ -73,15 +74,15 @@ void WagoProcess::messageReceived(const string &msg)
     if (jsonData["action"] == "read_bits" ||
         jsonData["action"] == "read_output_bits")
     {
-        UWord address;
+        Utils::UWord address;
         int count;
-        vector<bool> values_bits;
+        std::vector<bool> values_bits;
         bool status = true;
 
         Utils::from_string(jsonData["address"], address);
         Utils::from_string(jsonData["count"], count);
 
-        UWord offset = 0;
+        Utils::UWord offset = 0;
         if (jsonData["action"] == "read_output_bits")
             offset = 0x200;
 
@@ -113,7 +114,7 @@ void WagoProcess::messageReceived(const string &msg)
     }
     else if (jsonData["action"] == "write_bit")
     {
-        UWord address;
+        Utils::UWord address;
         bool value = jsonData["value"] == "true";
         bool status = true;
 
@@ -139,9 +140,9 @@ void WagoProcess::messageReceived(const string &msg)
     }
     else if (jsonData["action"] == "write_bits")
     {
-        UWord address;
+        Utils::UWord address;
         int count;
-        vector<bool> values_bits;
+        std::vector<bool> values_bits;
         bool status = true;
 
         Utils::from_string(jsonData["address"], address);
@@ -154,7 +155,7 @@ void WagoProcess::messageReceived(const string &msg)
 
         json_array_foreach(json_object_get(jroot, "values"), idx, value)
         {
-            string v = json_string_value(value);
+            std::string v = json_string_value(value);
             values_bits.push_back(v == "true");
         }
 
@@ -177,15 +178,15 @@ void WagoProcess::messageReceived(const string &msg)
     else if (jsonData["action"] == "read_words" ||
              jsonData["action"] == "read_output_words")
     {
-        UWord address;
+        Utils::UWord address;
         int count;
-        vector<UWord> values_words;
+        std::vector<Utils::UWord> values_words;
         bool status = true;
 
         Utils::from_string(jsonData["address"], address);
         Utils::from_string(jsonData["count"], count);
 
-        UWord offset = 0;
+        Utils::UWord offset = 0;
         if (jsonData["action"] == "read_output_words")
             offset = 0x200;
 
@@ -217,8 +218,8 @@ void WagoProcess::messageReceived(const string &msg)
     }
     else if (jsonData["action"] == "write_word")
     {
-        UWord address;
-        UWord value;
+        Utils::UWord address;
+        Utils::UWord value;
         bool status = true;
 
         Utils::from_string(jsonData["address"], address);
@@ -244,9 +245,9 @@ void WagoProcess::messageReceived(const string &msg)
     }
     else if (jsonData["action"] == "write_words")
     {
-        UWord address;
+        Utils::UWord address;
         int count;
-        vector<UWord> values_words;
+        std::vector<Utils::UWord> values_words;
         bool status = true;
 
         Utils::from_string(jsonData["address"], address);
@@ -259,8 +260,8 @@ void WagoProcess::messageReceived(const string &msg)
 
         json_array_foreach(json_object_get(jroot, "values"), idx, value)
         {
-            string v = json_string_value(value);
-            UWord vv;
+            std::string v = json_string_value(value);
+            Utils::UWord vv;
             Utils::from_string(v, vv);
             values_words.push_back(vv);
         }
@@ -316,4 +317,7 @@ int WagoProcess::procMain()
     return 0;
 }
 
-EXTERN_PROC_CLIENT_MAIN(WagoProcess)
+
+}
+
+EXTERN_PROC_CLIENT_MAIN(Calaos::WagoProcess)

--- a/src/bin/calaos_server/IO/Wago/WagoMap.cpp
+++ b/src/bin/calaos_server/IO/Wago/WagoMap.cpp
@@ -23,9 +23,8 @@
 #include <tcpsocket.h>
 #include "Prefix.h"
 
-using namespace Utils;
-using namespace Calaos;
 
+namespace Calaos {
 static Eina_Bool _ecore_con_handler_data_get(void *data, int type, Ecore_Con_Event_Server_Data *ev);
 
 WagoMapManager WagoMap::wagomaps;
@@ -57,7 +56,7 @@ WagoMap::WagoMap(std::string h, int p):
 
     exe = Prefix::Instance().binDirectoryGet() + "/calaos_wago";
 
-    string args = host;
+    std::string args = host;
     args += " " + Utils::to_string(port);
 
     process->messageReceived.connect(sigc::mem_fun(*this, &WagoMap::processNewMessage));
@@ -121,13 +120,13 @@ void WagoMap::WagoModbusHeartBeatTick()
     read_bits(0, 1, sigc::mem_fun(*this, &WagoMap::WagoModbusReadHeartbeatCallback));
 }
 
-void WagoMap::WagoModbusReadHeartbeatCallback(bool status, UWord address, int count, vector<bool> &values)
+void WagoMap::WagoModbusReadHeartbeatCallback(bool status, UWord address, int count, std::vector<bool> &values)
 {
     if (!status)
         cErrorDom("wago") << "failed to read !";
 }
 
-void WagoMap::processNewMessage(const string &msg)
+void WagoMap::processNewMessage(const std::string &msg)
 {
     json_error_t jerr;
     json_t *jroot = json_loads(msg.c_str(), 0, &jerr);
@@ -151,8 +150,8 @@ void WagoMap::processNewMessage(const string &msg)
 
     UWord address = 0;
     int count = 0;
-    vector<bool> values_bits;
-    vector<UWord> values_words;
+    std::vector<bool> values_bits;
+    std::vector<UWord> values_words;
     bool status = jsonData["status"] == "true";
 
     Utils::from_string(jsonData["address"], address);
@@ -166,7 +165,7 @@ void WagoMap::processNewMessage(const string &msg)
 
         json_array_foreach(json_object_get(jroot, "values"), idx, value)
         {
-            string v = json_string_value(value);
+            std::string v = json_string_value(value);
             values_bits.push_back(v == "true");
         }
 
@@ -191,7 +190,7 @@ void WagoMap::processNewMessage(const string &msg)
 
         json_array_foreach(json_object_get(jroot, "values"), idx, value)
         {
-            string v = json_string_value(value);
+            std::string v = json_string_value(value);
             UWord vv;
             Utils::from_string(v, vv);
             values_words.push_back(vv);
@@ -267,7 +266,7 @@ void WagoMap::write_single_bit(UWord address, bool val, SingleBit_cb callback)
     mbus_commands[cmd.wago_cmd_id] = cmd;
 }
 
-void WagoMap::write_multiple_bits(UWord address, int nb, vector<bool> &values, MultiBits_cb callback)
+void WagoMap::write_multiple_bits(UWord address, int nb, std::vector<bool> &values, MultiBits_cb callback)
 {
     WagoMapCmd cmd(MBUS_WRITE_BITS);
     cmd.createSignals();
@@ -341,7 +340,7 @@ void WagoMap::write_single_word(UWord address, UWord val, SingleWord_cb callback
     mbus_commands[cmd.wago_cmd_id] = cmd;
 }
 
-void WagoMap::write_multiple_words(UWord address, int nb, vector<UWord> &values, MultiWords_cb callback)
+void WagoMap::write_multiple_words(UWord address, int nb, std::vector<UWord> &values, MultiWords_cb callback)
 {
     WagoMapCmd cmd(MBUS_WRITE_WORDS);
     cmd.createSignals();
@@ -375,7 +374,7 @@ Eina_Bool _ecore_con_handler_data_get(void *data, int type, Ecore_Con_Event_Serv
 
     if (w)
     {
-        string d((char *)ev->data, ev->size);
+        std::string d((char *)ev->data, ev->size);
 
         w->udpRequest_cb(true, d);
     }
@@ -387,7 +386,7 @@ Eina_Bool _ecore_con_handler_data_get(void *data, int type, Ecore_Con_Event_Serv
     return ECORE_CALLBACK_RENEW;
 }
 
-void WagoMap::SendUDPCommand(string command, WagoUdp_cb callback)
+void WagoMap::SendUDPCommand(std::string command, WagoUdp_cb callback)
 {
     bool restart_timer = false;
 
@@ -411,7 +410,7 @@ void WagoMap::SendUDPCommand(string command, WagoUdp_cb callback)
     }
 }
 
-void WagoMap::SendUDPCommand(string command)
+void WagoMap::SendUDPCommand(std::string command)
 {
     bool restart_timer = false;
 
@@ -434,7 +433,7 @@ void WagoMap::SendUDPCommand(string command)
     }
 }
 
-void WagoMap::udpRequest_cb(bool status, string res)
+void WagoMap::udpRequest_cb(bool status, std::string res)
 {
     if (udp_timeout_timer)
     {
@@ -495,10 +494,10 @@ void WagoMap::WagoHeartBeatTick()
     if (heartbeat_timer->getTime() < 10.0)
         heartbeat_timer->Reset(10.0);
 
-    string ip = TCPSocket::GetLocalIPFor(get_host());
+    std::string ip = TCPSocket::GetLocalIPFor(get_host());
     if (ip != "")
     {
-        string cmd = "WAGO_SET_SERVER_IP ";
+        std::string cmd = "WAGO_SET_SERVER_IP ";
         cmd += ip;
 
         SendUDPCommand(cmd);
@@ -510,4 +509,6 @@ void WagoMap::WagoHeartBeatTick()
     {
         cDebugDom("wago") << "No interface found corresponding to network : " << get_host();
     }
+}
+
 }

--- a/src/bin/calaos_server/IO/Wago/WagoMap.h
+++ b/src/bin/calaos_server/IO/Wago/WagoMap.h
@@ -29,13 +29,13 @@
 namespace Calaos
 {
 
-typedef sigc::slot<void, bool, UWord, int, vector<bool> &> MultiBits_cb;
+typedef sigc::slot<void, bool, UWord, int, std::vector<bool> &> MultiBits_cb;
 typedef sigc::slot<void, bool, UWord, bool> SingleBit_cb;
-typedef sigc::slot<void, bool, UWord, int, vector<UWord> &> MultiWords_cb;
+typedef sigc::slot<void, bool, UWord, int, std::vector<UWord> &> MultiWords_cb;
 typedef sigc::slot<void, bool, UWord, UWord> SingleWord_cb;
 
-typedef sigc::slot<void, bool, string, string> WagoUdp_cb;
-typedef sigc::signal<void, bool, string, string> WagoUdp_signal;
+typedef sigc::slot<void, bool, std::string, std::string> WagoUdp_cb;
+typedef sigc::signal<void, bool, std::string, std::string> WagoUdp_signal;
 
 enum { MBUS_NONE = 0, MBUS_READ_BITS, MBUS_READ_OUTBITS, MBUS_WRITE_BIT, MBUS_WRITE_BITS,
        MBUS_READ_WORDS, MBUS_READ_OUTWORDS, MBUS_WRITE_WORD, MBUS_WRITE_WORDS,
@@ -70,11 +70,11 @@ public:
 
     int command = MBUS_NONE;
 
-    string wago_cmd_id;
+    std::string wago_cmd_id;
 
     bool no_callback;
-    string udp_command;
-    string udp_result;
+    std::string udp_command;
+    std::string udp_result;
     bool inProgress;
 
     WagoMapSignals *mapSignals = nullptr;
@@ -93,7 +93,7 @@ public:
         maps.clear();
     }
 
-    vector<WagoMap *> maps;
+    std::vector<WagoMap *> maps;
 };
 
 class WagoMap: public sigc::trackable
@@ -104,30 +104,30 @@ protected:
     int port;
 
     ExternProcServer *process;
-    string exe;
+    std::string exe;
 
-    vector<bool> input_bits;
-    vector<bool> output_bits;
+    std::vector<bool> input_bits;
+    std::vector<bool> output_bits;
 
-    vector<UWord> input_words;
-    vector<UWord> output_words;
+    std::vector<UWord> input_words;
+    std::vector<UWord> output_words;
 
     WagoMap(std::string host, int port);
 
     static WagoMapManager wagomaps;
 
-    unordered_map<string, WagoMapCmd> mbus_commands;
+    std::unordered_map<std::string, WagoMapCmd> mbus_commands;
 
     /* Heartbeat timer that do a modbus query to avoid TCP disconnection with the Wago */
     EcoreTimer *mbus_heartbeat_timer;
 
-    queue<WagoMapCmd> udp_commands;
+    std::queue<WagoMapCmd> udp_commands;
     EcoreTimer *udp_timer;
     EcoreTimer *udp_timeout_timer;
     Ecore_Con_Server *econ;
     Ecore_Event_Handler *event_handler_data_get;
 
-    void processNewMessage(const string &msg);
+    void processNewMessage(const std::string &msg);
 
     /* Timer callback for udp commands */
     void UDPCommand_cb();
@@ -138,37 +138,37 @@ protected:
     void WagoHeartBeatTick();
     void WagoModbusHeartBeatTick();
 
-    void WagoModbusReadHeartbeatCallback(bool status, UWord address, int count, vector<bool> &values);
+    void WagoModbusReadHeartbeatCallback(bool status, UWord address, int count, std::vector<bool> &values);
 
 public:
     ~WagoMap();
 
     //Singleton
     static WagoMap &Instance(std::string host, int port);
-    static vector<WagoMap *> &get_maps() { return wagomaps.maps; }
+    static std::vector<WagoMap *> &get_maps() { return wagomaps.maps; }
     static void stopAllWagoMaps();
 
     //bits
     void read_bits(UWord address, int nb, MultiBits_cb callback);
     void read_output_bits(UWord address, int nb, MultiBits_cb callback);
     void write_single_bit(UWord address, bool val, SingleBit_cb callback);
-    void write_multiple_bits(UWord address, int nb, vector<bool> &values, MultiBits_cb callback);
+    void write_multiple_bits(UWord address, int nb, std::vector<bool> &values, MultiBits_cb callback);
 
     //Words
     void read_words(UWord address, int nb, MultiWords_cb callback);
     void read_output_words(UWord address, int nb, MultiWords_cb callback);
     void write_single_word(UWord address, UWord val, SingleWord_cb callback);
-    void write_multiple_words(UWord address, int nb, vector<UWord> &values, MultiWords_cb callback);
+    void write_multiple_words(UWord address, int nb, std::vector<UWord> &values, MultiWords_cb callback);
 
     std::string get_host() { return host; }
     int get_port() { return port; }
 
     //Send a command through the timer
-    void SendUDPCommand(string cmd, WagoUdp_cb callback);
-    void SendUDPCommand(string cmd);
+    void SendUDPCommand(std::string cmd, WagoUdp_cb callback);
+    void SendUDPCommand(std::string cmd);
 
     /* Private stuff used by C callbacks */
-    void udpRequest_cb(bool status, string res);
+    void udpRequest_cb(bool status, std::string res);
 
     sigc::signal<void> onWagoConnected;
     sigc::signal<void> onWagoDisconnected;

--- a/src/bin/calaos_server/IO/Web/WebCtrl.cpp
+++ b/src/bin/calaos_server/IO/Web/WebCtrl.cpp
@@ -26,9 +26,9 @@
 #include <TinyXML/xpath_processor.h>
 
 
-using namespace Calaos;
+namespace Calaos {
 
-unordered_map<string, WebCtrl> WebCtrl::hash;
+std::unordered_map<std::string, WebCtrl> WebCtrl::hash;
 
 WebCtrl::WebCtrl()
 {
@@ -55,11 +55,11 @@ WebCtrl::~WebCtrl()
 
 WebCtrl &WebCtrl::Instance(Params &p)
 {
-    string url = p.get_param("url");
+    std::string url = p.get_param("url");
 
     if (hash.find(url) == hash.end())
     {
-        string str_file_type = p.get_param("file_type");
+        std::string str_file_type = p.get_param("file_type");
         int file_type;
 
         if (str_file_type == "xml" || str_file_type == "XML")
@@ -78,7 +78,7 @@ WebCtrl &WebCtrl::Instance(Params &p)
 }
 
 
-void WebCtrl::Add(string path,
+void WebCtrl::Add(std::string path,
                   double _frequency,
                   std::function<void()> fileDownloaded_cb)
 {
@@ -105,7 +105,7 @@ void WebCtrl::Add(string path,
     launchDownload();
 }
 
-void WebCtrl::Del(string path)
+void WebCtrl::Del(std::string path)
 {
     for(unsigned int i = 0; i < fileDownloadedCallbacks.size(); i++)
     {
@@ -116,20 +116,20 @@ void WebCtrl::Del(string path)
 
 void WebCtrl::launchDownload()
 {
-    string filename = "/tmp/calaos_" + param.get_param("id") + ".part";
-    string u = param.get_param("url");
+    std::string filename = "/tmp/calaos_" + param.get_param("id") + ".part";
+    std::string u = param.get_param("url");
 
     if (u.find("http://") == 0)
     {
-        dlManager->add(param.get_param("url"), filename, [=](string emission, string source, void* data) {
-            string dest =  "/tmp/calaos_" + param.get_param("id");
-            string src = dest + ".part";
+        dlManager->add(param.get_param("url"), filename, [=](std::string emission, std::string source, void* data) {
+            std::string dest =  "/tmp/calaos_" + param.get_param("id");
+            std::string src = dest + ".part";
             ecore_file_mv(src.c_str(), dest.c_str());
             for(unsigned int i = 0; i < fileDownloadedCallbacks.size(); i++)
               {
                 fileDownloadedCallbacks[i].second();
               }
-          }, [=](string url, string destination_file, double dl_now, double dl_total, void *data) {
+          }, [=](std::string url, std::string destination_file, double dl_now, double dl_total, void *data) {
           }, NULL);
     }
     else
@@ -141,14 +141,14 @@ void WebCtrl::launchDownload()
     }
 }
 
-string WebCtrl::getValueJson(string path, string filename)
+std::string WebCtrl::getValueJson(std::string path, std::string filename)
 {
-    string value;
+    std::string value;
     json_t *root = nullptr, *parent = nullptr, *var = nullptr;
     json_error_t err;
 
-    vector<string> tokens;
-    vector<string>::iterator it;
+    std::vector<std::string> tokens;
+    std::vector<std::string>::iterator it;
 
     Utils::split(path, tokens, "/");
 
@@ -161,7 +161,7 @@ string WebCtrl::getValueJson(string path, string filename)
             parent = root;
             for (it = tokens.begin();it != tokens.end();it++)
             {
-                string val = *it;
+                std::string val = *it;
                 // Test if the token is an array index
                 // if it's the case, it must be something like [x]
                 if (val[0] == '[')
@@ -219,11 +219,11 @@ string WebCtrl::getValueJson(string path, string filename)
     return value;
 }
 
-string WebCtrl::getValueXml(string path, string filename)
+std::string WebCtrl::getValueXml(std::string path, std::string filename)
 {
     TiXmlDocument document(filename);
-    string value;
-    string xpath;
+    std::string value;
+    std::string xpath;
 
     if (!document.LoadFile())
     {
@@ -254,15 +254,15 @@ string WebCtrl::getValueXml(string path, string filename)
  * The value returned will be the 4th token of the second line : 20.3
  *
  */
-string WebCtrl::getValueText(string path, string filename)
+std::string WebCtrl::getValueText(std::string path, std::string filename)
 {
-    string value;
-    vector<string> tokens;
-    vector<string> items;
+    std::string value;
+    std::vector<std::string> tokens;
+    std::vector<std::string> items;
     int line_nb;
     unsigned int item_nb;
-    ifstream file(filename);
-    string line;
+    std::ifstream file(filename);
+    std::string line;
     int i;
 
     if (!file.is_open())
@@ -296,10 +296,10 @@ string WebCtrl::getValueText(string path, string filename)
 }
 
 
-double WebCtrl::getValueDouble(string path)
+double WebCtrl::getValueDouble(std::string path)
 {
     double val = 0;
-    string value;
+    std::string value;
 
     value = getValue(path);
     if (Utils::is_of_type<double>(value) && !value.empty())
@@ -307,10 +307,10 @@ double WebCtrl::getValueDouble(string path)
     return val;
 }
 
-string WebCtrl::getValue(string path)
+std::string WebCtrl::getValue(std::string path)
 {
-    string filename;
-    string url =  param.get_param("url");
+    std::string filename;
+    std::string url =  param.get_param("url");
 
     if (url.find("http://") != 0)
     {
@@ -335,22 +335,21 @@ string WebCtrl::getValue(string path)
         return "";
 }
 
-void WebCtrl::setValue(string value)
+void WebCtrl::setValue(std::string value)
 {
-    string url =  param.get_param("url");
-    string data = param.get_param("data");
-    string data_type = param.get_param("data_type");
+    std::string url =  param.get_param("url");
+    std::string data = param.get_param("data");
+    std::string data_type = param.get_param("data_type");
 
     // Case where there is no data to send, we assume the value is in the url
     if (param.get_param("data") == "")
     {
-    string filename;
-
-        replace_str(url, "__##VALUE##__", url_encode(value));
+        std::string filename;
+        Utils::replace_str(url, "__##VALUE##__", Utils::url_encode(value));
     }
     else
     {
-        replace_str(data, "__##VALUE##__", value);
+        Utils::replace_str(data, "__##VALUE##__", value);
     }
 
     FileDownloader *fdownloader = new FileDownloader(url, data, data_type, true);
@@ -364,3 +363,5 @@ void WebCtrl::setValue(string value)
 
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Web/WebCtrl.h
+++ b/src/bin/calaos_server/IO/Web/WebCtrl.h
@@ -38,30 +38,30 @@ private:
     DownloadManager *dlManager;
     double frequency;
     EcoreTimer *timer;
-    void downloadFinished(string emission, string source, void* data);
-    void downloadProgress(string url, string destination_file, double dl_now, double dl_total, void* data);
+    void downloadFinished(std::string emission, std::string source, void* data);
+    void downloadProgress(std::string url, std::string destination_file, double dl_now, double dl_total, void* data);
     Params param;
     int file_type;
-    static unordered_map<string, WebCtrl> hash;
+    static std::unordered_map<std::string, WebCtrl> hash;
     void launchDownload();
-    vector<pair<string, std::function<void()>>> fileDownloadedCallbacks;
+    std::vector<std::pair<std::string, std::function<void()>>> fileDownloadedCallbacks;
 
 public:
     static WebCtrl &Instance(Params &p); //Singleton
     WebCtrl();
     ~WebCtrl();
     enum {XML, JSON, TEXT, UNKNOWN};
-    void Add(string path, double _frequency = 60.0,
+    void Add(std::string path, double _frequency = 60.0,
              std::function<void()> fileDownloaded_cb = []() { cDebugDom("web") << "File downloaded"; });
-    void Del(string path);
+    void Del(std::string path);
 
-    string getValueJson(string path, string filename);
-    string getValueXml(string path, string filename);
-    string getValueText(string path, string filename);
-    string getValue(string path);
-    double getValueDouble(string path);
+    std::string getValueJson(std::string path, std::string filename);
+    std::string getValueXml(std::string path, std::string filename);
+    std::string getValueText(std::string path, std::string filename);
+    std::string getValue(std::string path);
+    double getValueDouble(std::string path);
 
-    void setValue(string value);
+    void setValue(std::string value);
 };
 
 }

--- a/src/bin/calaos_server/IO/Web/WebInputAnalog.cpp
+++ b/src/bin/calaos_server/IO/Web/WebInputAnalog.cpp
@@ -28,7 +28,7 @@
 #include <jansson.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WebInputAnalog)
 
@@ -87,3 +87,5 @@ void WebInputAnalog::readValue()
 }
 
 
+
+}

--- a/src/bin/calaos_server/IO/Web/WebInputString.cpp
+++ b/src/bin/calaos_server/IO/Web/WebInputString.cpp
@@ -27,7 +27,7 @@
 #include <WebCtrl.h>
 #include <jansson.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WebInputString)
 
@@ -84,4 +84,6 @@ void WebInputString::readValue()
     value = WebCtrl::Instance(get_params()).getValue(get_param("path"));
     cInfoDom("input") << "Read string value : " << value;
     emitChange();
+}
+
 }

--- a/src/bin/calaos_server/IO/Web/WebInputTemp.cpp
+++ b/src/bin/calaos_server/IO/Web/WebInputTemp.cpp
@@ -28,7 +28,7 @@
 #include <jansson.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WebInputTemp)
 
@@ -85,3 +85,5 @@ void WebInputTemp::readValue()
     emitChange();
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Web/WebOutputLight.cpp
+++ b/src/bin/calaos_server/IO/Web/WebOutputLight.cpp
@@ -27,7 +27,7 @@
 #include <WebCtrl.h>
 #include <jansson.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WebOutputLight)
 
@@ -89,8 +89,8 @@ void WebOutputLight::readValue()
 
 bool WebOutputLight::set_value_real(bool val)
 {
-    string on_value = "on";
-    string off_value = "off";
+    std::string on_value = "on";
+    std::string off_value = "off";
 
     if (get_params().Exists("on_value"))
         on_value = get_param("on_value");
@@ -103,4 +103,6 @@ bool WebOutputLight::set_value_real(bool val)
         WebCtrl::Instance(get_params()).setValue(off_value);
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IO/Web/WebOutputLightRGB.cpp
+++ b/src/bin/calaos_server/IO/Web/WebOutputLightRGB.cpp
@@ -27,7 +27,7 @@
 #include <WebCtrl.h>
 #include <jansson.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WebOutputLightRGB)
 
@@ -83,9 +83,11 @@ void WebOutputLightRGB::readValue()
 
 void WebOutputLightRGB::setColorReal(const ColorValue &c, bool s)
 {
-    string cStr = c.toString();
+    std::string cStr = c.toString();
     if (raw_value && cStr[0] == '#')
             cStr.erase(0, 1);
 
     WebCtrl::Instance(get_params()).setValue(cStr);
+}
+
 }

--- a/src/bin/calaos_server/IO/Web/WebOutputString.cpp
+++ b/src/bin/calaos_server/IO/Web/WebOutputString.cpp
@@ -27,7 +27,7 @@
 #include <WebCtrl.h>
 #include <jansson.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(WebOutputString)
 
@@ -88,8 +88,10 @@ void WebOutputString::readValue()
 }
 
 
-void WebOutputString::set_value_real(string val)
+void WebOutputString::set_value_real(std::string val)
 {
     cInfoDom("output") << "Set new string value " << val;
     WebCtrl::Instance(get_params()).setValue(val);
+}
+
 }

--- a/src/bin/calaos_server/IO/Web/WebOutputString.h
+++ b/src/bin/calaos_server/IO/Web/WebOutputString.h
@@ -33,7 +33,7 @@ class WebOutputString : public OutputString
 
 protected:
     virtual void readValue();
-    virtual void set_value_real(string val);
+    virtual void set_value_real(std::string val);
 
 public:
     WebOutputString(Params &p);

--- a/src/bin/calaos_server/IO/X10/X10Output.cpp
+++ b/src/bin/calaos_server/IO/X10/X10Output.cpp
@@ -22,7 +22,7 @@
 #include <Ecore.h>
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(X10Output)
 
@@ -94,38 +94,38 @@ bool X10Output::set_value_real(int val)
 
 bool X10Output::X10Command(std::string cmd, int *dval)
 {
-    vector<string> argv;
+    std::vector<std::string> argv;
 
     if (cmd == "on")
     {
-        string cmd_line = "heyu on " + housecode;
+        std::string cmd_line = "heyu on " + housecode;
         ecore_exe_run(cmd_line.c_str(), NULL);
     }
     else if (cmd == "off")
     {
-        string cmd_line = "heyu off " + housecode;
+        std::string cmd_line = "heyu off " + housecode;
         ecore_exe_run(cmd_line.c_str(), NULL);
     }
     else if (cmd == "dimb")
     {
-        string cmd_line = "heyu dimb " + housecode + " " + Utils::to_string(*dval);
+        std::string cmd_line = "heyu dimb " + housecode + " " + Utils::to_string(*dval);
         ecore_exe_run(cmd_line.c_str(), NULL);
     }
     else if (cmd == "bright")
     {
-        string cmd_line = "heyu bright " + housecode + " " + Utils::to_string(*dval);
+        std::string cmd_line = "heyu bright " + housecode + " " + Utils::to_string(*dval);
         ecore_exe_run(cmd_line.c_str(), NULL);
     }
     else if (cmd == "dim")
     {
-        string cmd_line = "heyu dim " + housecode + " " + Utils::to_string(*dval);
+        std::string cmd_line = "heyu dim " + housecode + " " + Utils::to_string(*dval);
         ecore_exe_run(cmd_line.c_str(), NULL);
     }
     else if (cmd == "onstate")
     {
         //setup params for heyu
-        string _cmd = "heyu onstate " + housecode;
-        string std_out;
+        std::string _cmd = "heyu onstate " + housecode;
+        std::string std_out;
         int _ret = -1;
 
         //TO FIX: Need to fix that using ecore_exe...
@@ -134,7 +134,7 @@ bool X10Output::X10Command(std::string cmd, int *dval)
         if (_ret != 0)
         {
             //reload the heyu engine
-            string cmd_line = "heyu engine";
+            std::string cmd_line = "heyu engine";
             ecore_exe_run(cmd_line.c_str(), NULL);
 
             //then try again
@@ -150,8 +150,8 @@ bool X10Output::X10Command(std::string cmd, int *dval)
     else if (cmd == "dimstate")
     {
         //setup params for heyu
-        string _cmd = "heyu dimstate " + housecode;
-        string std_out;
+        std::string _cmd = "heyu dimstate " + housecode;
+        std::string std_out;
         int _ret = -1;
 
         //TO FIX: Need to fix that using ecore_exe...
@@ -160,7 +160,7 @@ bool X10Output::X10Command(std::string cmd, int *dval)
         if (_ret != 0)
         {
             //reload the heyu engine
-            string cmd_line = "heyu engine";
+            std::string cmd_line = "heyu engine";
             ecore_exe_run(cmd_line.c_str(), NULL);
 
             //then try again
@@ -175,3 +175,5 @@ bool X10Output::X10Command(std::string cmd, int *dval)
     return true;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Zibase/Zibase.cpp
+++ b/src/bin/calaos_server/IO/Zibase/Zibase.cpp
@@ -185,7 +185,7 @@ Zibase &Zibase::Instance(std::string h, int p)
 
 void Zibase::stopAllZibase()
 {
-    std::for_each(zibasemaps.maps.begin(), zibasemaps.maps.end(), Delete());
+    std::for_each(zibasemaps.maps.begin(), zibasemaps.maps.end(), Utils::Delete());
     zibasemaps.maps.clear();
 }
 
@@ -268,7 +268,7 @@ void Zibase::udpListenData(Ecore_Con_Event_Server_Data *ev)
                     std::string myip = TCPSocket::GetLocalIPFor(remote_ip);
 
 
-                    vector<string> splitter;
+                    std::vector<std::string> splitter;
                     Utils::split(myip, splitter, ".", 4);
                     int ipHexa = (atoi(splitter[0].c_str())<<24) |
                             (atoi(splitter[1].c_str())<<16) |

--- a/src/bin/calaos_server/IO/Zibase/Zibase.h
+++ b/src/bin/calaos_server/IO/Zibase/Zibase.h
@@ -33,11 +33,11 @@ class ZibaseManager
 public:
     ~ZibaseManager()
     {
-        std::for_each(maps.begin(), maps.end(), Delete());
+        std::for_each(maps.begin(), maps.end(), Utils::Delete());
         maps.clear();
     }
 
-    vector<Zibase *> maps;
+    std::vector<Zibase *> maps;
 };
 
 class ZibaseInfoSensor
@@ -113,7 +113,7 @@ protected:
 
     void ZibaseCommand_Timeout();
 
-    queue<ZibaseQueuRequest> zibase_queue_req;
+    std::queue<ZibaseQueuRequest> zibase_queue_req;
     EcoreTimer *zibase_timer;
 
     int extract_infos(char* frame,ZibaseInfoSensor* elm);
@@ -162,7 +162,7 @@ public:
 
     //Singleton
     static Zibase &Instance(std::string host, int port);
-    static vector<Zibase *> &get_maps() { return zibasemaps.maps; }
+    static std::vector<Zibase *> &get_maps() { return zibasemaps.maps; }
     static void stopAllZibase();
 
     std::string get_host() { return host; }

--- a/src/bin/calaos_server/IO/Zibase/ZibaseAnalogIn.cpp
+++ b/src/bin/calaos_server/IO/Zibase/ZibaseAnalogIn.cpp
@@ -22,7 +22,7 @@
 #include "Zibase.h"
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(ZibaseAnalogIn)
 
@@ -93,3 +93,5 @@ void ZibaseAnalogIn::readValue()
     //the zibase will send us new values
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Zibase/ZibaseDigitalIn.cpp
+++ b/src/bin/calaos_server/IO/Zibase/ZibaseDigitalIn.cpp
@@ -22,7 +22,7 @@
 #include "Zibase.h"
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(ZibaseDigitalIn)
 
@@ -81,3 +81,5 @@ bool ZibaseDigitalIn::readValue()
     return val;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Zibase/ZibaseDigitalOut.cpp
+++ b/src/bin/calaos_server/IO/Zibase/ZibaseDigitalOut.cpp
@@ -22,7 +22,7 @@
 #include "Zibase.h"
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(ZibaseDigitalOut)
 
@@ -148,3 +148,5 @@ bool ZibaseDigitalOut::set_value_real(bool val)
     return true;
 }
 
+
+}

--- a/src/bin/calaos_server/IO/Zibase/ZibaseTemp.cpp
+++ b/src/bin/calaos_server/IO/Zibase/ZibaseTemp.cpp
@@ -22,7 +22,7 @@
 #include "Zibase.h"
 #include <IOFactory.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(ZibaseTemp)
 
@@ -80,3 +80,5 @@ void ZibaseTemp::readValue()
     //the zibase will send us new values
 }
 
+
+}

--- a/src/bin/calaos_server/IOBase.cpp
+++ b/src/bin/calaos_server/IOBase.cpp
@@ -23,7 +23,7 @@
 #include "ListeRule.h"
 #include "DataLogger.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 IOBase::IOBase(Params &p, int iotype):
     param(p),
@@ -31,12 +31,12 @@ IOBase::IOBase(Params &p, int iotype):
     io_type(iotype)
 {
     ioDoc = new IODoc();
-    ioDoc->paramAdd("id", _("Unique ID identifying the Input/Output in calaos-server"), IODoc::TYPE_STRING, true, string(), true);
+    ioDoc->paramAdd("id", _("Unique ID identifying the Input/Output in calaos-server"), IODoc::TYPE_STRING, true, std::string(), true);
     ioDoc->paramAdd("name", _("Name of Input/Output."), IODoc::TYPE_STRING, true);
     ioDoc->paramAdd("visible", _("Display the Input/Output on all user interfaces if set. Default to true"), IODoc::TYPE_BOOL, false, "true");
     ioDoc->paramAdd("enabled", _("Enable the Input/Output. The default value is true. This parameter is added if it's not found in the configuration."), IODoc::TYPE_BOOL, false, "true");
-    ioDoc->paramAdd("gui_type", _("Internal graphical type for all calaos objects. Set automatically, read-only parameter."), IODoc::TYPE_STRING, false, string(), true);
-    ioDoc->paramAdd("io_type", _("IO type, can be \"input\", \"output\", \"inout\""), IODoc::TYPE_STRING, true, string(), true);
+    ioDoc->paramAdd("gui_type", _("Internal graphical type for all calaos objects. Set automatically, read-only parameter."), IODoc::TYPE_STRING, false, std::string(), true);
+    ioDoc->paramAdd("io_type", _("IO type, can be \"input\", \"output\", \"inout\""), IODoc::TYPE_STRING, true, std::string(), true);
 
     if (!param.Exists("enabled"))
         param.Add("enabled", "true");
@@ -76,10 +76,12 @@ bool IOBase::SaveToXml(TiXmlElement *node)
 
     for (int i = 0;i < get_params().size();i++)
     {
-        string key, value;
+        std::string key, value;
         get_params().get_item(i, key, value);
         cnode->SetAttribute(key, value);
     }
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IOBase.h
+++ b/src/bin/calaos_server/IOBase.h
@@ -60,15 +60,15 @@ public:
     virtual DATA_TYPE get_type() = 0;
 
     virtual bool get_value_bool() { return false; }
-    virtual map<string, bool> get_all_values_bool() { map<string, bool> m; return m; }
+    virtual std::map<std::string, bool> get_all_values_bool() { std::map<std::string, bool> m; return m; }
 
     virtual double get_value_double() { return 0.0; }
-    virtual map<string, double> get_all_values_double() { map<string, double> m; return m; }
+    virtual std::map<std::string, double> get_all_values_double() { std::map<std::string, double> m; return m; }
 
     virtual std::string get_value_string() { return ""; }
-    virtual map<string, string> get_all_values_string() { map<string, string> m; return m; }
+    virtual std::map<std::string, std::string> get_all_values_string() { std::map<std::string, std::string> m; return m; }
 
-    virtual map<string, string> query_param(string key) { map<string, string> m; return m; }
+    virtual std::map<std::string, std::string> query_param(std::string key) { std::map<std::string, std::string> m; return m; }
 
     virtual void set_param(std::string opt, std::string val) { param.Add(opt, val); }
     virtual std::string get_param(std::string opt) { return param[opt]; }

--- a/src/bin/calaos_server/IPCam/Axis.cpp
+++ b/src/bin/calaos_server/IPCam/Axis.cpp
@@ -21,7 +21,7 @@
 #include "Axis.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(Axis)
 
@@ -56,7 +56,7 @@ Axis::Axis(Params &p):
 
 std::string Axis::getVideoUrl()
 {
-    string user;
+    std::string user;
 
     if (param["model"] != "") camera = param["model"];
 
@@ -76,7 +76,7 @@ std::string Axis::getVideoUrl()
 
 std::string Axis::getPictureUrl()
 {
-    string user;
+    std::string user;
 
     if (param["model"] != "") camera = param["model"];
 
@@ -99,13 +99,13 @@ void Axis::activateCapabilities(std::string cap, std::string cmd, std::string va
 {
     if (!caps.Exists(cap)) return;
 
-    string user;
+    std::string user;
     if (param.Exists("username"))
         user = param["username"] + ":" + param["password"] + "@";
 
     if (cap == "resolution" && cmd == "set")
     {
-        vector<string> res;
+        std::vector<std::string> res;
         Utils::split(caps["resolution"], res, " ");
         for (uint i = 0;i < res.size();i++)
         {
@@ -124,14 +124,14 @@ void Axis::activateCapabilities(std::string cap, std::string cmd, std::string va
     }
     else if (cap == "ptz" && cmd == "move")
     {
-        string url;
+        std::string url;
 
         if (value == "zoomin" || value == "zoomout")
         {
             url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/axis-cgi/com/ptz.cgi?";
             url += "camera=" + camera;
-            url += "&rzoom=" + string((value == "zoomout")?"-":"") + param["zoom_step"];
+            url += "&rzoom=" + std::string((value == "zoomout")?"-":"") + param["zoom_step"];
         }
         else
         {
@@ -152,7 +152,7 @@ void Axis::activateCapabilities(std::string cap, std::string cmd, std::string va
             return;
 
         //Parse pan/tilt values
-        vector<string> tok;
+        std::vector<std::string> tok;
         split(value, tok, ",");
         if (tok.size() != 2) return;
 
@@ -174,7 +174,7 @@ void Axis::activateCapabilities(std::string cap, std::string cmd, std::string va
         pan = (pan * pan_framesize) / 320.0;
         tilt = (tilt * tilt_framesize) / 240.0;
 
-        string url = "http://" + user + param["host"] + ":" + param["port"];
+        std::string url = "http://" + user + param["host"] + ":" + param["port"];
         url += "/axis-cgi/com/ptz.cgi?";
         url += "camera=" + camera;
         url += "&rpan=" + Utils::to_string(-pan) + "&rtilt=" + Utils::to_string(tilt);
@@ -183,7 +183,7 @@ void Axis::activateCapabilities(std::string cap, std::string cmd, std::string va
     }
     else if (cap == "position" && cmd == "recall")
     {
-        string url = "http://" + user + param["host"] + ":" + param["port"];
+        std::string url = "http://" + user + param["host"] + ":" + param["port"];
         url += "/axis-cgi/com/ptz.cgi?";
         url += "camera=" + camera;
         url += "&gotoserverpresetno=" + value;
@@ -192,11 +192,13 @@ void Axis::activateCapabilities(std::string cap, std::string cmd, std::string va
     }
     else if (cap == "position" && cmd == "save")
     {
-        string url = "http://" + user + param["host"] + ":" + param["port"];
+        std::string url = "http://" + user + param["host"] + ":" + param["port"];
         url += "/axis-cgi/com/ptz.cgi?";
         url += "camera=" + camera;
         url += "&setserverpresetno=" + value;
 
         Calaos::CallUrl(url);
     }
+}
+
 }

--- a/src/bin/calaos_server/IPCam/Axis.h
+++ b/src/bin/calaos_server/IPCam/Axis.h
@@ -29,7 +29,7 @@ namespace Calaos
 class Axis: public IPCam
 {
 protected:
-    string resolution, quality, camera;
+    std::string resolution, quality, camera;
 
 public:
     Axis(Params &p);

--- a/src/bin/calaos_server/IPCam/Gadspot.cpp
+++ b/src/bin/calaos_server/IPCam/Gadspot.cpp
@@ -21,7 +21,7 @@
 #include "Gadspot.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(Gadspot)
 
@@ -49,4 +49,6 @@ std::string Gadspot::getPictureUrl()
     url += "/Jpeg/CamImg.jpg";
 
     return url;
+}
+
 }

--- a/src/bin/calaos_server/IPCam/IPCam.cpp
+++ b/src/bin/calaos_server/IPCam/IPCam.cpp
@@ -20,7 +20,8 @@
  ******************************************************************************/
 #include "IPCam.h"
 
-using namespace Calaos;
+
+namespace Calaos {
 
 IPCam::IPCam(Params &p):
     IOBase(p, IOBase::IO_INOUT)
@@ -74,10 +75,12 @@ bool IPCam::SaveToXml(TiXmlElement *node)
 
     for (int i = 0;i < get_params().size();i++)
     {
-        string key, value;
+        std::string key, value;
         param.get_item(i, key, value);
         cnode->SetAttribute(key, value);
     }
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/IPCam/Planet.cpp
+++ b/src/bin/calaos_server/IPCam/Planet.cpp
@@ -21,7 +21,7 @@
 #include "Planet.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(Planet)
 
@@ -128,7 +128,7 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (value == "320x240") resolution = "2";
             if (value == "640x480") resolution = "3";
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/Change_Resolution.cgi?ResType=" + resolution;
             Calaos::CallUrl(url);
         }
@@ -141,7 +141,7 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (q >= 0 && q < _q)
                 quality = value;
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/Change_Compress_Ratio.cgi?Ratio=" + quality;
             Calaos::CallUrl(url);
         }
@@ -154,13 +154,13 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (q >= 0 && q < _q)
                 saturation = value;
 
-            string _size;
+            std::string _size;
             if (resolution == "0") _size = "176";
             if (resolution == "1") _size = "352";
             if (resolution == "2") _size = "320";
             if (resolution == "3") _size = "640";
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/Set_Camera.cgi?Saturation=" + saturation;
             url += "&Sharpness=" + sharpness;
             url += "&Contrast=" + contrast;
@@ -179,13 +179,13 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (q >= 0 && q < _q)
                 sharpness = value;
 
-            string _size;
+            std::string _size;
             if (resolution == "0") _size = "176";
             if (resolution == "1") _size = "352";
             if (resolution == "2") _size = "320";
             if (resolution == "3") _size = "640";
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/Set_Camera.cgi?Saturation=" + saturation;
             url += "&Sharpness=" + sharpness;
             url += "&Contrast=" + contrast;
@@ -204,13 +204,13 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (q >= 0 && q < _q)
                 contrast = value;
 
-            string _size;
+            std::string _size;
             if (resolution == "0") _size = "176";
             if (resolution == "1") _size = "352";
             if (resolution == "2") _size = "320";
             if (resolution == "3") _size = "640";
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/Set_Camera.cgi?Saturation=" + saturation;
             url += "&Sharpness=" + sharpness;
             url += "&Contrast=" + contrast;
@@ -229,13 +229,13 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (q >= 0 && q < _q)
                 hue = value;
 
-            string _size;
+            std::string _size;
             if (resolution == "0") _size = "176";
             if (resolution == "1") _size = "352";
             if (resolution == "2") _size = "320";
             if (resolution == "3") _size = "640";
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/Set_Camera.cgi?Saturation=" + saturation;
             url += "&Sharpness=" + sharpness;
             url += "&Contrast=" + contrast;
@@ -254,7 +254,7 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (q >= 0 && q < _q)
                 brightness = value;
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/Change_Brightness.cgi?Brightness=" + brightness;
             Calaos::CallUrl(url);
         }
@@ -264,7 +264,7 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
     {
         if (cap == "ptz" && cmd == "move")
         {
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/MoveCamera.cgi?Dir=";
 
             if (value == "home") url += "Home";
@@ -277,14 +277,14 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
         }
         else if (cap == "position" && cmd == "recall")
         {
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/MoveCamera.cgi?Dir=Recall&CameraParam=" + value;
 
             Calaos::CallUrl(url);
         }
         else if (cap == "position" && cmd == "save")
         {
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/MoveCamera.cgi?Dir=Preset&CameraParam=" + value;
 
             Calaos::CallUrl(url);
@@ -299,7 +299,7 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (value == "320x240") resolution = "1";
             if (value == "640x480") resolution = "2";
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/resSel?f_ResIdxSel=" + resolution;
             Calaos::CallUrl(url);
         }
@@ -309,13 +309,13 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (value == "1") quality = "2";
             if (value == "2") quality = "0";
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/qualSel?f_quality=" + quality;
             Calaos::CallUrl(url);
         }
         if (cap == "ptz" && cmd == "move")
         {
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/ptact?f_mvaction=";
 
             if (value == "home") url += "2";
@@ -328,7 +328,7 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
         }
         else if (cap == "position" && cmd == "recall")
         {
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/ptpreset?f_presetact=" + value;
 
             Calaos::CallUrl(url);
@@ -338,35 +338,35 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             int pos;
             Utils::from_string(value, pos);
             pos--;
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/adminptpreset?f_presetidx=" + Utils::to_string(pos);
 
             Calaos::CallUrl(url);
         }
         else if (cap == "led")
         {
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/devact?f_devno=2&f_devact=1";
 
             Calaos::CallUrl(url);
         }
         else if (cap == "buzzer")
         {
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/devact?f_devno=1&f_devact=1";
 
             Calaos::CallUrl(url);
         }
         else if (cap == "privacy" && cmd == "set" && value == "true")
         {
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/ptact?f_mvaction=1";
 
             Calaos::CallUrl(url);
         }
         else if (cap == "privacy" && cmd == "set" && value == "false")
         {
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/privacymode_unset";
 
             Calaos::CallUrl(url);
@@ -380,7 +380,7 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (q > 0 && q <= _q)
                 brightness = value;
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/cameraconfig?brightness=" + brightness;
             url += "&contrast=" + contrast;
             url += "&color=" + color;
@@ -398,7 +398,7 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (q > 0 && q <= _q)
                 color = value;
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/cameraconfig?brightness=" + brightness;
             url += "&contrast=" + contrast;
             url += "&color=" + color;
@@ -416,7 +416,7 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (q > 0 && q <= _q)
                 contrast = value;
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/cameraconfig?brightness=" + brightness;
             url += "&contrast=" + contrast;
             url += "&color=" + color;
@@ -434,7 +434,7 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
             if (q > 0 && q <= _q)
                 sharpness = value;
 
-            string url = "http://" + user + param["host"] + ":" + param["port"];
+            std::string url = "http://" + user + param["host"] + ":" + param["port"];
             url += "/goform/cameraconfig?brightness=" + brightness;
             url += "&contrast=" + contrast;
             url += "&color=" + color;
@@ -449,3 +449,5 @@ void Planet::activateCapabilities(std::string cap, std::string cmd, std::string 
 //Move ICA-210 click on screen
 //http://10.0.0.23/goform/ptmovepos?dx=-314&dy=90&res=2
 //where dx and dy are relative to the center of the current frame
+
+}

--- a/src/bin/calaos_server/IPCam/Planet.h
+++ b/src/bin/calaos_server/IPCam/Planet.h
@@ -29,9 +29,9 @@ namespace Calaos
 class Planet: public IPCam
 {
 protected:
-    string resolution, quality;
-    string saturation, sharpness, contrast, hue;
-    string brightness, color;
+    std::string resolution, quality;
+    std::string saturation, sharpness, contrast, hue;
+    std::string brightness, color;
 
 public:
     Planet(Params &p);

--- a/src/bin/calaos_server/IPCam/StandardMjpeg.cpp
+++ b/src/bin/calaos_server/IPCam/StandardMjpeg.cpp
@@ -21,7 +21,7 @@
 #include "StandardMjpeg.h"
 #include "IOFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 REGISTER_IO(StandardMjpeg)
 REGISTER_IO_USERTYPE(standard_mjpeg, StandardMjpeg)
@@ -66,9 +66,11 @@ std::string StandardMjpeg::getPictureUrl()
 
 std::string StandardMjpeg::getVideoUrl()
 {
-    string url;
+    std::string url;
     if (param["url_mjpeg"] != "")
         url = param["url_mjpeg"];
 
     return url;
+}
+
 }

--- a/src/bin/calaos_server/JsonApi.cpp
+++ b/src/bin/calaos_server/JsonApi.cpp
@@ -25,6 +25,9 @@
 #include "AutoScenario.h"
 #include "CalaosConfig.h"
 
+
+namespace Calaos {
+
 JsonApi::JsonApi(HttpClient *client):
     httpClient(client)
 {
@@ -40,14 +43,14 @@ JsonApi::~JsonApi()
 
 void JsonApi::buildJsonIO(IOBase *io, json_t *jio)
 {
-    vector<string> params =
+    std::vector<std::string> params =
     { "id", "name", "type", "hits", "var_type", "visible",
       "chauffage_id", "rw", "unit", "gui_type", "state",
       "auto_scenario", "step", "io_type" };
 
-    for (string &param: params)
+    for (std::string &param: params)
     {
-        string value;
+        std::string value;
 
         if (param == "state")
         {
@@ -140,7 +143,7 @@ json_t *JsonApi::buildJsonCameras()
 {
     json_t *jdata = json_array();
 
-    list<IOBase *> camlist = ListeRoom::Instance().getCameraList();
+    std::list<IOBase *> camlist = ListeRoom::Instance().getCameraList();
 
     int cpt = 0;
     for (IOBase *io: camlist)
@@ -170,7 +173,7 @@ json_t *JsonApi::buildJsonAudio()
 {
     json_t *jdata = json_array();
 
-    list<IOBase *> audiolist = ListeRoom::Instance().getAudioList();
+    std::list<IOBase *> audiolist = ListeRoom::Instance().getAudioList();
 
     for (IOBase *io: audiolist)
     {
@@ -202,7 +205,7 @@ void JsonApi::buildJsonState(json_t *jroot, std::function<void(json_t *)> result
 {
     json_incref(jroot);
     json_t *jio = json_object();
-    list<AudioPlayer *> audioplayers;
+    std::list<AudioPlayer *> audioplayers;
 
     json_t *jin = json_object_get(jroot, "items");
     if (jin && json_is_array(jin))
@@ -212,7 +215,7 @@ void JsonApi::buildJsonState(json_t *jroot, std::function<void(json_t *)> result
 
         json_array_foreach(jin, idx, value)
         {
-            string svalue;
+            std::string svalue;
 
             if (!json_is_string(value)) continue;
 
@@ -237,7 +240,7 @@ void JsonApi::buildJsonState(json_t *jroot, std::function<void(json_t *)> result
         }
     }
 
-    string uuid = Utils::createRandomUuid();
+    std::string uuid = Utils::createRandomUuid();
     playerCounts[uuid] = 0;
 
     for (AudioPlayer *player: audioplayers)
@@ -271,7 +274,7 @@ void JsonApi::buildJsonState(json_t *jroot, std::function<void(json_t *)> result
 
                         player->get_status([=](AudioPlayerData data5)
                         {
-                            string status;
+                            std::string status;
                             switch (data5.ivalue)
                             {
                             case AudioPlay: status = "playing"; break;
@@ -292,7 +295,7 @@ void JsonApi::buildJsonState(json_t *jroot, std::function<void(json_t *)> result
                                 Params &infos = data6.params;
                                 for (int i = 0;i < infos.size();i++)
                                 {
-                                    string inf_key, inf_value;
+                                    std::string inf_key, inf_value;
                                     infos.get_item(i, inf_key, inf_value);
 
                                     json_object_set_new(jtrack,
@@ -386,7 +389,7 @@ void JsonApi::buildQuery(const Params &jParam, std::function<void (json_t *)> re
             return;
         }
 
-        map<string, string> m = o->query_param(jParam["param"]);
+        std::map<std::string, std::string> m = o->query_param(jParam["param"]);
         for (auto it: m)
             res.Add(it.first, it.second);
     }
@@ -483,7 +486,7 @@ json_t *JsonApi::buildJsonGetIO(json_t *jroot)
 
         json_array_foreach(jin, idx, value)
         {
-            string svalue;
+            std::string svalue;
 
             if (!json_is_string(value)) continue;
 
@@ -573,7 +576,7 @@ void JsonApi::getNextPlaylistItem(AudioPlayer *player, json_t *jplayer, json_t *
         Params &infos = data.params;
         for (int i = 0;i < infos.size();i++)
         {
-            string inf_key, inf_value;
+            std::string inf_key, inf_value;
             infos.get_item(i, inf_key, inf_value);
 
             json_object_set_new(jtrack,
@@ -599,12 +602,12 @@ void JsonApi::getNextPlaylistItem(AudioPlayer *player, json_t *jplayer, json_t *
     });
 }
 
-AudioPlayer *JsonApi::getAudioPlayer(json_t *jdata, string &err)
+AudioPlayer *JsonApi::getAudioPlayer(json_t *jdata, std::string &err)
 {
     AudioPlayer *player = nullptr;
     err.clear();
 
-    string id = jansson_string_get(jdata, "id");
+    std::string id = jansson_string_get(jdata, "id");
     if (id == "")
     {
         err = "empty player id";
@@ -622,7 +625,7 @@ AudioPlayer *JsonApi::getAudioPlayer(json_t *jdata, string &err)
 
 void JsonApi::audioGetDbStats(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -641,7 +644,7 @@ void JsonApi::audioGetDbStats(json_t *jdata, std::function<void(json_t *)>result
 
 void JsonApi::audioGetPlaylistSize(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -661,7 +664,7 @@ void JsonApi::audioGetPlaylistSize(json_t *jdata, std::function<void(json_t *)>r
 
 void JsonApi::audioGetTime(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -681,7 +684,7 @@ void JsonApi::audioGetTime(json_t *jdata, std::function<void(json_t *)>result_la
 
 void JsonApi::audioGetPlaylistItem(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -691,7 +694,7 @@ void JsonApi::audioGetPlaylistItem(json_t *jdata, std::function<void(json_t *)>r
         return;
     }
 
-    string it = jansson_string_get(jdata, "item");
+    std::string it = jansson_string_get(jdata, "item");
     if (it.empty() || !Utils::is_of_type<int>(it))
     {
         Params p = {{"error", "wrong item" }};
@@ -710,7 +713,7 @@ void JsonApi::audioGetPlaylistItem(json_t *jdata, std::function<void(json_t *)>r
 
 void JsonApi::audioGetCoverInfo(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -731,9 +734,9 @@ json_t *JsonApi::processDbResult(const AudioPlayerData &data)
 {
     json_t *ret = json_object();
     json_t *aret = json_array();
-    string scount;
+    std::string scount;
 
-    const vector<Params> &vp = data.vparams;
+    const std::vector<Params> &vp = data.vparams;
     for (const Params &p: vp)
     {
         if (p.Exists("count"))
@@ -753,7 +756,7 @@ json_t *JsonApi::processDbResult(const AudioPlayerData &data)
 
 void JsonApi::audioDbGetAlbums(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -763,8 +766,8 @@ void JsonApi::audioDbGetAlbums(json_t *jdata, std::function<void(json_t *)>resul
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -785,7 +788,7 @@ void JsonApi::audioDbGetAlbums(json_t *jdata, std::function<void(json_t *)>resul
 
 void JsonApi::audioDbGetAlbumArtistItem(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -795,9 +798,9 @@ void JsonApi::audioDbGetAlbumArtistItem(json_t *jdata, std::function<void(json_t
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
-    string artist_id = jansson_string_get(jdata, "artist_id");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
+    std::string artist_id = jansson_string_get(jdata, "artist_id");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -818,7 +821,7 @@ void JsonApi::audioDbGetAlbumArtistItem(json_t *jdata, std::function<void(json_t
 
 void JsonApi::audioDbGetYearAlbums(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -828,9 +831,9 @@ void JsonApi::audioDbGetYearAlbums(json_t *jdata, std::function<void(json_t *)>r
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
-    string year = jansson_string_get(jdata, "year");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
+    std::string year = jansson_string_get(jdata, "year");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -851,7 +854,7 @@ void JsonApi::audioDbGetYearAlbums(json_t *jdata, std::function<void(json_t *)>r
 
 void JsonApi::audioDbGetGenreArtists(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -861,9 +864,9 @@ void JsonApi::audioDbGetGenreArtists(json_t *jdata, std::function<void(json_t *)
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
-    string genre = jansson_string_get(jdata, "genre");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
+    std::string genre = jansson_string_get(jdata, "genre");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -884,7 +887,7 @@ void JsonApi::audioDbGetGenreArtists(json_t *jdata, std::function<void(json_t *)
 
 void JsonApi::audioDbGetAlbumTitles(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -894,9 +897,9 @@ void JsonApi::audioDbGetAlbumTitles(json_t *jdata, std::function<void(json_t *)>
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
-    string album_id = jansson_string_get(jdata, "album_id");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
+    std::string album_id = jansson_string_get(jdata, "album_id");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -917,7 +920,7 @@ void JsonApi::audioDbGetAlbumTitles(json_t *jdata, std::function<void(json_t *)>
 
 void JsonApi::audioDbGetPlaylistTitles(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -927,9 +930,9 @@ void JsonApi::audioDbGetPlaylistTitles(json_t *jdata, std::function<void(json_t 
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
-    string pl_id = jansson_string_get(jdata, "playlist_id");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
+    std::string pl_id = jansson_string_get(jdata, "playlist_id");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -950,7 +953,7 @@ void JsonApi::audioDbGetPlaylistTitles(json_t *jdata, std::function<void(json_t 
 
 void JsonApi::audioDbGetArtists(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -960,8 +963,8 @@ void JsonApi::audioDbGetArtists(json_t *jdata, std::function<void(json_t *)>resu
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -982,7 +985,7 @@ void JsonApi::audioDbGetArtists(json_t *jdata, std::function<void(json_t *)>resu
 
 void JsonApi::audioDbGetYears(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -992,8 +995,8 @@ void JsonApi::audioDbGetYears(json_t *jdata, std::function<void(json_t *)>result
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -1014,7 +1017,7 @@ void JsonApi::audioDbGetYears(json_t *jdata, std::function<void(json_t *)>result
 
 void JsonApi::audioDbGetGenres(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -1024,8 +1027,8 @@ void JsonApi::audioDbGetGenres(json_t *jdata, std::function<void(json_t *)>resul
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -1046,7 +1049,7 @@ void JsonApi::audioDbGetGenres(json_t *jdata, std::function<void(json_t *)>resul
 
 void JsonApi::audioDbGetPlaylists(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -1056,8 +1059,8 @@ void JsonApi::audioDbGetPlaylists(json_t *jdata, std::function<void(json_t *)>re
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -1078,7 +1081,7 @@ void JsonApi::audioDbGetPlaylists(json_t *jdata, std::function<void(json_t *)>re
 
 void JsonApi::audioDbGetMusicFolder(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -1088,9 +1091,9 @@ void JsonApi::audioDbGetMusicFolder(json_t *jdata, std::function<void(json_t *)>
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
-    string folder_id = jansson_string_get(jdata, "folder_id");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
+    std::string folder_id = jansson_string_get(jdata, "folder_id");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -1111,7 +1114,7 @@ void JsonApi::audioDbGetMusicFolder(json_t *jdata, std::function<void(json_t *)>
 
 void JsonApi::audioDbGetSearch(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -1121,9 +1124,9 @@ void JsonApi::audioDbGetSearch(json_t *jdata, std::function<void(json_t *)>resul
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
-    string search = jansson_string_get(jdata, "search");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
+    std::string search = jansson_string_get(jdata, "search");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -1144,7 +1147,7 @@ void JsonApi::audioDbGetSearch(json_t *jdata, std::function<void(json_t *)>resul
 
 void JsonApi::audioDbGetRadios(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -1154,8 +1157,8 @@ void JsonApi::audioDbGetRadios(json_t *jdata, std::function<void(json_t *)>resul
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -1176,7 +1179,7 @@ void JsonApi::audioDbGetRadios(json_t *jdata, std::function<void(json_t *)>resul
 
 void JsonApi::audioDbGetRadioItems(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -1186,8 +1189,8 @@ void JsonApi::audioDbGetRadioItems(json_t *jdata, std::function<void(json_t *)>r
         return;
     }
 
-    string itfrom = jansson_string_get(jdata, "from");
-    string itcount = jansson_string_get(jdata, "count");
+    std::string itfrom = jansson_string_get(jdata, "from");
+    std::string itcount = jansson_string_get(jdata, "count");
     if (itfrom.empty() || !Utils::is_of_type<int>(itfrom) ||
         itcount.empty() || !Utils::is_of_type<int>(itcount))
     {
@@ -1200,9 +1203,9 @@ void JsonApi::audioDbGetRadioItems(json_t *jdata, std::function<void(json_t *)>r
     Utils::from_string(itfrom, from);
     Utils::from_string(itcount, count);
 
-    string radio_id = jansson_string_get(jdata, "radio_id");
-    string item_id = jansson_string_get(jdata, "item_id");
-    string search = jansson_string_get(jdata, "search");
+    std::string radio_id = jansson_string_get(jdata, "radio_id");
+    std::string item_id = jansson_string_get(jdata, "item_id");
+    std::string search = jansson_string_get(jdata, "search");
 
     player->get_database()->getRadiosItems([=](AudioPlayerData data)
     {
@@ -1212,7 +1215,7 @@ void JsonApi::audioDbGetRadioItems(json_t *jdata, std::function<void(json_t *)>r
 
 void JsonApi::audioDbGetTrackInfos(json_t *jdata, std::function<void(json_t *)>result_lambda)
 {
-    string err;
+    std::string err;
     AudioPlayer *player = getAudioPlayer(jdata, err);
 
     if (!err.empty())
@@ -1222,7 +1225,7 @@ void JsonApi::audioDbGetTrackInfos(json_t *jdata, std::function<void(json_t *)>r
         return;
     }
 
-    string trackid = jansson_string_get(jdata, "track_id");
+    std::string trackid = jansson_string_get(jdata, "track_id");
 
     player->get_database()->getTrackInfos([=](AudioPlayerData data)
     {
@@ -1244,7 +1247,7 @@ json_t *JsonApi::buildJsonGetTimerange(const Params &jParam)
 
     for (int day = 0;day < 7;day++)
     {
-        vector<TimeRange> h;
+        std::vector<TimeRange> h;
         if (day == 0) h = o->getMonday();
         if (day == 1) h = o->getTuesday();
         if (day == 2) h = o->getWednesday();
@@ -1258,9 +1261,9 @@ json_t *JsonApi::buildJsonGetTimerange(const Params &jParam)
 
     json_object_set_new(ret, "ranges", jarr);
 
-    stringstream ssmonth;
+    std::stringstream ssmonth;
     ssmonth << o->months;
-    string str = ssmonth.str();
+    std::string str = ssmonth.str();
     std::reverse(str.begin(), str.end());
     json_object_set_new(ret, "months", json_string(str.c_str()));
 
@@ -1269,7 +1272,7 @@ json_t *JsonApi::buildJsonGetTimerange(const Params &jParam)
 
 json_t *JsonApi::buildJsonSetTimerange(json_t *jdata)
 {
-    string id = jansson_string_get(jdata, "id");
+    std::string id = jansson_string_get(jdata, "id");
     InPlageHoraire *o = dynamic_cast<InPlageHoraire *>(ListeRoom::Instance().get_io(id));
     if (!o)
     {
@@ -1289,7 +1292,7 @@ json_t *JsonApi::buildJsonSetTimerange(json_t *jdata)
 
         TimeRange tr(p);
 
-        cout << "Adding timerange: " << p.toString() << endl;
+        std::cout << "Adding timerange: " << p.toString() << std::endl;
 
         if (p["day"] == "1") o->AddMonday(tr);
         if (p["day"] == "2") o->AddTuesday(tr);
@@ -1301,7 +1304,7 @@ json_t *JsonApi::buildJsonSetTimerange(json_t *jdata)
     }
 
     //set months
-    string m = jansson_string_get(jdata, "months");
+    std::string m = jansson_string_get(jdata, "months");
     if (!m.empty())
     {
         //reverse to have a left to right months representation
@@ -1309,7 +1312,7 @@ json_t *JsonApi::buildJsonSetTimerange(json_t *jdata)
 
         try
         {
-            bitset<12> mset(m);
+            std::bitset<12> mset(m);
             o->months = mset;
         }
         catch(...)
@@ -1352,7 +1355,7 @@ json_t *JsonApi::buildAutoscenarioList(json_t *jdata)
 
 json_t *JsonApi::buildAutoscenarioGet(json_t *jdata)
 {
-    string id = jansson_string_get(jdata, "id");
+    std::string id = jansson_string_get(jdata, "id");
     Scenario *sc = dynamic_cast<Scenario *>(ListeRoom::Instance().get_io(id));
     if (!sc || !sc->getAutoScenario())
     {
@@ -1413,7 +1416,7 @@ json_t *JsonApi::buildAutoscenarioCreate(json_t *jdata)
         json_array_foreach(json_object_get(value, "actions"), idx_act, value_act)
         {
 
-            string id_out = jansson_string_get(value_act, "id");
+            std::string id_out = jansson_string_get(value_act, "id");
             IOBase *out = ListeRoom::Instance().get_io(id_out);
             if (out)
                 scenario->getAutoScenario()->addStepAction(index_act, out,
@@ -1434,7 +1437,7 @@ json_t *JsonApi::buildAutoscenarioCreate(json_t *jdata)
 
 json_t *JsonApi::buildAutoscenarioDelete(json_t *jdata)
 {
-    string id = jansson_string_get(jdata, "id");
+    std::string id = jansson_string_get(jdata, "id");
     Scenario *sc = dynamic_cast<Scenario *>(ListeRoom::Instance().get_io(id));
     if (!sc || !sc->getAutoScenario())
     {
@@ -1460,7 +1463,7 @@ json_t *JsonApi::buildAutoscenarioDelete(json_t *jdata)
 
 json_t *JsonApi::buildAutoscenarioModify(json_t *jdata)
 {
-    string id = jansson_string_get(jdata, "id");
+    std::string id = jansson_string_get(jdata, "id");
     Scenario *scenario = dynamic_cast<Scenario *>(ListeRoom::Instance().get_io(id));
     if (!scenario || !scenario->getAutoScenario())
     {
@@ -1506,7 +1509,7 @@ json_t *JsonApi::buildAutoscenarioModify(json_t *jdata)
         json_array_foreach(json_object_get(value, "actions"), idx_act, value_act)
         {
 
-            string id_out = jansson_string_get(value_act, "id");
+            std::string id_out = jansson_string_get(value_act, "id");
             IOBase *out = ListeRoom::Instance().get_io(id_out);
             cDebugDom("network") << "scenario: " << scenario << " index_act: " << index_act << " out: " << out << " action: " << jansson_string_get(value_act, "action");
             if (out)
@@ -1580,7 +1583,7 @@ json_t *JsonApi::buildAutoscenarioModify(json_t *jdata)
 
 json_t *JsonApi::buildAutoscenarioAddSchedule(json_t *jdata)
 {
-    string id = jansson_string_get(jdata, "id");
+    std::string id = jansson_string_get(jdata, "id");
     Scenario *sc = dynamic_cast<Scenario *>(ListeRoom::Instance().get_io(id));
     if (!sc || !sc->getAutoScenario())
     {
@@ -1603,7 +1606,7 @@ json_t *JsonApi::buildAutoscenarioAddSchedule(json_t *jdata)
 
 json_t *JsonApi::buildAutoscenarioDelSchedule(json_t *jdata)
 {
-    string id = jansson_string_get(jdata, "id");
+    std::string id = jansson_string_get(jdata, "id");
     Scenario *sc = dynamic_cast<Scenario *>(ListeRoom::Instance().get_io(id));
     if (!sc || !sc->getAutoScenario())
     {
@@ -1622,4 +1625,6 @@ json_t *JsonApi::buildAutoscenarioDelSchedule(json_t *jdata)
 
     Params p = {{ "success", "true" }};
     return p.toJson();
+}
+
 }

--- a/src/bin/calaos_server/JsonApi.h
+++ b/src/bin/calaos_server/JsonApi.h
@@ -27,7 +27,7 @@
 #include "Room.h"
 #include "AudioPlayer.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 class HttpClient;
 
@@ -38,10 +38,10 @@ public:
     JsonApi();
     virtual ~JsonApi();
 
-    virtual void processApi(const string &data, const Params &paramsGET) { VAR_UNUSED(data); VAR_UNUSED(paramsGET); }
+    virtual void processApi(const std::string &data, const Params &paramsGET) { VAR_UNUSED(data); VAR_UNUSED(paramsGET); }
 
-    sigc::signal<void, const string &> sendData;
-    sigc::signal<void, int, const string &> closeConnection;
+    sigc::signal<void, const std::string &> sendData;
+    sigc::signal<void, int, const std::string &> closeConnection;
 
 
 
@@ -82,7 +82,7 @@ public:
     void decodeGetPlaylist(Params &jParam, std::function<void(json_t *)>result_lambda);
     void getNextPlaylistItem(AudioPlayer *player, json_t *jplayer, json_t *jplaylist, int it_current, int it_count, std::function<void(json_t *)>result_lambda);
 
-    AudioPlayer *getAudioPlayer(json_t *jdata, string &err);
+    AudioPlayer *getAudioPlayer(json_t *jdata, std::string &err);
     void audioGetDbStats(json_t *jdata, std::function<void(json_t *)>result_lambda);
     void audioGetPlaylistSize(json_t *jdata, std::function<void(json_t *)>result_lambda);
     void audioGetTime(json_t *jdata, std::function<void(json_t *)>result_lambda);
@@ -113,8 +113,11 @@ protected:
 
     HttpClient *httpClient = nullptr;
 
-    map<string, int> playerCounts;
+  std::map<std::string, int> playerCounts;
 };
 
+}
+
 #endif // JSONAPI_H
+
 

--- a/src/bin/calaos_server/JsonApiHandlerHttp.cpp
+++ b/src/bin/calaos_server/JsonApiHandlerHttp.cpp
@@ -30,6 +30,7 @@
 #include "EcoreTimer.h"
 #include "HttpClient.h"
 
+namespace Calaos {
 Eina_Bool _ecore_exe_finished(void *data, int type, void *event)
 {
     JsonApiHandlerHttp *api = reinterpret_cast<JsonApiHandlerHttp *>(data);
@@ -64,7 +65,7 @@ JsonApiHandlerHttp::~JsonApiHandlerHttp()
     ecore_file_unlink(tempfname.c_str());
 }
 
-void JsonApiHandlerHttp::processApi(const string &data, const Params &paramsGET)
+void JsonApiHandlerHttp::processApi(const std::string &data, const Params &paramsGET)
 {
     jsonParam.clear();
 
@@ -99,8 +100,8 @@ void JsonApiHandlerHttp::processApi(const string &data, const Params &paramsGET)
 
 
     //check for if username/password matches
-    string user = Utils::get_config_option("calaos_user");
-    string pass = Utils::get_config_option("calaos_password");
+    std::string user = Utils::get_config_option("calaos_user");
+    std::string pass = Utils::get_config_option("calaos_password");
 
     if (Utils::get_config_option("cn_user") != "" &&
         Utils::get_config_option("cn_pass") != "")
@@ -116,9 +117,9 @@ void JsonApiHandlerHttp::processApi(const string &data, const Params &paramsGET)
         Params headers;
         headers.Add("Connection", "close");
         headers.Add("Content-Type", "text/html");
-        string res = httpClient->buildHttpResponse(HTTP_400, headers, HTTP_400_BODY);
+        std::string res = httpClient->buildHttpResponse(HTTP_400, headers, HTTP_400_BODY);
         sendData.emit(res);
-        closeConnection.emit(0, string());
+        closeConnection.emit(0, std::string());
 
         if (jroot)
         {
@@ -165,9 +166,9 @@ void JsonApiHandlerHttp::processApi(const string &data, const Params &paramsGET)
             Params headers;
             headers.Add("Connection", "close");
             headers.Add("Content-Type", "text/html");
-            string res = httpClient->buildHttpResponse(HTTP_400, headers, HTTP_400_BODY);
+            std::string res = httpClient->buildHttpResponse(HTTP_400, headers, HTTP_400_BODY);
             sendData.emit(res);
-            closeConnection.emit(0, string());
+            closeConnection.emit(0, std::string());
 
             return;
         }
@@ -201,15 +202,15 @@ void JsonApiHandlerHttp::sendJson(json_t *json)
         Params headers;
         headers.Add("Connection", "close");
         headers.Add("Content-Type", "text/html");
-        string res = httpClient->buildHttpResponse(HTTP_500, headers, HTTP_500_BODY);
+        std::string res = httpClient->buildHttpResponse(HTTP_500, headers, HTTP_500_BODY);
         sendData.emit(res);
-        closeConnection.emit(0, string());
+        closeConnection.emit(0, std::string());
 
         return;
     }
     json_decref(json);
 
-    string data(d);
+    std::string data(d);
     free(d);
 
     Params headers;
@@ -218,7 +219,7 @@ void JsonApiHandlerHttp::sendJson(json_t *json)
     headers.Add("Expires", "Mon, 26 Jul 1997 05:00:00 GMT");
     headers.Add("Content-Type", "application/json");
     headers.Add("Content-Length", Utils::to_string(data.size()));
-    string res = httpClient->buildHttpResponse(HTTP_200, headers, data);
+    std::string res = httpClient->buildHttpResponse(HTTP_200, headers, data);
     sendData.emit(res);
 }
 
@@ -304,19 +305,19 @@ void JsonApiHandlerHttp::processPolling()
 
     if (jsonParam["type"] == "register")
     {
-        string uuid = PollListenner::Instance().Register();
+        std::string uuid = PollListenner::Instance().Register();
         json_object_set_new(jret, "uuid", json_string(uuid.c_str()));
     }
     else if (jsonParam["type"] == "unregister")
     {
-        string uuid = jsonParam["uuid"];
+        std::string uuid = jsonParam["uuid"];
         bool success = PollListenner::Instance().Unregister(uuid);
         json_object_set_new(jret, "success", json_string(success?"true":"false"));
     }
     else if (jsonParam["type"] == "get")
     {
-        string uuid = jsonParam["uuid"];
-        list<CalaosEvent> events;
+        std::string uuid = jsonParam["uuid"];
+        std::list<CalaosEvent> events;
 
         bool res = PollListenner::Instance().GetEvents(uuid, events);
         if (!res)
@@ -351,7 +352,7 @@ void JsonApiHandlerHttp::processGetCover()
         return;
     }
 
-    string w, h;
+    std::string w, h;
     if (jsonParam.Exists("width"))
         w = jsonParam["width"];
     if (jsonParam.Exists("height"))
@@ -369,7 +370,7 @@ void JsonApiHandlerHttp::processGetCover()
             return;
         }
 
-        string cmd = "calaos_thumb \"" + data.svalue + "\" \"" + tempfname + "\"";
+        std::string cmd = "calaos_thumb \"" + data.svalue + "\" \"" + tempfname + "\"";
         if (w.empty() || h.empty())
             cmd += " " + w + "x" + h;
         exe_thumb = ecore_exe_run(cmd.c_str(), nullptr);
@@ -388,13 +389,13 @@ void JsonApiHandlerHttp::processGetCameraPic()
         return;
     }
 
-    string w, h;
+    std::string w, h;
     if (jsonParam.Exists("width"))
         w = jsonParam["width"];
     if (jsonParam.Exists("height"))
         h = jsonParam["height"];
 
-    string cmd = "calaos_thumb \"" + camera->getPictureUrl() + "\" \"" + tempfname + "\"";
+    std::string cmd = "calaos_thumb \"" + camera->getPictureUrl() + "\" \"" + tempfname + "\"";
     if (w.empty() || h.empty())
         cmd += " " + w + "x" + h;
     exe_thumb = ecore_exe_run(cmd.c_str(), nullptr);
@@ -454,7 +455,7 @@ void JsonApiHandlerHttp::processConfig(json_t *jroot)
             {
                 if (key && json_is_string(value))
                 {
-                    string skey = key;
+                    std::string skey = key;
                     if (skey != IO_CONFIG &&
                         skey != RULES_CONFIG &&
                         skey != LOCAL_CONFIG)
@@ -464,9 +465,9 @@ void JsonApiHandlerHttp::processConfig(json_t *jroot)
                         continue;
                     }
 
-                    string filecontent = json_string_value(value);
+                    std::string filecontent = json_string_value(value);
 
-                    ofstream ofs(Utils::getConfigFile(key), ios::out | ios::trunc);
+                    std::ofstream ofs(Utils::getConfigFile(key), std::ios::out | std::ios::trunc);
 
                     if (ofs.is_open())
                     {
@@ -507,7 +508,7 @@ void JsonApiHandlerHttp::processConfig(json_t *jroot)
 
 void JsonApiHandlerHttp::processAudio(json_t *jdata)
 {
-    string msg = jansson_string_get(jdata, "audio_action");
+    std::string msg = jansson_string_get(jdata, "audio_action");
     if (msg == "get_playlist_size")
         audioGetPlaylistSize(jdata, [=](json_t *jret)
         {
@@ -534,7 +535,7 @@ void JsonApiHandlerHttp::processAudio(json_t *jdata)
 
 void JsonApiHandlerHttp::processAudioDb(json_t *jdata)
 {
-    string msg = jansson_string_get(jdata, "audio_action");
+    std::string msg = jansson_string_get(jdata, "audio_action");
     if (msg == "get_albums")
         audioDbGetAlbums(jdata, [=](json_t *jret)
         {
@@ -631,7 +632,7 @@ void JsonApiHandlerHttp::processSetTimerange(json_t *jroot)
 
 void JsonApiHandlerHttp::processAutoscenario(json_t *jroot)
 {
-    string msg = jansson_string_get(jroot, "type");
+    std::string msg = jansson_string_get(jroot, "type");
     if (msg == "list")
         sendJson(buildAutoscenarioList(jroot));
     else if (msg == "get")
@@ -665,13 +666,13 @@ void JsonApiHandlerHttp::processCamera()
         {
             if (status == 200)
             {
-                string bodypic((const char *)eina_binbuf_string_get(downloadedData),
+                std::string bodypic((const char *)eina_binbuf_string_get(downloadedData),
                                eina_binbuf_length_get(downloadedData));
 
                 Params headers;
                 headers.Add("Connection", "close");
                 headers.Add("Content-Type", "image/jpeg");
-                string res = httpClient->buildHttpResponse(HTTP_200, headers, bodypic);
+                std::string res = httpClient->buildHttpResponse(HTTP_200, headers, bodypic);
                 sendData.emit(res);
             }
             else
@@ -681,7 +682,7 @@ void JsonApiHandlerHttp::processCamera()
                 Params headers;
                 headers.Add("Connection", "close");
                 headers.Add("Content-Type", "image/jpeg");
-                string res = httpClient->buildHttpResponseFromFile(HTTP_200, headers,
+                std::string res = httpClient->buildHttpResponseFromFile(HTTP_200, headers,
                                                                    Prefix::Instance().dataDirectoryGet() + "/camfail.jpg");
                 sendData.emit(res);
             }
@@ -713,14 +714,14 @@ void JsonApiHandlerHttp::processCamera()
             {
                 if (!camHeaderSent)
                 {
-                    stringstream sres;
+                    std::stringstream sres;
                     //HTTP code
                     sres << HTTP_200 << "\r\n";
 
                     Params h = cameraDl->getResponseHeaders();
                     for (int i = 0;i < h.size();i++)
                     {
-                        string key, value;
+                        std::string key, value;
                         h.get_item(i, key, value);
                         sres << key << ": " << value << "\r\n";
                     }
@@ -731,12 +732,12 @@ void JsonApiHandlerHttp::processCamera()
                     camHeaderSent = true;
                 }
 
-                sendData.emit(string((char *)data, size));
+                sendData.emit(std::string((char *)data, size));
             });
 
             cameraDl->m_signalComplete.connect([=](int)
             {
-                closeConnection.emit(0, string());
+                closeConnection.emit(0, std::string());
                 cameraDl = nullptr;
             });
             cameraDl->httpGet();
@@ -752,7 +753,7 @@ void JsonApiHandlerHttp::downloadCameraPicture(IPCam *camera)
         sendData.emit(HTTP_CAMERA_STREAM_BOUNDARY);
         if (status == 200)
         {
-            string bodypic((const char *)eina_binbuf_string_get(downloadedData),
+            std::string bodypic((const char *)eina_binbuf_string_get(downloadedData),
                            eina_binbuf_length_get(downloadedData));
             sendData.emit(bodypic);
         }
@@ -760,8 +761,8 @@ void JsonApiHandlerHttp::downloadCameraPicture(IPCam *camera)
         {
             cErrorDom("network") << "Failed to get image for camera at url: " << camera->getPictureUrl() << " failed with code: " << status;
 
-            ifstream file(Prefix::Instance().dataDirectoryGet() + "/camfail.jpg");
-            string bodypic((std::istreambuf_iterator<char>(file)),
+            std::ifstream file(Prefix::Instance().dataDirectoryGet() + "/camfail.jpg");
+            std::string bodypic((std::istreambuf_iterator<char>(file)),
                             std::istreambuf_iterator<char>());
             sendData.emit(bodypic);
         }
@@ -774,4 +775,6 @@ void JsonApiHandlerHttp::downloadCameraPicture(IPCam *camera)
         });
     });
     cameraDl->httpGet();
+}
+
 }

--- a/src/bin/calaos_server/JsonApiHandlerHttp.h
+++ b/src/bin/calaos_server/JsonApiHandlerHttp.h
@@ -28,7 +28,7 @@
 #include "UrlDownloader.h"
 #include "IPCam.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 class JsonApiHandlerHttp: public JsonApi
 {
@@ -36,13 +36,13 @@ public:
     JsonApiHandlerHttp(HttpClient *client);
     virtual ~JsonApiHandlerHttp();
 
-    virtual void processApi(const string &data, const Params &paramsGET);
+    virtual void processApi(const std::string &data, const Params &paramsGET);
 
 private:
 
     Ecore_Event_Handler *exe_handler;
     Ecore_Exe *exe_thumb;
-    string tempfname;
+    std::string tempfname;
 
     Params jsonParam;
 
@@ -82,5 +82,7 @@ private:
 
     void downloadCameraPicture(IPCam *camera);
 };
+
+}
 
 #endif // JSONAPIV2_H

--- a/src/bin/calaos_server/JsonApiHandlerWS.cpp
+++ b/src/bin/calaos_server/JsonApiHandlerWS.cpp
@@ -30,6 +30,8 @@
 #include "HttpCodes.h"
 #include "WebSocket.h"
 
+namespace Calaos {
+
 JsonApiHandlerWS::JsonApiHandlerWS(HttpClient *client):
     JsonApi(client)
 {
@@ -51,7 +53,7 @@ void JsonApiHandlerWS::handleEvents(const CalaosEvent &event)
     sendJson("event", event.toJson());
 }
 
-void JsonApiHandlerWS::sendJson(const string &msg_type, json_t *data, const string &client_id)
+void JsonApiHandlerWS::sendJson(const std::string &msg_type, json_t *data, const std::string &client_id)
 {
     json_t *jroot = json_object();
     json_object_set_new(jroot, "msg", json_string(msg_type.c_str()));
@@ -63,12 +65,12 @@ void JsonApiHandlerWS::sendJson(const string &msg_type, json_t *data, const stri
     sendData.emit(jansson_to_string(jroot));
 }
 
-void JsonApiHandlerWS::sendJson(const string &msg_type, const Params &p, const string &client_id)
+void JsonApiHandlerWS::sendJson(const std::string &msg_type, const Params &p, const std::string &client_id)
 {
     sendJson(msg_type, p.toJson(), client_id);
 }
 
-void JsonApiHandlerWS::processApi(const string &data, const Params &paramsGET)
+void JsonApiHandlerWS::processApi(const std::string &data, const Params &paramsGET)
 {
     VAR_UNUSED(paramsGET); //not used for websocket
 
@@ -105,8 +107,8 @@ void JsonApiHandlerWS::processApi(const string &data, const Params &paramsGET)
     if (jsonRoot["msg"] == "login")
     {
         //check for if username/password matches
-        string user = Utils::get_config_option("calaos_user");
-        string pass = Utils::get_config_option("calaos_password");
+        std::string user = Utils::get_config_option("calaos_user");
+        std::string pass = Utils::get_config_option("calaos_password");
 
         if (Utils::get_config_option("cn_user") != "" &&
             Utils::get_config_option("cn_pass") != "")
@@ -182,7 +184,7 @@ void JsonApiHandlerWS::processApi(const string &data, const Params &paramsGET)
     json_decref(jroot);
 }
 
-void JsonApiHandlerWS::processGetHome(const Params &jsonReq, const string &client_id)
+void JsonApiHandlerWS::processGetHome(const Params &jsonReq, const std::string &client_id)
 {
     json_t *jret = nullptr;
 
@@ -194,7 +196,7 @@ void JsonApiHandlerWS::processGetHome(const Params &jsonReq, const string &clien
     sendJson("get_home", jret, client_id);
 }
 
-void JsonApiHandlerWS::processGetState(json_t *jdata, const string &client_id)
+void JsonApiHandlerWS::processGetState(json_t *jdata, const std::string &client_id)
 {
     if (!jdata)
     {
@@ -208,7 +210,7 @@ void JsonApiHandlerWS::processGetState(json_t *jdata, const string &client_id)
     });
 }
 
-void JsonApiHandlerWS::processGetStates(const Params &jsonReq, const string &client_id)
+void JsonApiHandlerWS::processGetStates(const Params &jsonReq, const std::string &client_id)
 {
     buildJsonStates(jsonReq, [=](json_t *jret)
     {
@@ -216,7 +218,7 @@ void JsonApiHandlerWS::processGetStates(const Params &jsonReq, const string &cli
     });
 }
 
-void JsonApiHandlerWS::processQuery(const Params &jsonReq, const string &client_id)
+void JsonApiHandlerWS::processQuery(const Params &jsonReq, const std::string &client_id)
 {
     buildQuery(jsonReq, [=](json_t *jret)
     {
@@ -224,22 +226,22 @@ void JsonApiHandlerWS::processQuery(const Params &jsonReq, const string &client_
     });
 }
 
-void JsonApiHandlerWS::processGetParam(const Params &jsonReq, const string &client_id)
+void JsonApiHandlerWS::processGetParam(const Params &jsonReq, const std::string &client_id)
 {
     sendJson("get_param", buildJsonGetParam(jsonReq), client_id);
 }
 
-void JsonApiHandlerWS::processSetParam(const Params &jsonReq, const string &client_id)
+void JsonApiHandlerWS::processSetParam(const Params &jsonReq, const std::string &client_id)
 {
     sendJson("set_param", buildJsonSetParam(jsonReq), client_id);
 }
 
-void JsonApiHandlerWS::processDelParam(const Params &jsonReq, const string &client_id)
+void JsonApiHandlerWS::processDelParam(const Params &jsonReq, const std::string &client_id)
 {
     sendJson("del_param", buildJsonDelParam(jsonReq), client_id);
 }
 
-void JsonApiHandlerWS::processGetIO(json_t *jdata, const string &client_id)
+void JsonApiHandlerWS::processGetIO(json_t *jdata, const std::string &client_id)
 {
     if (!jdata)
     {
@@ -250,7 +252,7 @@ void JsonApiHandlerWS::processGetIO(json_t *jdata, const string &client_id)
     sendJson("get_io", buildJsonGetIO(jdata), client_id);
 }
 
-void JsonApiHandlerWS::processSetState(Params &jsonReq, const string &client_id)
+void JsonApiHandlerWS::processSetState(Params &jsonReq, const std::string &client_id)
 {
     bool res = decodeSetState(jsonReq);
 
@@ -262,7 +264,7 @@ void JsonApiHandlerWS::processSetState(Params &jsonReq, const string &client_id)
     }
 }
 
-void JsonApiHandlerWS::processGetPlaylist(Params &jsonReq, const string &client_id)
+void JsonApiHandlerWS::processGetPlaylist(Params &jsonReq, const std::string &client_id)
 {
     decodeGetPlaylist(jsonReq, [=](json_t *jret)
     {
@@ -270,9 +272,9 @@ void JsonApiHandlerWS::processGetPlaylist(Params &jsonReq, const string &client_
     });
 }
 
-void JsonApiHandlerWS::processAudio(json_t *jdata, const string &client_id)
+void JsonApiHandlerWS::processAudio(json_t *jdata, const std::string &client_id)
 {
-    string msg = jansson_string_get(jdata, "audio_action");
+    std::string msg = jansson_string_get(jdata, "audio_action");
     if (msg == "get_playlist_size")
         audioGetPlaylistSize(jdata, [=](json_t *jret)
         {
@@ -297,9 +299,9 @@ void JsonApiHandlerWS::processAudio(json_t *jdata, const string &client_id)
         sendJson("audio", {{"error", "unkown audio_action" }} , client_id);
 }
 
-void JsonApiHandlerWS::processAudioDb(json_t *jdata, const string &client_id)
+void JsonApiHandlerWS::processAudioDb(json_t *jdata, const std::string &client_id)
 {
-    string msg = jansson_string_get(jdata, "audio_action");
+    std::string msg = jansson_string_get(jdata, "audio_action");
     if (msg == "get_album")
         audioDbGetAlbums(jdata, [=](json_t *jret)
         {
@@ -384,19 +386,19 @@ void JsonApiHandlerWS::processAudioDb(json_t *jdata, const string &client_id)
         sendJson("audio_db", {{"error", "unkown audio_action" }} , client_id);
 }
 
-void JsonApiHandlerWS::processGetTimerange(const Params &jsonReq, const string &client_id)
+void JsonApiHandlerWS::processGetTimerange(const Params &jsonReq, const std::string &client_id)
 {
     sendJson("get_timerange", buildJsonGetTimerange(jsonReq), client_id);
 }
 
-void JsonApiHandlerWS::processSetTimerange(json_t *jdata, const string &client_id)
+void JsonApiHandlerWS::processSetTimerange(json_t *jdata, const std::string &client_id)
 {
     sendJson("set_timerange", buildJsonSetTimerange(jdata), client_id);
 }
 
-void JsonApiHandlerWS::processAutoscenario(json_t *jdata, const string &client_id)
+void JsonApiHandlerWS::processAutoscenario(json_t *jdata, const std::string &client_id)
 {
-    string msg = jansson_string_get(jdata, "type");
+    std::string msg = jansson_string_get(jdata, "type");
     if (msg == "list")
         sendJson("autoscenario", buildAutoscenarioList(jdata), client_id);
     else if (msg == "get")
@@ -411,4 +413,6 @@ void JsonApiHandlerWS::processAutoscenario(json_t *jdata, const string &client_i
         sendJson("autoscenario", buildAutoscenarioAddSchedule(jdata), client_id);
     else if (msg == "del_schedule")
         sendJson("autoscenario", buildAutoscenarioDelSchedule(jdata), client_id);
+}
+
 }

--- a/src/bin/calaos_server/JsonApiHandlerWS.h
+++ b/src/bin/calaos_server/JsonApiHandlerWS.h
@@ -24,44 +24,48 @@
 #include "JsonApi.h"
 #include "EventManager.h"
 
+namespace Calaos {
+
 class JsonApiHandlerWS: public JsonApi
 {
 public:
     JsonApiHandlerWS(HttpClient *client);
     virtual ~JsonApiHandlerWS();
 
-    virtual void processApi(const string &data, const Params &paramsGET);
+    virtual void processApi(const std::string &data, const Params &paramsGET);
 
 private:
 
     sigc::connection evcon;
 
-    sigc::signal<void, string, string, void*, void*> sig_events;
+    sigc::signal<void, std::string, std::string, void*, void*> sig_events;
 
     void handleEvents(const CalaosEvent &event);
 
     bool loggedin = false;
 
-    void sendJson(const string &msg_type, json_t *data, const string &client_id = string());
-    void sendJson(const string &msg_type, const Params &p, const string &client_id = string());
+    void sendJson(const std::string &msg_type, json_t *data, const std::string &client_id = std::string());
+    void sendJson(const std::string &msg_type, const Params &p, const std::string &client_id = std::string());
 
-    void processGetHome(const Params &jsonReq, const string &client_id = string());
-    void processGetState(json_t *jdata, const string &client_id = string());
-    void processGetStates(const Params &jsonReq, const string &client_id = string());
-    void processQuery(const Params &jsonReq, const string &client_id = string());
-    void processGetParam(const Params &jsonReq, const string &client_id = string());
-    void processSetParam(const Params &jsonReq, const string &client_id = string());
-    void processDelParam(const Params &jsonReq, const string &client_id = string());
-    void processSetState(Params &jsonReq, const string &client_id = string());
-    void processGetPlaylist(Params &jsonReq, const string &client_id = string());
-    void processGetIO(json_t *jdata, const string &client_id = string());
-    void processGetTimerange(const Params &jsonReq, const string &client_id = string());
-    void processSetTimerange(json_t *jdata, const string &client_id = string());
+    void processGetHome(const Params &jsonReq, const std::string &client_id = std::string());
+    void processGetState(json_t *jdata, const std::string &client_id = std::string());
+    void processGetStates(const Params &jsonReq, const std::string &client_id = std::string());
+    void processQuery(const Params &jsonReq, const std::string &client_id = std::string());
+    void processGetParam(const Params &jsonReq, const std::string &client_id = std::string());
+    void processSetParam(const Params &jsonReq, const std::string &client_id = std::string());
+    void processDelParam(const Params &jsonReq, const std::string &client_id = std::string());
+    void processSetState(Params &jsonReq, const std::string &client_id = std::string());
+    void processGetPlaylist(Params &jsonReq, const std::string &client_id = std::string());
+    void processGetIO(json_t *jdata, const std::string &client_id = std::string());
+    void processGetTimerange(const Params &jsonReq, const std::string &client_id = std::string());
+    void processSetTimerange(json_t *jdata, const std::string &client_id = std::string());
 
-    void processAudio(json_t *jdata, const string &client_id = string());
-    void processAudioDb(json_t *jdata, const string &client_id = string());
+    void processAudio(json_t *jdata, const std::string &client_id = std::string());
+    void processAudioDb(json_t *jdata, const std::string &client_id = std::string());
 
-    void processAutoscenario(json_t *jdata, const string &client_id = string());
+    void processAutoscenario(json_t *jdata, const std::string &client_id = std::string());
 };
+
+}
 
 #endif // JSONAPIV3_H

--- a/src/bin/calaos_server/ListeRoom.cpp
+++ b/src/bin/calaos_server/ListeRoom.cpp
@@ -22,7 +22,7 @@
 #include "AutoScenario.h"
 #include "CalaosConfig.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 ListeRoom &ListeRoom::Instance()
 {
@@ -85,7 +85,7 @@ void ListeRoom::Add(Room *p)
 
 void ListeRoom::Remove(int pos)
 {
-    vector<Room *>::iterator iter = rooms.begin();
+    std::vector<Room *>::iterator iter = rooms.begin();
     for (int i = 0;i < pos;iter++, i++) ;
     delete rooms[pos];
     rooms.erase(iter);
@@ -186,7 +186,7 @@ void ListeRoom::delScenarioCache(Scenario *sc)
     auto_scenario_cache.remove(sc);
 }
 
-list<Scenario *> ListeRoom::getAutoScenarios()
+std::list<Scenario *> ListeRoom::getAutoScenarios()
 {
     cDebugDom("room") << "Found " << auto_scenario_cache.size() << " auto_scenarios.";
 
@@ -195,7 +195,7 @@ list<Scenario *> ListeRoom::getAutoScenarios()
 
 void ListeRoom::checkAutoScenario()
 {
-    list<Scenario *>::iterator it = auto_scenario_cache.begin();
+    std::list<Scenario *>::iterator it = auto_scenario_cache.begin();
 
     for (;it != auto_scenario_cache.end();it++)
     {
@@ -204,7 +204,7 @@ void ListeRoom::checkAutoScenario()
             sc->getAutoScenario()->checkScenarioRules();
     }
 
-    list<Rule *> to_remove;
+    std::list<Rule *> to_remove;
     for (int i = 0;i < ListeRule::Instance().size();i++)
     {
         Rule *rule = ListeRule::Instance().get_rule(i);
@@ -212,7 +212,7 @@ void ListeRoom::checkAutoScenario()
             to_remove.push_back(rule);
     }
 
-    list<Rule *>::iterator itr = to_remove.begin();
+    std::list<Rule *>::iterator itr = to_remove.begin();
     for (;itr != to_remove.end();itr++)
         ListeRule::Instance().Remove(*itr);
 
@@ -221,10 +221,10 @@ void ListeRoom::checkAutoScenario()
     Config::Instance().SaveConfigRule();
 }
 
-Room * ListeRoom::searchRoomByNameAndType(string name, string type)
+Room * ListeRoom::searchRoomByNameAndType(std::string name, std::string type)
 {
     Room *r = NULL;
-    vector<Room *>::iterator itRoom;
+    std::vector<Room *>::iterator itRoom;
 
     for(itRoom = rooms.begin(); itRoom != rooms.end() && !r; itRoom++)
         if( (*itRoom)->get_name() == name && (*itRoom)->get_type() == type)
@@ -285,4 +285,6 @@ IOBase* ListeRoom::createIO(Params param, Room *room)
                            { "room_type", room->get_type() } });
 
     return io;
+}
+
 }

--- a/src/bin/calaos_server/ListeRoom.h
+++ b/src/bin/calaos_server/ListeRoom.h
@@ -36,12 +36,12 @@ class ListeRoom
 {
 protected:
     std::vector<Room *> rooms;
-    unordered_map<string, IOBase *> io_table;
+    std::unordered_map<std::string, IOBase *> io_table;
 
-    list<IOBase *> cameraCache;
-    list<IOBase *> audioCache;
+    std::list<IOBase *> cameraCache;
+    std::list<IOBase *> audioCache;
 
-    list<Scenario *> auto_scenario_cache;
+    std::list<Scenario *> auto_scenario_cache;
 
     ListeRoom();
 
@@ -66,17 +66,17 @@ public:
 
     IOBase *get_chauffage_var(std::string &chauff_id, ChauffType type);
 
-    list<IOBase *> getCameraList() { return cameraCache; }
-    list<IOBase *> getAudioList() { return audioCache; }
+    std::list<IOBase *> getCameraList() { return cameraCache; }
+    std::list<IOBase *> getAudioList() { return audioCache; }
 
     //Auto scenarios
 
     void addScenarioCache(Scenario *sc);
     void delScenarioCache(Scenario *sc);
-    list<Scenario *> getAutoScenarios();
+    std::list<Scenario *> getAutoScenarios();
     void checkAutoScenario();
 
-    Room * searchRoomByNameAndType(string name,string type);
+    Room * searchRoomByNameAndType(std::string name,std::string type);
 
     Room *getRoomByIO(IOBase *o);
 

--- a/src/bin/calaos_server/ListeRule.cpp
+++ b/src/bin/calaos_server/ListeRule.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include <ListeRule.h>
 
-using namespace Calaos;
+namespace Calaos {
 
 ListeRule &ListeRule::Instance()
 {
@@ -51,7 +51,7 @@ void ListeRule::Add(Rule *r)
 
 void ListeRule::Remove(int pos)
 {
-    vector<Rule *>::iterator iter = rules.begin();
+    std::vector<Rule *>::iterator iter = rules.begin();
     for (int i = 0;i < pos;iter++, i++) ;
 
     if (rules[pos]->param_exists("auto_scenario"))
@@ -111,7 +111,7 @@ void ListeRule::ExecuteRuleSignal(std::string id)
 
     cDebugDom("rule") << "Received signal for id " << id;
 
-    unordered_map<Rule *, bool> execRules;
+    std::unordered_map<Rule *, bool> execRules;
 
     for (Rule *rule: rules)
     {
@@ -135,7 +135,7 @@ void ListeRule::ExecuteRuleSignal(std::string id)
             }
             if (!exec && cond)
             {
-                vector<IOBase *> list;
+                std::vector<IOBase *> list;
                 cond->getVarIds(list);
 
                 for (uint k = 0;k < list.size();k++)
@@ -280,10 +280,10 @@ void ListeRule::ExecuteStartRules()
     }
 }
 
-list<Rule *> ListeRule::getRuleAutoScenario(string auto_scenario)
+std::list<Rule *> ListeRule::getRuleAutoScenario(std::string auto_scenario)
 {
-    list<Rule *> l;
-    list<Rule *>::iterator it = rules_scenarios.begin();
+    std::list<Rule *> l;
+    std::list<Rule *>::iterator it = rules_scenarios.begin();
 
     for (;it != rules_scenarios.end();it++)
     {
@@ -293,4 +293,6 @@ list<Rule *> ListeRule::getRuleAutoScenario(string auto_scenario)
     }
 
     return l;
+}
+
 }

--- a/src/bin/calaos_server/ListeRule.h
+++ b/src/bin/calaos_server/ListeRule.h
@@ -32,7 +32,6 @@
 #include "Room.h"
 #include <Ecore.h>
 
-using namespace std;
 
 namespace Calaos
 {
@@ -46,7 +45,7 @@ protected:
     std::vector<IOBase *> in_event;
 
     //Rules for autoscenario
-    list<Rule *> rules_scenarios;
+    std::list<Rule *> rules_scenarios;
 
     bool loop = false;
 
@@ -92,7 +91,7 @@ public:
                  */
     void ExecuteStartRules();
 
-    list<Rule *> getRuleAutoScenario(string auto_scenario);
+    std::list<Rule *> getRuleAutoScenario(std::string auto_scenario);
 };
 
 }

--- a/src/bin/calaos_server/LuaScript/ScriptBindings.cpp
+++ b/src/bin/calaos_server/LuaScript/ScriptBindings.cpp
@@ -22,10 +22,10 @@
 #include "ScriptManager.h"
 #include "FileDownloader.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 //Debug
-void Calaos::Lua_stackDump(lua_State *L)
+void Lua_stackDump(lua_State *L)
 {
     int i;
     int top = lua_gettop(L);
@@ -58,10 +58,10 @@ void Calaos::Lua_stackDump(lua_State *L)
 /* This print version will replace the one in base lib. It prints out everything
  * through the shared logging facility instead of stdout
  */
-int Calaos::Lua_print(lua_State *L)
+int Lua_print(lua_State *L)
 {
     int n = lua_gettop(L);
-    string msg;
+    std::string msg;
 
     for (int i = 1;i <= n;i++)
     {
@@ -86,7 +86,7 @@ int Calaos::Lua_print(lua_State *L)
     return 0;
 }
 
-void Calaos::Lua_DebugHook(lua_State *L, lua_Debug *ar)
+void Lua_DebugHook(lua_State *L, lua_Debug *ar)
 {
     ScriptManager::Instance().LuaDebugHook(L, ar);
 //    double time;
@@ -125,7 +125,7 @@ Lua_Calaos::Lua_Calaos()
 
 Lua_Calaos::Lua_Calaos(lua_State *L)
 {
-    string err = "Calaos(): Don't create a new object, juste use the existing one \"calaos:...\"";
+    std::string err = "Calaos(): Don't create a new object, juste use the existing one \"calaos:...\"";
     lua_pushstring(L, err.c_str());
     lua_error(L);
 }
@@ -136,10 +136,10 @@ int Lua_Calaos::getIOValue(lua_State *L)
 
     if (nb == 1 && lua_isstring(L, 1))
     {
-        string o = lua_tostring(L, 1);
+        std::string o = lua_tostring(L, 1);
         if (ioMap.find(o) == ioMap.end())
         {
-            string err = "getIOValue(): invalid IO id: " + o;
+            std::string err = "getIOValue(): invalid IO id: " + o;
             lua_pushstring(L, err.c_str());
             lua_error(L);
         }
@@ -156,7 +156,7 @@ int Lua_Calaos::getIOValue(lua_State *L)
     }
     else
     {
-        string err = "getIOValue(): invalid argument. Requires an IO id.";
+        std::string err = "getIOValue(): invalid argument. Requires an IO id.";
         lua_pushstring(L, err.c_str());
         lua_error(L);
     }
@@ -170,10 +170,10 @@ int Lua_Calaos::setIOValue(lua_State *L)
 
     if (nb == 2 && lua_isstring(L, 1))
     {
-        string o = lua_tostring(L, 1);
+        std::string o = lua_tostring(L, 1);
         if (ioMap.find(o) == ioMap.end())
         {
-            string err = "setIOValue(): invalid IO id: " + o;
+            std::string err = "setIOValue(): invalid IO id: " + o;
             lua_pushstring(L, err.c_str());
             lua_error(L);
         }
@@ -188,7 +188,7 @@ int Lua_Calaos::setIOValue(lua_State *L)
                 io.set_value(Utils::to_string(lua_tostring(L, 2)));
             else
             {
-                string err = "setIOValue(): invalid IO id";
+                std::string err = "setIOValue(): invalid IO id";
                 lua_pushstring(L, err.c_str());
                 lua_error(L);
             }
@@ -196,7 +196,7 @@ int Lua_Calaos::setIOValue(lua_State *L)
     }
     else
     {
-        string err = "setIOValue(): invalid argument. Requires an IO id.";
+        std::string err = "setIOValue(): invalid argument. Requires an IO id.";
         lua_pushstring(L, err.c_str());
         lua_error(L);
     }
@@ -210,16 +210,16 @@ int Lua_Calaos::getIOParam(lua_State *L)
 
     if (nb == 2 && lua_isstring(L, 1) && lua_isstring(L, 2))
     {
-        string o = lua_tostring(L, 1);
+        std::string o = lua_tostring(L, 1);
         if (ioMap.find(o) == ioMap.end())
         {
-            string err = "getIOParam(): invalid IO id: " + o;
+            std::string err = "getIOParam(): invalid IO id: " + o;
             lua_pushstring(L, err.c_str());
             lua_error(L);
         }
         else
         {
-            string key = Utils::to_string(lua_tostring(L, 2));
+            std::string key = Utils::to_string(lua_tostring(L, 2));
             auto io = ioMap[o];
 
             if (Utils::is_of_type<double>(io.params[key]))
@@ -237,7 +237,7 @@ int Lua_Calaos::getIOParam(lua_State *L)
     }
     else
     {
-        string err = "getIOParam(): invalid argument. Requires an IO id.";
+        std::string err = "getIOParam(): invalid argument. Requires an IO id.";
         lua_pushstring(L, err.c_str());
         lua_error(L);
     }
@@ -251,17 +251,17 @@ int Lua_Calaos::setIOParam(lua_State *L)
 
     if (nb == 3 && lua_isstring(L, 1) && lua_isstring(L, 2))
     {
-        string o = lua_tostring(L, 1);
+        std::string o = lua_tostring(L, 1);
         if (ioMap.find(o) == ioMap.end())
         {
-            string err = "setIOParam(): invalid IO id: " + o;
+            std::string err = "setIOParam(): invalid IO id: " + o;
             lua_pushstring(L, err.c_str());
             lua_error(L);
         }
         else
         {
-            string key = Utils::to_string(lua_tostring(L, 2));
-            string value;
+            std::string key = Utils::to_string(lua_tostring(L, 2));
+            std::string value;
 
             auto io = ioMap[o];
 
@@ -273,7 +273,7 @@ int Lua_Calaos::setIOParam(lua_State *L)
                 value = Utils::to_string(lua_tostring(L, 3));
             else
             {
-                string err = "setIOParam(): wrong value";
+                std::string err = "setIOParam(): wrong value";
                 lua_pushstring(L, err.c_str());
                 lua_error(L);
             }
@@ -283,7 +283,7 @@ int Lua_Calaos::setIOParam(lua_State *L)
     }
     else
     {
-        string err = "setIOParam(): invalid argument. Requires an IO id.";
+        std::string err = "setIOParam(): invalid argument. Requires an IO id.";
         lua_pushstring(L, err.c_str());
         lua_error(L);
     }
@@ -297,10 +297,10 @@ int Lua_Calaos::waitForIO(lua_State *L)
 
     if (nb == 1 && lua_isstring(L, 1))
     {
-        string id = lua_tostring(L, 1);
+        std::string id = lua_tostring(L, 1);
         if (ioMap.find(id) == ioMap.end())
         {
-            string err = "waitForIO(): invalid IO id: " + id;
+            std::string err = "waitForIO(): invalid IO id: " + id;
             lua_pushstring(L, err.c_str());
             lua_error(L);
         }
@@ -312,7 +312,7 @@ int Lua_Calaos::waitForIO(lua_State *L)
 
             if (abort)
             {
-                string err = "waitForIO(): Abort script.";
+                std::string err = "waitForIO(): Abort script.";
                 lua_pushstring(L, err.c_str());
                 lua_error(L);
             }
@@ -320,7 +320,7 @@ int Lua_Calaos::waitForIO(lua_State *L)
     }
     else
     {
-        string err = "waitForIO(): invalid argument. Requires an IO id.";
+        std::string err = "waitForIO(): invalid argument. Requires an IO id.";
         lua_pushstring(L, err.c_str());
         lua_error(L);
     }
@@ -334,9 +334,9 @@ int Lua_Calaos::requestUrl(lua_State *L)
 
     if (nb == 1 && lua_isstring(L, 1))
     {
-        string url = lua_tostring(L, 1);
+        std::string url = lua_tostring(L, 1);
 
-        string code = "local http = require(\"socket.http\")\n" \
+        std::string code = "local http = require(\"socket.http\")\n"    \
                       "http.request(\"" + url + "\")";
 
         luaL_loadstring(L, code.c_str());
@@ -344,10 +344,10 @@ int Lua_Calaos::requestUrl(lua_State *L)
     }
     else if (nb == 2 && lua_isstring(L, 1) && lua_isstring(L, 2))
     {
-        string url = lua_tostring(L, 1);
-        string post_data = lua_tostring(L, 2);
+        std::string url = lua_tostring(L, 1);
+        std::string post_data = lua_tostring(L, 2);
 
-        string code = "local http = require(\"socket.http\")\n" \
+        std::string code = "local http = require(\"socket.http\")\n"    \
                       "http.request(\"" + url + "\", \"" + Utils::escape_quotes(post_data) + "\")";
 
         luaL_loadstring(L, code.c_str());
@@ -355,7 +355,7 @@ int Lua_Calaos::requestUrl(lua_State *L)
     }
     else
     {
-        string err = "requestUrl(): invalid argument. Requires a string (URL to call).";
+        std::string err = "requestUrl(): invalid argument. Requires a string (URL to call).";
         lua_pushstring(L, err.c_str());
         lua_error(L);
     }
@@ -376,7 +376,7 @@ double LuaIOBase::get_value_double() const
     return v;
 }
 
-string LuaIOBase::get_value_string() const
+std::string LuaIOBase::get_value_string() const
 {
     return params["state"];
 }
@@ -405,7 +405,7 @@ void LuaIOBase::set_value(std::string val) const
     sendJson("set_state", p);
 }
 
-void LuaIOBase::set_param(const string &key, const string &val)
+void LuaIOBase::set_param(const std::string &key, const std::string &val)
 {
     Params p = {{ "id", params["id"] },
                 { "param", key },
@@ -414,10 +414,12 @@ void LuaIOBase::set_param(const string &key, const string &val)
     sendJson("set_param", p);
 }
 
-void LuaIOBase::sendJson(const string &msg_type, const Params &param) const
+void LuaIOBase::sendJson(const std::string &msg_type, const Params &param) const
 {
     json_t *jroot = json_object();
     json_object_set_new(jroot, "msg", json_string(msg_type.c_str()));
     json_object_set_new(jroot, "data", param.toJson());
     extClient->sendMessage(jansson_to_string(jroot));
+}
+
 }

--- a/src/bin/calaos_server/LuaScript/ScriptBindings.h
+++ b/src/bin/calaos_server/LuaScript/ScriptBindings.h
@@ -45,18 +45,18 @@ public:
 
     bool get_value_bool() const;
     double get_value_double() const ;
-    string get_value_string() const;
+    std::string get_value_string() const;
 
     void set_value(bool val) const;
     void set_value(double val) const;
     void set_value(std::string val) const;
 
-    void set_param(const string &key, const string &val);
+    void set_param(const std::string &key, const std::string &val);
 
 private:
     ExternProcClient *extClient;
 
-    void sendJson(const string &msg_type, const Params &param) const;
+    void sendJson(const std::string &msg_type, const Params &param) const;
 };
 
 int Lua_print(lua_State *L);
@@ -76,10 +76,10 @@ public:
     Lua_Calaos();
     Lua_Calaos(lua_State *L);
 
-    unordered_map<string, LuaIOBase> ioMap;
+    std::unordered_map<std::string, LuaIOBase> ioMap;
     bool abort = false;
 
-    sigc::signal<bool, const string &> waitForIOChanged;
+    sigc::signal<bool, const std::string &> waitForIOChanged;
 
     /* IO set/get */
     int getIOValue(lua_State *L);

--- a/src/bin/calaos_server/LuaScript/ScriptExec.h
+++ b/src/bin/calaos_server/LuaScript/ScriptExec.h
@@ -24,6 +24,8 @@
 #include "Utils.h"
 #include "ExternProc.h"
 
+namespace Calaos {
+
 class ScriptExec
 {
 public:
@@ -31,10 +33,12 @@ public:
     /* Execute the script in a detached process (calaos_script)
      * Communication is done with ExternProc
      */
-    static ExternProcServer *ExecuteScriptDetached(const string &script, std::function<void(bool ret)> cb);
+    static ExternProcServer *ExecuteScriptDetached(const std::string &script, std::function<void(bool ret)> cb);
 
 private:
     ScriptExec() {}
 };
+
+}
 
 #endif // SCRIPTEXEC_H

--- a/src/bin/calaos_server/LuaScript/ScriptExtern_main.cpp
+++ b/src/bin/calaos_server/LuaScript/ScriptExtern_main.cpp
@@ -21,8 +21,8 @@
 #include "ExternProc.h"
 #include "LuaScript/ScriptManager.h"
 
-using namespace Calaos;
 
+namespace Calaos {
 class ScriptProcess: public ExternProcClient
 {
 public:
@@ -35,14 +35,14 @@ public:
 
 protected:
 
-    map<string, string> waitIds;
+    std::map<std::string, std::string> waitIds;
 
     //needs to be reimplemented
     virtual void readTimeout() {}
-    virtual void messageReceived(const string &msg);
+    virtual void messageReceived(const std::string &msg);
 };
 
-void ScriptProcess::messageReceived(const string &msg)
+void ScriptProcess::messageReceived(const std::string &msg)
 {
     json_error_t jerr;
     json_t *jroot = json_loads(msg.c_str(), 0, &jerr);
@@ -55,12 +55,12 @@ void ScriptProcess::messageReceived(const string &msg)
         return;
     }
 
-    string mtype = jansson_string_get(jroot, "msg");
+    std::string mtype = jansson_string_get(jroot, "msg");
 
     if (mtype == "execute")
     {
         cInfoDom("lua") << "Executing LUA script";
-        string script = jansson_string_get(jroot, "script");
+        std::string script = jansson_string_get(jroot, "script");
 
         json_t *jctx = json_object_get(jroot, "context");
         size_t idx;
@@ -96,7 +96,7 @@ void ScriptProcess::messageReceived(const string &msg)
                 ScriptManager::Instance().abortScript();
         });
 
-        ScriptManager::Instance().luaCalaos.waitForIOChanged.connect([=](const string &id) -> bool
+        ScriptManager::Instance().luaCalaos.waitForIOChanged.connect([=](const std::string &id) -> bool
         {
             waitIds.clear();
 
@@ -144,7 +144,7 @@ void ScriptProcess::messageReceived(const string &msg)
         Params ev;
         jansson_decode_object(jdata, ev);
 
-        string t = jansson_string_get(jev, "type_str");
+        std::string t = jansson_string_get(jev, "type_str");
 
         //this IO has been changed by an event
         //if script is waiting on that IO, the script will be resumed
@@ -161,7 +161,7 @@ void ScriptProcess::messageReceived(const string &msg)
             {
                 for (int i = 0;i < ev.size();i++)
                 {
-                    string key, val;
+                    std::string key, val;
                     ev.get_item(i, key, val);
                     ScriptManager::Instance().luaCalaos.ioMap[ev["id"]].params.Add(key, val);
                 }
@@ -201,4 +201,7 @@ int ScriptProcess::procMain()
     return 0;
 }
 
-EXTERN_PROC_CLIENT_MAIN(ScriptProcess)
+}
+
+EXTERN_PROC_CLIENT_MAIN(Calaos::ScriptProcess)
+

--- a/src/bin/calaos_server/LuaScript/ScriptManager.cpp
+++ b/src/bin/calaos_server/LuaScript/ScriptManager.cpp
@@ -21,8 +21,8 @@
 #include "ScriptManager.h"
 #include <setjmp.h>
 
-using namespace Calaos;
 
+namespace Calaos {
 double ScriptManager::start_time = 0.0;
 static jmp_buf panic_jmp;
 
@@ -31,7 +31,7 @@ ScriptManager::ScriptManager()
     cDebugDom("script.lua");
 }
 
-bool ScriptManager::ExecuteScript(const string &script)
+bool ScriptManager::ExecuteScript(const std::string &script)
 {
     bool ret = true;
     errorScript = true;
@@ -65,13 +65,13 @@ bool ScriptManager::ExecuteScript(const string &script)
         ret = false;
         if (err == LUA_ERRSYNTAX)
         {
-            string msg = lua_tostring(L, -1);
+            std::string msg = lua_tostring(L, -1);
             cErrorDom("script.lua") << "Syntax Error: " << msg;
             errorMsg = "Syntax Error:\n" + msg;
         }
         else if (err == LUA_ERRMEM)
         {
-            string msg = lua_tostring(L, -1);
+            std::string msg = lua_tostring(L, -1);
             cErrorDom("script.lua") << "LUA memory allocation error: " << msg;
             errorMsg = "Fatal Error:\nLUA memory allocation error:\n" + msg;
         }
@@ -89,14 +89,14 @@ bool ScriptManager::ExecuteScript(const string &script)
         {
             ret = false;
 
-            string errcode;
+            std::string errcode;
             if (err == LUA_ERRRUN) errcode = "Runtime error";
             else if (err == LUA_ERRSYNTAX) errcode = "Syntax error";
             else if (err == LUA_ERRMEM) errcode = "Memory allocation error";
             else if (err == LUA_ERRERR) errcode = "Error";
             else errcode = "Unknown error";
 
-            string msg = lua_tostring(L, -1);
+            std::string msg = lua_tostring(L, -1);
             cErrorDom("script.lua") << errcode << " : " << msg;
             errorMsg = "Error " + errcode + " :\n\t" + msg;
         }
@@ -125,10 +125,12 @@ void ScriptManager::LuaDebugHook(lua_State *L, lua_Debug *ar)
 {
     if (abort)
     {
-        string err = "waitForIO(): Abort script.";
+        std::string err = "waitForIO(): Abort script.";
         lua_pushstring(L, err.c_str());
         lua_error(L);
     }
 
     debugHook.emit();
+}
+
 }

--- a/src/bin/calaos_server/LuaScript/ScriptManager.h
+++ b/src/bin/calaos_server/LuaScript/ScriptManager.h
@@ -34,7 +34,7 @@ private:
     ScriptManager();
 
     bool errorScript;
-    string errorMsg;
+    std::string errorMsg;
     bool abort = false;
 
 public:
@@ -47,10 +47,10 @@ public:
     /* Execute script and return true or false depending on
      * the return value of the script
      */
-    bool ExecuteScript(const string &script);
+    bool ExecuteScript(const std::string &script);
 
     /** Retrieve the last error message */
-    string getErrorMsg() { return errorMsg; }
+    std::string getErrorMsg() { return errorMsg; }
 
     bool hasError() { return errorScript; }
 

--- a/src/bin/calaos_server/PollListenner.cpp
+++ b/src/bin/calaos_server/PollListenner.cpp
@@ -20,9 +20,9 @@
  ******************************************************************************/
 #include <PollListenner.h>
 
-using namespace Calaos;
+namespace Calaos {
 
-PollObject::PollObject(string _uuid):
+PollObject::PollObject(std::string _uuid):
     uuid(_uuid),
     timeout(NULL)
 {
@@ -80,10 +80,10 @@ PollListenner::~PollListenner()
 {
 }
 
-string PollListenner::Register()
+std::string PollListenner::Register()
 {
     srand(time(NULL));
-    stringstream ssUuid;
+    std::stringstream ssUuid;
     ssUuid << std::hex << std::setfill('0') ;
     ssUuid << std::setw(4) << (rand() & 0xffff) << std::setw(4) << (rand() & 0xffff) << "-";
     ssUuid << std::setw(4) << (rand() & 0xffff) << "-";
@@ -91,7 +91,7 @@ string PollListenner::Register()
     ssUuid << std::setw(4) << (rand() & 0xffff) << "-";
     ssUuid << std::setw(4) << (rand() & 0xffff) << std::setw(4) << (rand() & 0xffff)<< std::setw(4) << (rand() & 0xffff);
 
-    string uuid = ssUuid.str();
+    std::string uuid = ssUuid.str();
     pollobjects[uuid] = new PollObject(uuid);
 
     cDebugDom("poll_listener") << "uuid:" << uuid;
@@ -99,7 +99,7 @@ string PollListenner::Register()
     return uuid;
 }
 
-bool PollListenner::Unregister(string uuid)
+bool PollListenner::Unregister(std::string uuid)
 {
     if (pollobjects.find(uuid) == pollobjects.end())
     {
@@ -122,7 +122,7 @@ bool PollListenner::Unregister(string uuid)
     return true;
 }
 
-bool PollListenner::GetEvents(string uuid, list<CalaosEvent> &events)
+bool PollListenner::GetEvents(std::string uuid, std::list<CalaosEvent> &events)
 {
     if (pollobjects.find(uuid) == pollobjects.end())
     {
@@ -137,4 +137,6 @@ bool PollListenner::GetEvents(string uuid, list<CalaosEvent> &events)
     o->ResetTimer();
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/PollListenner.h
+++ b/src/bin/calaos_server/PollListenner.h
@@ -33,9 +33,9 @@ namespace Calaos
 class PollObject
 {
 private:
-    sigc::signal<void, string, string, void*, void*> sig_events;
+    sigc::signal<void, std::string, std::string, void*, void*> sig_events;
 
-    string uuid;
+    std::string uuid;
     EcoreTimer *timeout; //timer that invalidates uuid after some time of inactivity
 
     //callback to handle all events from the system
@@ -44,16 +44,16 @@ private:
     //Timeout callback
     void Timeout_cb();
 
-    list<CalaosEvent> events;
+    std::list<CalaosEvent> events;
 
     sigc::connection evcon;
 
 public:
-    PollObject(string uuid);
+    PollObject(std::string uuid);
     ~PollObject();
 
-    list<CalaosEvent> &getEvents() { return events; }
-    string getUUID() { return uuid; }
+    std::list<CalaosEvent> &getEvents() { return events; }
+    std::string getUUID() { return uuid; }
     void ResetTimer() { timeout->Reset(); }
     void clearEvents() { events.clear(); }
 };
@@ -61,7 +61,7 @@ public:
 class PollListenner
 {
 private:
-    map<string, PollObject *> pollobjects;
+    std::map<std::string, PollObject *> pollobjects;
 
     PollListenner();
 
@@ -78,13 +78,13 @@ public:
     // Get an uuid.
     // The uuid will be automatically unregistered after some time
     // and become invalid
-    string Register();
+    std::string Register();
 
     // Unregister the uuid, return false if error
-    bool Unregister(string uuid);
+    bool Unregister(std::string uuid);
 
     // Get events for the registered uuid, return false if error
-    bool GetEvents(string uuid, list<CalaosEvent> &events);
+    bool GetEvents(std::string uuid, std::list<CalaosEvent> &events);
 };
 
 }

--- a/src/bin/calaos_server/Room.cpp
+++ b/src/bin/calaos_server/Room.cpp
@@ -23,9 +23,9 @@
 #include "ListeRoom.h"
 #include "AVReceiver.h"
 
-using namespace Calaos;
+namespace Calaos {
 
-Room::Room(string _name, string _type, int _hits):
+Room::Room(std::string _name, std::string _type, int _hits):
     name(_name),
     type(_type),
     hits(_hits)
@@ -57,7 +57,7 @@ void Room::RemoveIO(int pos, bool del)
                            { "room_name", get_name() },
                            { "room_type", get_type() } });
 
-    vector<IOBase *>::iterator iter = ios.begin();
+    std::vector<IOBase *>::iterator iter = ios.begin();
     for (int i = 0;i < pos;iter++, i++) ;
     if (del) delete ios[pos];
     ios.erase(iter);
@@ -67,7 +67,7 @@ void Room::RemoveIO(int pos, bool del)
 
 void Room::RemoveIOFromRoom(IOBase *io)
 {
-    vector<IOBase *>::iterator it = find(ios.begin(), ios.end(), io);
+    std::vector<IOBase *>::iterator it = find(ios.begin(), ios.end(), io);
     if (it != ios.end())
     {
         ios.erase(it);
@@ -146,4 +146,6 @@ bool Room::SaveToXml(TiXmlElement *node)
     }
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/Room.h
+++ b/src/bin/calaos_server/Room.h
@@ -25,7 +25,6 @@
 #include "IOBase.h"
 #include <type_traits>
 
-using namespace std;
 
 namespace Calaos
 {
@@ -33,21 +32,21 @@ namespace Calaos
 class Room
 {
 protected:
-    string name;
-    string type;
+    std::string name;
+    std::string type;
     int hits;
 
-    vector<IOBase *> ios;
+    std::vector<IOBase *> ios;
 
 public:
-    Room(string _name, string _type, int _hits = 0);
+    Room(std::string _name, std::string _type, int _hits = 0);
     ~Room();
 
-    string &get_name() { return name; }
-    string &get_type() { return type; }
+    std::string &get_name() { return name; }
+    std::string &get_type() { return type; }
 
-    void set_name(string &s);
-    void set_type(string &s);
+    void set_name(std::string &s);
+    void set_type(std::string &s);
 
     int get_hits() { return hits; }
 

--- a/src/bin/calaos_server/Rule.cpp
+++ b/src/bin/calaos_server/Rule.cpp
@@ -21,9 +21,9 @@
 #include "Rule.h"
 #include "Rules/RulesFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
-Rule::Rule(string type, string name):
+Rule::Rule(std::string type, std::string name):
     auto_sc_mark(false)
 {
     params.Add("type", type);
@@ -92,7 +92,7 @@ void Rule::CheckConditionsAsync(std::function<void (bool check)> cb)
     //if one is failing, stops immediatly.
     //then we can start all scripts in parallel
 
-    list<ConditionScript *> cond_scripts;
+    std::list<ConditionScript *> cond_scripts;
 
     for (Condition *condition: conds)
     {
@@ -162,7 +162,7 @@ bool Rule::ExecuteActions()
 
 void Rule::RemoveCondition(int pos)
 {
-    vector<Condition *>::iterator iter = conds.begin();
+    std::vector<Condition *>::iterator iter = conds.begin();
     for (int i = 0;i < pos;iter++, i++) ;
     conds.erase(iter);
 
@@ -171,7 +171,7 @@ void Rule::RemoveCondition(int pos)
 
 void Rule::RemoveAction(int pos)
 {
-    vector<Action *>::iterator iter = actions.begin();
+    std::vector<Action *>::iterator iter = actions.begin();
     for (int i = 0;i < pos;iter++, i++) ;
     actions.erase(iter);
 
@@ -184,7 +184,7 @@ bool Rule::LoadFromXml(TiXmlElement *node)
 
     for (; attr; attr = attr->Next())
     {
-        if (string(attr->Name()) != "name" && string(attr->Name()) != "type")
+        if (std::string(attr->Name()) != "name" && std::string(attr->Name()) != "type")
             params.Add(attr->Name(), attr->ValueStr());
     }
 
@@ -215,7 +215,7 @@ bool Rule::SaveToXml(TiXmlElement *node)
 
     for (int i = 0;i < params.size();i++)
     {
-        string key, value;
+        std::string key, value;
         params.get_item(i, key, value);
         rule_node->SetAttribute(key, value);
     }
@@ -235,4 +235,6 @@ bool Rule::SaveToXml(TiXmlElement *node)
     }
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/Rule.h
+++ b/src/bin/calaos_server/Rule.h
@@ -26,7 +26,6 @@
 #include "Action.h"
 #include "EcoreTimer.h"
 
-using namespace std;
 
 namespace Calaos
 {
@@ -34,15 +33,15 @@ namespace Calaos
 class Rule
 {
 protected:
-    vector<Condition *> conds;
-    vector<Action *> actions;
+    std::vector<Condition *> conds;
+    std::vector<Action *> actions;
 
     Params params;
 
     bool auto_sc_mark; //true if rule is used by an auto_scenario
 
 public:
-    Rule(string _type, string _name);
+    Rule(std::string _type, std::string _name);
     virtual ~Rule();
 
     void AddCondition(Condition *p);
@@ -60,11 +59,11 @@ public:
     int get_size_conds() { return conds.size(); }
     int get_size_actions() { return actions.size(); }
 
-    string get_type() { return params["type"]; }
-    string get_name() { return params["name"]; }
-    string get_param(string p) { return params[p]; }
-    void set_param(string p, string v) { params.Add(p, v); }
-    bool param_exists(string p) { return params.Exists(p); }
+    std::string get_type() { return params["type"]; }
+    std::string get_name() { return params["name"]; }
+    std::string get_param(std::string p) { return params[p]; }
+    void set_param(std::string p, std::string v) { params.Add(p, v); }
+    bool param_exists(std::string p) { return params.Exists(p); }
 
     bool isAutoScenario() { return auto_sc_mark; }
     void setAutoScenario(bool m) { auto_sc_mark = m; }

--- a/src/bin/calaos_server/Rules/Action.cpp
+++ b/src/bin/calaos_server/Rules/Action.cpp
@@ -20,8 +20,8 @@
  ******************************************************************************/
 #include "Action.h"
 
-using namespace Calaos;
 
+namespace Calaos {
 Action::Action(int type): action_type(type)
 {
     cDebugDom("rule.action") <<  "New action";
@@ -37,4 +37,6 @@ bool Action::Execute()
     cErrorDom("rule.action") <<  "Can't execute base Action class !";
 
     return false;
+}
+
 }

--- a/src/bin/calaos_server/Rules/Action.h
+++ b/src/bin/calaos_server/Rules/Action.h
@@ -23,7 +23,6 @@
 
 #include "Calaos.h"
 
-using namespace std;
 
 namespace Calaos
 {

--- a/src/bin/calaos_server/Rules/ActionMail.cpp
+++ b/src/bin/calaos_server/Rules/ActionMail.cpp
@@ -24,8 +24,8 @@
 #include "FileDownloader.h"
 #include "Prefix.h"
 
-using namespace Calaos;
 
+namespace Calaos {
 ActionMail::ActionMail():
     Action(ACTION_MAIL)
 {
@@ -50,7 +50,7 @@ bool ActionMail::Execute()
                                       << camera->get_param("name")
                                       << ") attachment";
 
-        string tmpFile;
+        std::string tmpFile;
         int cpt = 0;
 
         //Get a temporary filename
@@ -65,11 +65,11 @@ bool ActionMail::Execute()
         // Autodestroy file downloader
         cDebug() << "DL URL: " << camera->getPictureUrl();
         FileDownloader* downloader = new FileDownloader(camera->getPictureUrl(), tmpFile, true);
-        downloader->addCallback([=](string signal, void *sender_data)
+        downloader->addCallback([=](std::string signal, void *sender_data)
         {
             if (signal == "done")
             {
-                mail_attachment_tfile = *(reinterpret_cast<string *>(sender_data));
+                mail_attachment_tfile = *(reinterpret_cast<std::string *>(sender_data));
                 sendMail();
             }
             else if (signal == "failed" || signal == "aborted")
@@ -92,7 +92,7 @@ bool ActionMail::Execute()
 
 void ActionMail::sendMail()
 {
-    string tmpFile;
+    std::string tmpFile;
     int cpt = 0;
     //Get a temporary filename
     do
@@ -109,7 +109,7 @@ void ActionMail::sendMail()
     ofs << mail_message;
     ofs.close();
 
-    stringstream cmd;
+    std::stringstream cmd;
 
     cmd << Prefix::Instance().binDirectoryGet();
     cmd << "/calaos_mail";
@@ -176,4 +176,6 @@ bool ActionMail::SaveToXml(TiXmlElement *node)
     mail_node->LinkEndChild(txt_node);
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/Rules/ActionMail.h
+++ b/src/bin/calaos_server/Rules/ActionMail.h
@@ -30,12 +30,12 @@ namespace Calaos
 class ActionMail: public Action
 {
 private:
-    string mail_sender;
-    string mail_recipients;
-    string mail_subject;
-    string mail_attachment;
-    string mail_message;
-    string mail_attachment_tfile;
+    std::string mail_sender;
+    std::string mail_recipients;
+    std::string mail_subject;
+    std::string mail_attachment;
+    std::string mail_message;
+    std::string mail_attachment_tfile;
 
     void sendMail();
 

--- a/src/bin/calaos_server/Rules/ActionScript.cpp
+++ b/src/bin/calaos_server/Rules/ActionScript.cpp
@@ -20,8 +20,8 @@
  ******************************************************************************/
 #include "ActionScript.h"
 
-using namespace Calaos;
 
+namespace Calaos {
 ActionScript::ActionScript(): Action(ACTION_SCRIPT)
 {
     cDebugDom("rule.action.script") <<  "New Script action";
@@ -47,7 +47,7 @@ bool ActionScript::LoadFromXml(TiXmlElement *pnode)
     TiXmlElement *sc_node = pnode->FirstChildElement("calaos:script");
     if (!sc_node) return false;
 
-    string type = "";
+    std::string type = "";
     if (sc_node->Attribute("type"))
         type = sc_node->Attribute("type");
     if (type == "lua")
@@ -76,4 +76,6 @@ bool ActionScript::SaveToXml(TiXmlElement *node)
     sc_node->LinkEndChild(txt_node);
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/Rules/ActionScript.h
+++ b/src/bin/calaos_server/Rules/ActionScript.h
@@ -31,7 +31,7 @@ namespace Calaos
 class ActionScript: public Action
 {
 private:
-    string script;
+    std::string script;
 
 public:
     ActionScript();

--- a/src/bin/calaos_server/Rules/ActionStd.cpp
+++ b/src/bin/calaos_server/Rules/ActionStd.cpp
@@ -24,8 +24,8 @@
 #include "WODigital.h"
 #include "ActionTouchscreen.h"
 
-using namespace Calaos;
 
+namespace Calaos {
 ActionStd::~ActionStd()
 {
     cDebugDom("rule.action.standard");
@@ -177,7 +177,7 @@ bool ActionStd::LoadFromXml(TiXmlElement *node)
     {
         if (node->ValueStr() == "calaos:output")
         {
-            string id = "", val = "", val_var = "";
+            std::string id = "", val = "", val_var = "";
 
             if (node->Attribute("id")) id = node->Attribute("id");
             if (node->Attribute("val")) val = node->Attribute("val");
@@ -196,7 +196,7 @@ bool ActionStd::LoadFromXml(TiXmlElement *node)
             if (!out)
             {
                 //for compatibility with old AudioPlayer and Camera, update ids if needed
-                list<IOBase *> l = ListeRoom::Instance().getAudioList();
+                std::list<IOBase *> l = ListeRoom::Instance().getAudioList();
                 for (IOBase *io: l)
                 {
                     if (io->get_param("iid") == id ||
@@ -251,4 +251,6 @@ bool ActionStd::SaveToXml(TiXmlElement *node)
     }
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/Rules/ActionTouchscreen.cpp
+++ b/src/bin/calaos_server/Rules/ActionTouchscreen.cpp
@@ -20,8 +20,8 @@
  ******************************************************************************/
 #include "ActionTouchscreen.h"
 
-using namespace Calaos;
 
+namespace Calaos {
 ActionTouchscreen::ActionTouchscreen():
     Action(ACTION_TOUCHSCREEN),
     econ(NULL)
@@ -31,7 +31,7 @@ ActionTouchscreen::ActionTouchscreen():
     cDebugDom("rule.action.touchscreen") <<  "New Touchscreen action";
 }
 
-ActionTouchscreen::ActionTouchscreen(string _action): Action(ACTION_TOUCHSCREEN), action(_action)
+ActionTouchscreen::ActionTouchscreen(std::string _action): Action(ACTION_TOUCHSCREEN), action(_action)
 {
     econ = ecore_con_server_connect(ECORE_CON_REMOTE_BROADCAST, "255.255.255.255", BCAST_UDP_PORT, NULL);
 
@@ -79,4 +79,6 @@ bool ActionTouchscreen::SaveToXml(TiXmlElement *node)
     node->LinkEndChild(action_node);
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/Rules/ActionTouchscreen.h
+++ b/src/bin/calaos_server/Rules/ActionTouchscreen.h
@@ -31,13 +31,13 @@ namespace Calaos
 class ActionTouchscreen: public Action
 {
 private:
-    string action;
+    std::string action;
 
     Ecore_Con_Server *econ;
 
 public:
     ActionTouchscreen();
-    ActionTouchscreen(string action);
+    ActionTouchscreen(std::string action);
     ~ActionTouchscreen();
 
     bool Execute();

--- a/src/bin/calaos_server/Rules/Condition.cpp
+++ b/src/bin/calaos_server/Rules/Condition.cpp
@@ -20,8 +20,8 @@
  ******************************************************************************/
 #include "Condition.h"
 
-using namespace Calaos;
 
+namespace Calaos {
 Condition::Condition(int type): condition_type(type)
 {
     cDebugDom("rule.condition") <<  "New condition";
@@ -38,4 +38,6 @@ bool Condition::Evaluate()
     cErrorDom("rule.condition") <<  "Can't evaluate base Condition class !";
 
     return false;
+}
+
 }

--- a/src/bin/calaos_server/Rules/Condition.h
+++ b/src/bin/calaos_server/Rules/Condition.h
@@ -23,7 +23,6 @@
 
 #include "Calaos.h"
 
-using namespace std;
 
 namespace Calaos
 {

--- a/src/bin/calaos_server/Rules/ConditionOutput.cpp
+++ b/src/bin/calaos_server/Rules/ConditionOutput.cpp
@@ -21,8 +21,8 @@
 #include "ConditionOutput.h"
 #include "ListeRoom.h"
 
-using namespace Calaos;
 
+namespace Calaos {
 ConditionOutput::ConditionOutput():
     Condition(COND_OUTPUT)
 {
@@ -36,7 +36,7 @@ ConditionOutput::~ConditionOutput()
 
 bool ConditionOutput::Evaluate()
 {
-    string sval, oper;
+    std::string sval, oper;
     bool bval;
     double dval;
     bool ret = false;
@@ -262,7 +262,7 @@ bool ConditionOutput::eval(std::string val1, std::string oper, std::string val2)
     return false;
 }
 
-bool ConditionOutput::eval(IOBase *out, string oper, string val)
+bool ConditionOutput::eval(IOBase *out, std::string oper, std::string val)
 {
     if (oper != "!=" && oper != "==")
     {
@@ -277,9 +277,9 @@ bool ConditionOutput::LoadFromXml(TiXmlElement *node)
 {
     if (node->Attribute("trigger"))
     {
-        if (node->Attribute("trigger") == string("true"))
+        if (node->Attribute("trigger") == std::string("true"))
             trigger = true;
-        else if (node->Attribute("trigger") == string("false"))
+        else if (node->Attribute("trigger") == std::string("false"))
             trigger = false;
     }
 
@@ -291,7 +291,7 @@ bool ConditionOutput::LoadFromXml(TiXmlElement *node)
     {
         if (node->ValueStr() == "calaos:output")
         {
-            string id = "", oper = "", val = "", val_var = "";
+            std::string id = "", oper = "", val = "", val_var = "";
 
             if (node->Attribute("id")) id = node->Attribute("id");
             if (node->Attribute("oper")) oper = node->Attribute("oper");
@@ -334,4 +334,6 @@ bool ConditionOutput::SaveToXml(TiXmlElement *node)
     cond_node->LinkEndChild(cnode);
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/Rules/ConditionOutput.h
+++ b/src/bin/calaos_server/Rules/ConditionOutput.h
@@ -32,11 +32,11 @@ class ConditionOutput: public Condition
 {
 protected:
     IOBase *output;
-    string params;
-    string ops;
+    std::string params;
+    std::string ops;
     //this is used to do the condition test
     //based on another output
-    string params_var;
+    std::string params_var;
 
     bool trigger = true;
 
@@ -56,12 +56,12 @@ public:
 
     bool useForTrigger() { return trigger; }
 
-    string get_params() { return params; }
-    string get_operator() { return ops; }
-    string get_params_var() { return params_var; }
-    void set_param(string p) { params = p; }
-    void set_operator(string p) { ops = p; }
-    void set_param_var(string p) { params_var = p; }
+    std::string get_params() { return params; }
+    std::string get_operator() { return ops; }
+    std::string get_params_var() { return params_var; }
+    void set_param(std::string p) { params = p; }
+    void set_operator(std::string p) { ops = p; }
+    void set_param_var(std::string p) { params_var = p; }
 
     bool LoadFromXml(TiXmlElement *node);
     bool SaveToXml(TiXmlElement *node);

--- a/src/bin/calaos_server/Rules/ConditionScript.cpp
+++ b/src/bin/calaos_server/Rules/ConditionScript.cpp
@@ -21,7 +21,7 @@
 #include "ConditionScript.h"
 #include "ListeRoom.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 ConditionScript::ConditionScript():
     Condition(COND_SCRIPT)
@@ -64,7 +64,7 @@ bool ConditionScript::LoadFromXml(TiXmlElement *node)
     {
         if (sc_node->ValueStr() == "calaos:script")
         {
-            string type = "";
+            std::string type = "";
             if (sc_node->Attribute("type"))
                 type = sc_node->Attribute("type");
             if (type == "lua")
@@ -78,7 +78,7 @@ bool ConditionScript::LoadFromXml(TiXmlElement *node)
         else if (sc_node->ValueStr() == "calaos:input" &&
                  sc_node->Attribute("id"))
         {
-            string id = sc_node->Attribute("id");
+            std::string id = sc_node->Attribute("id");
             IOBase *in = ListeRoom::Instance().get_io(id);
             if (in)
                 in_event[in] = in;
@@ -111,4 +111,6 @@ bool ConditionScript::SaveToXml(TiXmlElement *node)
     sc_node->LinkEndChild(txt_node);
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/Rules/ConditionScript.h
+++ b/src/bin/calaos_server/Rules/ConditionScript.h
@@ -26,7 +26,6 @@
 #include "ScriptExec.h"
 #include "IOBase.h"
 
-using namespace std;
 
 namespace Calaos
 {
@@ -34,11 +33,11 @@ namespace Calaos
 class ConditionScript: public Condition
 {
 private:
-    string script;
+    std::string script;
 
     //These are declared inputs that will trigger the rule execution
     //Most generaly, inputs are those used in the script
-    unordered_map<IOBase *, IOBase *> in_event;
+    std::unordered_map<IOBase *, IOBase *> in_event;
 
 public:
     ConditionScript();

--- a/src/bin/calaos_server/Rules/ConditionStart.cpp
+++ b/src/bin/calaos_server/Rules/ConditionStart.cpp
@@ -20,7 +20,7 @@
  ******************************************************************************/
 #include "ConditionStart.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 ConditionStart::ConditionStart():
     Condition(COND_START),
@@ -63,4 +63,6 @@ bool ConditionStart::SaveToXml(TiXmlElement *node)
     node->LinkEndChild(cond_node);
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/Rules/ConditionStart.h
+++ b/src/bin/calaos_server/Rules/ConditionStart.h
@@ -24,7 +24,6 @@
 #include "Calaos.h"
 #include "Condition.h"
 
-using namespace std;
 
 namespace Calaos
 {

--- a/src/bin/calaos_server/Rules/ConditionStd.cpp
+++ b/src/bin/calaos_server/Rules/ConditionStd.cpp
@@ -21,7 +21,7 @@
 #include "ConditionStd.h"
 #include "ListeRoom.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 ConditionStd::ConditionStd():
     Condition(COND_STD)
@@ -41,7 +41,7 @@ void ConditionStd::Add(IOBase *in)
     cDebugDom("rule.condition.standard") <<  "Input(" << in->get_param("id") << ") added";
 }
 
-void ConditionStd::getVarIds(vector<IOBase *> &list)
+void ConditionStd::getVarIds(std::vector<IOBase *> &list)
 {
     for (uint i = 0;i < inputs.size();i++)
     {
@@ -311,9 +311,9 @@ bool ConditionStd::LoadFromXml(TiXmlElement *node)
 {
     if (node->Attribute("trigger"))
     {
-        if (node->Attribute("trigger") == string("true"))
+        if (node->Attribute("trigger") == std::string("true"))
             trigger = true;
-        else if (node->Attribute("trigger") == string("false"))
+        else if (node->Attribute("trigger") == std::string("false"))
             trigger = false;
     }
 
@@ -323,7 +323,7 @@ bool ConditionStd::LoadFromXml(TiXmlElement *node)
     {
         if (node->ValueStr() == "calaos:input")
         {
-            string id = "", oper = "", val = "", val_var = "";
+            std::string id = "", oper = "", val = "", val_var = "";
 
             if (node->Attribute("id")) id = node->Attribute("id");
             if (node->Attribute("oper")) oper = node->Attribute("oper");
@@ -335,7 +335,7 @@ bool ConditionStd::LoadFromXml(TiXmlElement *node)
             if (!in)
             {
                 //for compatibility with old AudioPlayer and Camera, update ids if needed
-                list<IOBase *> l = ListeRoom::Instance().getAudioList();
+                std::list<IOBase *> l = ListeRoom::Instance().getAudioList();
                 for (IOBase *io: l)
                 {
                     if (io->get_param("iid") == id ||
@@ -394,4 +394,6 @@ bool ConditionStd::SaveToXml(TiXmlElement *node)
     }
 
     return true;
+}
+
 }

--- a/src/bin/calaos_server/Rules/ConditionStd.h
+++ b/src/bin/calaos_server/Rules/ConditionStd.h
@@ -53,7 +53,7 @@ public:
     void Remove(int i);
     void Assign(int i, IOBase *obj);
 
-    void getVarIds(vector<IOBase *> &list);
+    void getVarIds(std::vector<IOBase *> &list);
     bool useForTrigger() { return trigger; }
 
     IOBase *get_input(int i) { return inputs[i]; }

--- a/src/bin/calaos_server/Rules/RulesFactory.cpp
+++ b/src/bin/calaos_server/Rules/RulesFactory.cpp
@@ -20,14 +20,14 @@
  ******************************************************************************/
 #include "RulesFactory.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 Condition *RulesFactory::CreateCondition(TiXmlElement *node)
 {
     Condition *condition = NULL;
 
     /* read type */
-    string type = "";
+    std::string type = "";
     if (node->Attribute("type"))
         type = node->Attribute("type");
 
@@ -67,7 +67,7 @@ Action *RulesFactory::CreateAction(TiXmlElement *node)
     Action *action = NULL;
 
     /* read type */
-    string type = "";
+    std::string type = "";
     if (node->Attribute("type"))
         type = node->Attribute("type");
 
@@ -99,4 +99,6 @@ Action *RulesFactory::CreateAction(TiXmlElement *node)
         return NULL;
 
     return action;
+}
+
 }

--- a/src/bin/calaos_server/Scenario/AutoScenario.cpp
+++ b/src/bin/calaos_server/Scenario/AutoScenario.cpp
@@ -19,8 +19,8 @@
  **
  ******************************************************************************/
 #include "AutoScenario.h"
-using namespace Calaos;
 
+namespace Calaos {
 static bool _sortCompStepRule(Rule *r1, Rule* r2)
 {
     int t1, t2;
@@ -140,7 +140,7 @@ void AutoScenario::deleteRules()
     ruleSteps.clear();
 }
 
-IOBase *AutoScenario::createInput(string type, string id)
+IOBase *AutoScenario::createInput(std::string type, std::string id)
 {
     IOBase *in = ListeRoom::Instance().get_io(id);
     if (!in)
@@ -162,7 +162,7 @@ IOBase *AutoScenario::createInput(string type, string id)
     return in;
 }
 
-bool AutoScenario::checkCondition(Rule *rule, IOBase *input, string oper, string value)
+bool AutoScenario::checkCondition(Rule *rule, IOBase *input, std::string oper, std::string value)
 {
     bool ret = false;
     for (int i = 0;i < rule->get_size_conds() && !ret;i++)
@@ -180,7 +180,7 @@ bool AutoScenario::checkCondition(Rule *rule, IOBase *input, string oper, string
     return ret;
 }
 
-bool AutoScenario::checkAction(Rule *rule, IOBase *output, string value)
+bool AutoScenario::checkAction(Rule *rule, IOBase *output, std::string value)
 {
     bool ret = false;
     for (int i = 0;i < rule->get_size_actions() && !ret;i++)
@@ -197,7 +197,7 @@ bool AutoScenario::checkAction(Rule *rule, IOBase *output, string value)
     return ret;
 }
 
-void AutoScenario::addRuleCondition(Rule *rule, IOBase *input, string oper, string value)
+void AutoScenario::addRuleCondition(Rule *rule, IOBase *input, std::string oper, std::string value)
 {
     ConditionStd *cond = new ConditionStd();
     rule->AddCondition(cond);
@@ -207,7 +207,7 @@ void AutoScenario::addRuleCondition(Rule *rule, IOBase *input, string oper, stri
     cond->get_params().Add(input->get_param("id"), value);
 }
 
-void AutoScenario::addRuleAction(Rule *rule, IOBase *output, string value)
+void AutoScenario::addRuleAction(Rule *rule, IOBase *output, std::string value)
 {
     ActionStd *act = new ActionStd();
     rule->AddAction(act);
@@ -216,7 +216,7 @@ void AutoScenario::addRuleAction(Rule *rule, IOBase *output, string value)
     act->get_params().Add(output->get_param("id"), value);
 }
 
-void AutoScenario::setRuleCondition(Rule *rule, IOBase *input, string oper, string value)
+void AutoScenario::setRuleCondition(Rule *rule, IOBase *input, std::string oper, std::string value)
 {
     for (int i = 0;i < rule->get_size_conds();i++)
     {
@@ -231,7 +231,7 @@ void AutoScenario::setRuleCondition(Rule *rule, IOBase *input, string oper, stri
     }
 }
 
-void AutoScenario::setRuleAction(Rule *rule, IOBase *output, string value)
+void AutoScenario::setRuleAction(Rule *rule, IOBase *output, std::string value)
 {
     for (int i = 0;i < rule->get_size_actions();i++)
     {
@@ -245,9 +245,9 @@ void AutoScenario::setRuleAction(Rule *rule, IOBase *output, string value)
     }
 }
 
-string AutoScenario::getRuleConditionValue(Rule *rule, IOBase *input, string oper)
+std::string AutoScenario::getRuleConditionValue(Rule *rule, IOBase *input, std::string oper)
 {
-    string ret;
+    std::string ret;
 
     for (int i = 0;i < rule->get_size_conds();i++)
     {
@@ -265,9 +265,9 @@ string AutoScenario::getRuleConditionValue(Rule *rule, IOBase *input, string ope
     return ret;
 }
 
-string AutoScenario::getRuleActionValue(Rule *rule, IOBase *output)
+std::string AutoScenario::getRuleActionValue(Rule *rule, IOBase *output)
 {
-    string ret;
+    std::string ret;
 
     for (int i = 0;i < rule->get_size_actions();i++)
     {
@@ -336,8 +336,8 @@ void AutoScenario::checkScenarioRules()
 
     /* search needed rules for scenario */
 
-    list<Rule *> srules = ListeRule::Instance().getRuleAutoScenario(scenario_id);
-    list<Rule *>::iterator it = srules.begin();
+    std::list<Rule *> srules = ListeRule::Instance().getRuleAutoScenario(scenario_id);
+    std::list<Rule *>::iterator it = srules.begin();
 
     for (;it != srules.end();it++)
     {
@@ -561,7 +561,7 @@ void AutoScenario::setStepPause(int s, double pause)
     setRuleAction(step, ioTimer, Utils::to_string(pause));
 }
 
-void AutoScenario::addStepAction(int s, IOBase *out, string action)
+void AutoScenario::addStepAction(int s, IOBase *out, std::string action)
 {
     cDebugDom("scenario") << "s == " << s << " ruleSteps.size() == " << ruleSteps.size();
     if ((s >= (int)ruleSteps.size() || s < 0) && s != END_STEP) return;
@@ -670,7 +670,7 @@ static bool _sortDesc (SCCategory i, SCCategory j)
     return (i.count > j.count);
 }
 
-string AutoScenario::getCategory()
+std::string AutoScenario::getCategory()
 {
     struct SCCategory catLight = {0, 0};
     struct SCCategory catShutter = {0, 1};
@@ -700,14 +700,14 @@ string AutoScenario::getCategory()
         }
     }
 
-    vector<struct SCCategory> v;
+    std::vector<struct SCCategory> v;
     if (catLight.count) v.push_back(catLight);
     if (catShutter.count) v.push_back(catShutter);
     if (catOther.count) v.push_back(catOther);
 
     sort(v.begin(), v.end(), _sortDesc);
 
-    string cat;
+    std::string cat;
     for (uint i = 0;i < v.size();i++)
     {
         if (v[i].type == 0) cat += "light";
@@ -752,4 +752,6 @@ void AutoScenario::createRuleStepEnd()
         addRuleCondition(ruleStepEnd, ioTimer, "==", "true");
         addRuleAction(ruleStepEnd, ioIsActive, "false");
     }
+}
+
 }

--- a/src/bin/calaos_server/Scenario/AutoScenario.h
+++ b/src/bin/calaos_server/Scenario/AutoScenario.h
@@ -40,13 +40,13 @@ class ScenarioAction
 {
 public:
     IOBase *io;
-    string action;
+    std::string action;
 };
 
 class AutoScenario
 {
 private:
-    string scenario_id;
+    std::string scenario_id;
     bool cycle;
     bool disabled;
 
@@ -62,18 +62,18 @@ private:
 
     Rule *ruleStart, *ruleStop, *ruleStepEnd;
     Rule *rulePlageStart, *rulePlageStop;
-    vector<Rule *> ruleSteps;
+    std::vector<Rule *> ruleSteps;
 
-    IOBase *createInput(string type, string id);
-    bool checkCondition(Rule *rule, IOBase *input, string oper, string value);
-    bool checkAction(Rule *rule, IOBase *output, string value);
-    void addRuleCondition(Rule *rule, IOBase *input, string oper, string value);
-    void addRuleAction(Rule *rule, IOBase *output, string value);
-    void setRuleCondition(Rule *rule, IOBase *input, string oper, string value);
-    void setRuleAction(Rule *rule, IOBase *output, string value);
-    string getRuleConditionValue(Rule *rule, IOBase *input, string oper);
-    string getRuleActionValue(Rule *rule, IOBase *output);
-    list<IOBase *> getRuleRealActions(Rule *rule);
+    IOBase *createInput(std::string type, std::string id);
+    bool checkCondition(Rule *rule, IOBase *input, std::string oper, std::string value);
+    bool checkAction(Rule *rule, IOBase *output, std::string value);
+    void addRuleCondition(Rule *rule, IOBase *input, std::string oper, std::string value);
+    void addRuleAction(Rule *rule, IOBase *output, std::string value);
+    void setRuleCondition(Rule *rule, IOBase *input, std::string oper, std::string value);
+    void setRuleAction(Rule *rule, IOBase *output, std::string value);
+    std::string getRuleConditionValue(Rule *rule, IOBase *input, std::string oper);
+    std::string getRuleActionValue(Rule *rule, IOBase *output);
+    std::list<IOBase *> getRuleRealActions(Rule *rule);
     void createRuleStepEnd();
 
 public:
@@ -86,7 +86,7 @@ public:
     void deleteAll();
     void deleteRules();
 
-    string getScenarioId() { return scenario_id; }
+    std::string getScenarioId() { return scenario_id; }
     bool isCycling() { return cycle; }
     bool isDisabled() { return disabled; }
     bool isScheduled() { return ioTimeRange?true:false; }
@@ -95,7 +95,7 @@ public:
 
     //Try to categorize the scenario, returns either "light", "shutter", "other"
     //it can be mutliple category, like "light-shutter"
-    string getCategory();
+    std::string getCategory();
 
     Scenario *getIOScenario() { return ioScenario; }
     Internal *getIOIsActive() { return ioIsActive; }
@@ -111,11 +111,11 @@ public:
     Rule *getRuleStepEnd() { return ruleStepEnd; }
     Rule *getRulePlageStart() { return rulePlageStart; }
     Rule *getRulePlageStop() { return rulePlageStop; }
-    vector<Rule *> getRuleSteps() { return ruleSteps; }
+    std::vector<Rule *> getRuleSteps() { return ruleSteps; }
 
     void addStep(double pause);
     void setStepPause(int step, double pause);
-    void addStepAction(int step, IOBase *out, string action);
+    void addStepAction(int step, IOBase *out, std::string action);
     double getStepPause(int step);
     int getStepActionCount(int step);
     ScenarioAction getStepAction(int step, int action);

--- a/src/bin/calaos_server/UDPServer.cpp
+++ b/src/bin/calaos_server/UDPServer.cpp
@@ -20,8 +20,8 @@
  ******************************************************************************/
 #include <UDPServer.h>
 
-using namespace Calaos;
 
+namespace Calaos {
 static Eina_Bool _ecore_con_handler_data_get(void *data, int type, Ecore_Con_Event_Client_Data *ev);
 
 UDPServer::UDPServer(int p):
@@ -71,7 +71,7 @@ Eina_Bool _ecore_con_handler_data_get(void *data, int type, Ecore_Con_Event_Clie
 
     if (udpserver)
     {
-        string d((char *)ev->data, ev->size);
+        std::string d((char *)ev->data, ev->size);
 
         udpserver->ProcessRequest(ev->client, d);
     }
@@ -83,20 +83,20 @@ Eina_Bool _ecore_con_handler_data_get(void *data, int type, Ecore_Con_Event_Clie
     return ECORE_CALLBACK_RENEW;
 }
 
-void UDPServer::ProcessRequest(Ecore_Con_Client *client, string request)
+void UDPServer::ProcessRequest(Ecore_Con_Client *client, std::string request)
 {
     if (request == "CALAOS_DISCOVER")
     {
         cDebugDom("network") << "Got a CALAOS_DISCOVER";
 
-        string remote_ip = ecore_con_client_ip_get(client);
+        std::string remote_ip = ecore_con_client_ip_get(client);
 
         cDebugDom("network") << "Remote IP: " << remote_ip;
 
-        string ip = TCPSocket::GetLocalIPFor(remote_ip);
+        std::string ip = TCPSocket::GetLocalIPFor(remote_ip);
         if (ip != "")
         {
-            string packet = "CALAOS_IP ";
+            std::string packet = "CALAOS_IP ";
             packet += ip;
 
 
@@ -173,4 +173,6 @@ void UDPServer::ProcessRequest(Ecore_Con_Client *client, string request)
         //send a signal
         Utils::signal_wago.emit(std::string(ecore_con_client_ip_get(client)), input, val, "knx");
     }
+}
+
 }

--- a/src/bin/calaos_server/UDPServer.h
+++ b/src/bin/calaos_server/UDPServer.h
@@ -26,6 +26,8 @@
 #include <Ecore_Con.h>
 #include <WagoMap.h>
 
+namespace Calaos {
+
 class UDPServer
 {
 protected:
@@ -42,7 +44,9 @@ public:
     ~UDPServer();
 
     /* Internal stuff used by ecore-con */
-    void ProcessRequest(Ecore_Con_Client *client, string request);
+    void ProcessRequest(Ecore_Con_Client *client, std::string request);
 };
+
+}
 
 #endif

--- a/src/bin/calaos_server/WebSocket.h
+++ b/src/bin/calaos_server/WebSocket.h
@@ -27,7 +27,7 @@
 #include "HttpClient.h"
 #include "WebSocketFrame.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 class WebSocket: public HttpClient
 {
@@ -35,18 +35,18 @@ public:
     WebSocket(Ecore_Con_Client *cl);
     virtual ~WebSocket();
 
-    sigc::signal<void, const string &> textMessageReceived;
-    sigc::signal<void, const string &> binaryMessageReceived;
+    sigc::signal<void, const std::string &> textMessageReceived;
+    sigc::signal<void, const std::string &> binaryMessageReceived;
     sigc::signal<void> websocketDisconnected;
 
     /* Called by JsonApiServer whenever data comes in */
-    virtual void ProcessData(string data);
+    virtual void ProcessData(std::string data);
 
-    void sendPing(const string &data);
-    void sendCloseFrame(uint16_t code = WebSocketFrame::CloseCodeNormal, const string &reason = string(), bool forceClose = false);
+    void sendPing(const std::string &data);
+    void sendCloseFrame(uint16_t code = WebSocketFrame::CloseCodeNormal, const std::string &reason = std::string(), bool forceClose = false);
 
-    void sendTextMessage(const string &data);
-    void sendBinaryMessage(const string &data);
+    void sendTextMessage(const std::string &data);
+    void sendBinaryMessage(const std::string &data);
 
 private:
 
@@ -55,10 +55,10 @@ private:
     enum { WSConnecting, WSOpened, WSClosing, WSClosed };
     int status = WSConnecting;
 
-    string recv_buffer;
+    std::string recv_buffer;
 
     WebSocketFrame currentFrame;
-    string currentData;
+    std::string currentData;
     int currentOpcode;
 
     bool isfragmented = false;
@@ -71,14 +71,16 @@ private:
 
     bool checkHandshakeRequest();
     void processHandshake();
-    void processFrame(const string &data);
+    void processFrame(const std::string &data);
     void processControlFrame();
 
     bool checkCloseStatusCode(uint16_t code);
 
-    void sendFrameData(const string &data, bool isbinary);
+    void sendFrameData(const std::string &data, bool isbinary);
 
     EcoreTimer *timerPing = nullptr;
 };
+
+}
 
 #endif

--- a/src/bin/calaos_server/main.cpp
+++ b/src/bin/calaos_server/main.cpp
@@ -34,7 +34,7 @@
 #include "Prefix.h"
 #include "Audio/AVRManager.h"
 
-using namespace Calaos;
+namespace Calaos {
 
 // Globals
 static UDPServer *udpserver = NULL;
@@ -43,20 +43,20 @@ static EcoreTimer *watchdogLoop = NULL;
 
 static void echoVersion(char **argv)
 {
-    cout << "Calaos Version: \n\t" PACKAGE_STRING << endl;
+    std::cout << "Calaos Version: \n\t" PACKAGE_STRING << std::endl;
 }
 
 static void echoUsage(char **argv)
 {
     echoVersion(argv);
-    cout << _("Usage:\n\t") << argv[0] << _(" [options]") << endl;
-    cout << endl << _("\tOptions:\n");
-    cout << _("\t-h, --help\tDisplay this help.\n");
-    cout << _("\t--config <path>\tSet <path> as the directory for config files.\n");
-    cout << _("\t--cache <path>\tSet <path> as the directory for cache files.\n");
-    cout << _("\t--gendoc <path>\tGenerate Io documentation in <path>\n");
-    cout << _("\t-v, --version\tDisplay current version and exit.\n");
-    cout << endl;
+    std::cout << _("Usage:\n\t") << argv[0] << _(" [options]") << std::endl;
+    std::cout << std::endl << _("\tOptions:\n");
+    std::cout << _("\t-h, --help\tDisplay this help.\n");
+    std::cout << _("\t--config <path>\tSet <path> as the directory for config files.\n");
+    std::cout << _("\t--cache <path>\tSet <path> as the directory for cache files.\n");
+    std::cout << _("\t--gendoc <path>\tGenerate Io documentation in <path>\n");
+    std::cout << _("\t-v, --version\tDisplay current version and exit.\n");
+    std::cout << std::endl;
 }
 
 int main (int argc, char **argv)
@@ -67,18 +67,18 @@ int main (int argc, char **argv)
     ecore_init();
     ecore_con_init();
 
-    vector<Params> params;
+    std::vector<Params> params;
     Params p;
     p.Add("test", "valeur");
     params.push_back(p);
 
     for (auto p2 : params)
     {
-        cout << p2.size() << endl;
+        std::cout << p2.size() << std::endl;
     }
 
 
-    cout << "Calaos Server Daemon - http://www.calaos.fr" << endl;
+    std::cout << "Calaos Server Daemon - http://www.calaos.fr" << std::endl;
 
     Prefix::Instance(argc, argv);
 
@@ -135,7 +135,7 @@ int main (int argc, char **argv)
 
     //Start Json API server
     unsigned short port = JSONAPI_PORT;
-    string tmp =  Utils::get_config_option("port_api");
+    std::string tmp =  Utils::get_config_option("port_api");
     if (!tmp.empty())
         from_string(tmp, port);
     HttpServer::Instance(port);
@@ -186,4 +186,11 @@ int main (int argc, char **argv)
     Utils::FreeEinaLogs();
 
     return 0;
+}
+
+}
+
+int main (int argc, char **argv)
+{
+  return Calaos::main(argc, argv);
 }

--- a/src/bin/tools/calaos_config.cpp
+++ b/src/bin/tools/calaos_config.cpp
@@ -28,14 +28,14 @@
 
 void print_usage(void)
 {
-    cout << "Calaos Configuration Utility." << endl;
-    cout << "(c)2013 Calaos Team" << endl << endl;
-    cout << "Usage:\tcalaos_config <action> [params]" << endl << endl;
-    cout << "Where action can be:" << endl;
-    cout << "\tlist\t\tLists all keys:values" << endl;
-    cout << "\tset [key]\tSet the value for the specified key" << endl;
-    cout << "\tget [key]\tPrint the value for the specified key" << endl;
-    cout << "\tdel [key]\tDelete entry for the specified key" << endl;
+    std::cout << "Calaos Configuration Utility." << std::endl;
+    std::cout << "(c)2013 Calaos Team" << std::endl << std::endl;
+    std::cout << "Usage:\tcalaos_config <action> [params]" << std::endl << std::endl;
+    std::cout << "Where action can be:" << std::endl;
+    std::cout << "\tlist\t\tLists all keys:values" << std::endl;
+    std::cout << "\tset [key]\tSet the value for the specified key" << std::endl;
+    std::cout << "\tget [key]\tPrint the value for the specified key" << std::endl;
+    std::cout << "\tdel [key]\tDelete entry for the specified key" << std::endl;
 }
 
 int main (int argc, char **argv)
@@ -45,7 +45,7 @@ int main (int argc, char **argv)
         print_usage();
         return 1;
     }
-    string action = argv[1];
+    std::string action = argv[1];
 
     Utils::InitEinaLog("config");
 
@@ -53,12 +53,12 @@ int main (int argc, char **argv)
 
     if (action == "get")
     {
-        string key = argv[2];
+        std::string key = argv[2];
 
         if (key == "hwid")
-            cout << Utils::getHardwareID();
+            std::cout << Utils::getHardwareID();
         else
-            cout << Utils::get_config_option(key);
+            std::cout << Utils::get_config_option(key);
     }
     else if (action == "set")
     {
@@ -67,8 +67,8 @@ int main (int argc, char **argv)
             print_usage();
             return 1;
         }
-        string key = argv[2];
-        string value = argv[3];
+        std::string key = argv[2];
+        std::string value = argv[3];
 
         if (key == "hwid")
             cError() <<  "Can't change hwid";
@@ -79,12 +79,12 @@ int main (int argc, char **argv)
     {
         Params options;
         Utils::get_config_options(options);
-        cout << "Local configuration:" << endl;
+        std::cout << "Local configuration:" << std::endl;
         for (int i = 0;i < options.size();i++)
         {
             std::string key, value;
             options.get_item(i, key, value);
-            cout << key << ": " << value << endl;
+            std::cout << key << ": " << value << std::endl;
         }
     }
     else if (action == "del")

--- a/src/bin/tools/calaos_mail.cpp
+++ b/src/bin/tools/calaos_mail.cpp
@@ -24,16 +24,15 @@
 #include "libquickmail/quickmail.h"
 #include "uri_parser/hef_uri_syntax.h"
 
-using namespace Utils;
 
 void print_usage(void)
 {
-    cout << "Calaos Mail Utility." << endl;
-    cout << "(c)2014 Calaos Team" << endl << endl;
-    cout << "Usage:\tcalaos_mail --from <from address> --to <to address> --subject <subject> --body <body file> --attach <file to attach>" << endl << endl;
-    cout << "\t--attach\t\tAttach a file. Can be repeated to attach multiple files" << endl;
-    cout << "\t--delete\t\tDelete files passed in parameters (not done by default)" << endl;
-    cout << "\t--verbose\t\tVerbose mode to debug smtp transaction" << endl << endl;
+    std::cout << "Calaos Mail Utility." << std::endl;
+    std::cout << "(c)2014 Calaos Team" << std::endl << std::endl;
+    std::cout << "Usage:\tcalaos_mail --from <from address> --to <to address> --subject <subject> --body <body file> --attach <file to attach>" << std::endl << std::endl;
+    std::cout << "\t--attach\t\tAttach a file. Can be repeated to attach multiple files" << std::endl;
+    std::cout << "\t--delete\t\tDelete files passed in parameters (not done by default)" << std::endl;
+    std::cout << "\t--verbose\t\tVerbose mode to debug smtp transaction" << std::endl << std::endl;
 }
 
 #define EXIT_USAGE \
@@ -43,37 +42,37 @@ int main (int argc, char **argv)
 {
     if (argc < 2) EXIT_USAGE;
 
-    string confTo, confFrom, confSubject, confBody;
-    list<string> confAttach;
+    std::string confTo, confFrom, confSubject, confBody;
+    std::list<std::string> confAttach;
     bool verbose = false, del = false;
 
     Utils::InitEinaLog("mail");
 
-    char *argconf = argvOptionParam(argv, argv + argc, "--from");
+    char *argconf = Utils::argvOptionParam(argv, argv + argc, "--from");
     if (!argconf) EXIT_USAGE;
     confFrom = argconf;
 
-    argconf = argvOptionParam(argv, argv + argc, "--to");
+    argconf = Utils::argvOptionParam(argv, argv + argc, "--to");
     if (!argconf) EXIT_USAGE;
     confTo = argconf;
 
-    argconf = argvOptionParam(argv, argv + argc, "--subject");
+    argconf = Utils::argvOptionParam(argv, argv + argc, "--subject");
     if (!argconf) EXIT_USAGE;
     confSubject = argconf;
 
-    argconf = argvOptionParam(argv, argv + argc, "--body");
+    argconf = Utils::argvOptionParam(argv, argv + argc, "--body");
     if (!argconf) EXIT_USAGE;
     confBody = argconf;
 
     for (int i = 1;i < argc;i++)
     {
-        if (string(argv[i]) == "--attach" && i + 1 < argc)
+        if (std::string(argv[i]) == "--attach" && i + 1 < argc)
             confAttach.push_back(argv[++i]);
     }
 
-    if (argvOptionCheck(argv, argv + argc, "--verbose"))
+    if (Utils::argvOptionCheck(argv, argv + argc, "--verbose"))
         verbose = true;
-    if (argvOptionCheck(argv, argv + argc, "--delete"))
+    if (Utils::argvOptionCheck(argv, argv + argc, "--delete"))
         del = true;
 
     Utils::initConfigOptions(nullptr, nullptr, true);
@@ -82,9 +81,9 @@ int main (int argc, char **argv)
 
     quickmail mailobj = quickmail_create(confFrom.c_str(), confSubject.c_str());
     quickmail_add_to(mailobj, confTo.c_str());
-    quickmail_set_body(mailobj, getFileContent(confBody.c_str()).c_str());
+    quickmail_set_body(mailobj, Utils::getFileContent(confBody.c_str()).c_str());
 
-    for (string attach : confAttach)
+    for (std::string attach : confAttach)
     {
         quickmail_add_attachment_file(mailobj, attach.c_str(), "image/jpeg");
     }
@@ -93,10 +92,10 @@ int main (int argc, char **argv)
     if (verbose)
         quickmail_set_debug_log(mailobj, stderr);
 
-    string smtp_host = Utils::get_config_option("smtp_server");
+    std::string smtp_host = Utils::get_config_option("smtp_server");
 
-    if (strStartsWith(smtp_host, "smtp://") ||
-        strStartsWith(smtp_host, "smtps://"))
+    if (Utils::strStartsWith(smtp_host, "smtp://") ||
+        Utils::strStartsWith(smtp_host, "smtps://"))
     {
         //To be backward compatible with old config where we had full uri
         hef::HfURISyntax uri(smtp_host);
@@ -116,7 +115,7 @@ int main (int argc, char **argv)
                                 Utils::get_config_option("smtp_tls") == "true"?1:0);
 
     if (errmsg)
-        cout << "Error sending e-mail: " << errmsg << endl;
+        std::cout << "Error sending e-mail: " << errmsg << std::endl;
 
     quickmail_destroy(mailobj);
 
@@ -124,7 +123,7 @@ int main (int argc, char **argv)
     if (del)
     {
         ecore_file_unlink(confBody.c_str());
-        for (string attach : confAttach)
+        for (std::string attach : confAttach)
             ecore_file_unlink(attach.c_str());
     }
 

--- a/src/bin/tools/main_cover.cpp
+++ b/src/bin/tools/main_cover.cpp
@@ -29,7 +29,6 @@
 #include <Ecore_File.h>
 #include <curl/curl.h>
 
-using namespace std;
 
 //Usefull utility functions
 template<typename T>
@@ -62,7 +61,7 @@ typedef struct _ThumbSize
 
 struct CurlFile
 {
-    string filename;
+    std::string filename;
     FILE *stream;
 };
 
@@ -80,42 +79,42 @@ static size_t thumb_fwrite(void *buffer, size_t size, size_t nmemb, void *stream
 
 static int thumb_progress(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow)
 {
-    cout << "." << flush;
+    std::cout << "." << std::flush;
 
     return 0;
 }
 
-static void split(const string &str, vector<string> &tokens, const string &delimiters = " ", int max = 0);
-static bool CreateThumb_Evas(string &input_file, string &output_file, ThumbSize &thumb_sizes);
+static void split(const std::string &str, std::vector<std::string> &tokens, const std::string &delimiters = " ", int max = 0);
+static bool CreateThumb_Evas(std::string &input_file, std::string &output_file, ThumbSize &thumb_sizes);
 
 int main (int argc, char **argv)
 {
     if (argc < 3)
     {
-        cout << "Calaos thumbnailer" << endl << "\tUsage:" << endl;
-        cout << "\t\t" << argv[0] << " <image_file> <out_file> <size>" << endl << endl;
-        cout << "\tWhere <image_file> is an image file supported by Evas. <image_file> can be an http link and then the file is downloaded first." << endl;
-        cout << "\tAnd <size> is of the form: 123x123" << endl;
-        cout << endl << "Thumb is saved in <out_file> in JPG format." << endl;
-        cout << endl << "If <image_file> is an url the file is first downloaded." << endl;
+        std::cout << "Calaos thumbnailer" << std::endl << "\tUsage:" << std::endl;
+        std::cout << "\t\t" << argv[0] << " <image_file> <out_file> <size>" << std::endl << std::endl;
+        std::cout << "\tWhere <image_file> is an image file supported by Evas. <image_file> can be an http link and then the file is downloaded first." << std::endl;
+        std::cout << "\tAnd <size> is of the form: 123x123" << std::endl;
+        std::cout << std::endl << "Thumb is saved in <out_file> in JPG format." << std::endl;
+        std::cout << std::endl << "If <image_file> is an url the file is first downloaded." << std::endl;
 
         return 1;
     }
 
     //parse cmd line
-    string input_file = argv[1];
-    string output_file = argv[2];
+    std::string input_file = argv[1];
+    std::string output_file = argv[2];
     bool to_del = false;
 
     ThumbSize size = { 0, 0 };
-    vector<string> token;
+    std::vector<std::string> token;
 
-    string s;
+    std::string s;
     if (argc == 4) s = argv[3];
     split(s, token, "x", 2);
     if (token.size() != 2)
     {
-        cout << "calaos_thumb: Can't parse size, using original image size" << endl;
+        std::cout << "calaos_thumb: Can't parse size, using original image size" << std::endl;
     }
     else
     {
@@ -123,13 +122,13 @@ int main (int argc, char **argv)
         from_string(token[1], size.h);
     }
 
-    cout << "calaos_thumb: Using image source: " << input_file << endl;
+    std::cout << "calaos_thumb: Using image source: " << input_file << std::endl;
 
     //Check if it's an url and download it
     if (input_file.compare(0, 7, "http://") == 0 ||
         input_file.compare(0, 8, "https://") == 0)
     {
-        cout << "calaos_thumb: Input image is an URL, starting download: ." << flush;
+        std::cout << "calaos_thumb: Input image is an URL, starting download: ." << std::flush;
 
         CURL *curl;
         CURLcode res;
@@ -161,7 +160,7 @@ int main (int argc, char **argv)
             if(CURLE_OK != res)
             {
                 /* we failed */
-                cout << " Failed: curl told us: " << res << endl;
+                std::cout << " Failed: curl told us: " << res << std::endl;
                 return 1;
             }
 
@@ -172,7 +171,7 @@ int main (int argc, char **argv)
 
             curl_global_cleanup();
 
-            cout << " Done." << endl;
+            std::cout << " Done." << std::endl;
         }
     }
 
@@ -185,11 +184,11 @@ int main (int argc, char **argv)
     if (ret)
         return 0;
 
-    cout << "calaos_thumb: Unable to do thumbnails..." << endl;
+    std::cout << "calaos_thumb: Unable to do thumbnails..." << std::endl;
     return 1;
 }
 
-bool CreateThumb_Evas(string &input_file, string &output_file, ThumbSize &thumb_size)
+bool CreateThumb_Evas(std::string &input_file, std::string &output_file, ThumbSize &thumb_size)
 {
     evas_init();
     ecore_init();
@@ -214,7 +213,7 @@ bool CreateThumb_Evas(string &input_file, string &output_file, ThumbSize &thumb_
     Evas_Load_Error err = evas_object_image_load_error_get(image);
     if (err != EVAS_LOAD_ERROR_NONE)
     {
-        cout << "calaos_thumb: Error, can't load image: " << evas_load_error_str(err) << endl;
+        std::cout << "calaos_thumb: Error, can't load image: " << evas_load_error_str(err) << std::endl;
         return false;
     }
 
@@ -222,7 +221,7 @@ bool CreateThumb_Evas(string &input_file, string &output_file, ThumbSize &thumb_
     {
         //Get size from image
         evas_object_image_size_get(image, &thumb_size.w, &thumb_size.h);
-        cout << "calaos_thumb: Using detected size: " << thumb_size.w << "x" << thumb_size.h << endl;
+        std::cout << "calaos_thumb: Using detected size: " << thumb_size.w << "x" << thumb_size.h << std::endl;
         ecore_evas_resize(ee, thumb_size.w, thumb_size.h);
         evas_object_resize(im, thumb_size.w, thumb_size.h);
         evas_object_image_fill_set(im, 0, 0, thumb_size.w, thumb_size.h);
@@ -237,9 +236,9 @@ bool CreateThumb_Evas(string &input_file, string &output_file, ThumbSize &thumb_
 
     ecore_evas_buffer_pixels_get(ee);
     if (!evas_object_image_save(im, output_file.c_str(), NULL, "quality=85 compress=9"))
-        cout << "calaos_thumb: evas_object_image_save() failed..." << endl;
+        std::cout << "calaos_thumb: evas_object_image_save() failed..." << std::endl;
     else
-        cout << "calaos_thumb: Save image to " << output_file << endl;
+        std::cout << "calaos_thumb: Save image to " << output_file << std::endl;
 
     evas_object_del(image);
     evas_object_del(im);
@@ -251,20 +250,20 @@ bool CreateThumb_Evas(string &input_file, string &output_file, ThumbSize &thumb_
     return true;
 }
 
-void split(const string &str, vector<string> &tokens, const string &delimiters, int max /* = 0 */)
+void split(const std::string &str, std::vector<std::string> &tokens, const std::string &delimiters, int max /* = 0 */)
 {
     // Skip delimiters at beginning.
-    string::size_type lastPos = str.find_first_not_of(delimiters, 0);
+    std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
     // Find first "non-delimiter".
-    string::size_type pos     = str.find_first_of(delimiters, lastPos);
+    std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
 
     int counter = 0;
 
-    while (string::npos != pos || string::npos != lastPos)
+    while (std::string::npos != pos || std::string::npos != lastPos)
     {
         if (counter + 1 >= max && max > 0)
         {
-            tokens.push_back(str.substr(lastPos, string::npos));
+            tokens.push_back(str.substr(lastPos, std::string::npos));
             break;
         }
 

--- a/src/bin/tools/wago_test.cpp
+++ b/src/bin/tools/wago_test.cpp
@@ -25,69 +25,67 @@
 #include <tcpsocket.h>
 #include <Params.h>
 
-using namespace std;
-using namespace Utils;
 
 int main(int argc, char **argv)
 {
     TCPSocket *socket = new TCPSocket();
     socket->Create(UDP);
     char buffer[256];
-    string cmd;
-    string host, action;
+    std::string cmd;
+    std::string host, action;
     int address = 0;
-    string type;
+    std::string type;
     int addr1 = 0, addr2 = 0, sameas = 0;
-    stringstream s;
-    string file, ip, boolean;
+    std::stringstream s;
+    std::string file, ip, boolean;
     int dali_line = 0, dali_group = 0, dali_addr = 0, dali_value = 0, dali_fade = 0, dali_time = 0;
     int dali_faderate = 0, dali_fadetime = 0, dali_maxlevel = 0, dali_minlevel = 0, dali_systemfailurelevel = 0, dali_poweronlevel = 0;
 
     if (argc < 4)
     {
-        cout << "config_wago Usage:" << endl;
-        cout << "\t" << argv[0] << " host <ip address> action <action> [Action options]" << endl;
-        cout << endl;
-        cout << "\tWhere action:" << endl;
-        cout << "\t\tset_outtype: <address> <type> (type=NONE, TELERUPTEUR, DIRECT, VOLET, VOLET_IMPULSE, TELERUPTEUR_DALI, TELERUPTEUR_DALI_GROUP, TELERUPTEUR_KNX_OUTPUT, DIRECT_KNX_OUTPUT)" << endl;
-        cout << "\t\tget_outtype: <address>" << endl;
-        cout << "\t\tset_outaddr: <address> <out1> <out2> <SameAs>" << endl;
-        cout << "\t\tget_outaddr: <address>" << endl;
-        cout << "\t\tget_version" << endl;
-        cout << "\t\tget_info" << endl;
-        cout << "\t\tget_info_module: <module>" << endl;
-        cout << "\t\tget_volet_positions: <var_save>" << endl;
-        cout << "\t\tset_server_ip: <ip>" << endl;
-        cout << "\t\tset_output: <out> <boolean>" << endl;
-        cout << "\t\tset_knx_output: <out> <boolean>" << endl;
-        cout << "\t\theartbeat (send heartbeat to the PLC)" << endl;
-        cout << "\t\tset_dali: <dali_line> <group?> <address> <value> <fade_time>" << endl;
-        cout << "\t\tget_dali: <dali_line> <address>" << endl;
-        cout << "\t\tdali_search_devices: <dali_line>" << endl;
-        cout << "\t\tdali_get_device_info: <dali_line> <address>" << endl;
-        cout << "\t\tdali_get_device_group: <dali_line> <group>" << endl;
-        cout << "\t\tdali_device_add_group: <dali_line> <address> <group>" << endl;
-        cout << "\t\tdali_device_del_group: <dali_line> <address> <group>" << endl;
-        cout << "\t\tdali_central: <dali_line> <boolean> (switch on/off all DALI lamps)" << endl;
-        cout << "\t\tdali_blink: <dali_line> <address> <group?> <blink_time>" << endl;
-        cout << "\t\tdali_blink_stop: <dali_line>" << endl;
-        cout << "\t\tdali_set_device_config: <dali_line> <address> <fade_rate> <fade_time> <max_level> <min_level> <system_failure_level> <power_on_level>" << endl;
-        cout << "\t\tdali_addressing_new: <dali_line> <reset?>" << endl;
-        cout << "\t\tdali_addressing_add: <dali_line>" << endl;
-        cout << "\t\tdali_addressing_status: <dali_line>" << endl;
-        cout << "\t\tdali_addressing_change: <dali_line> <old_address> <new_address>" << endl;
-        cout << "\t\tdali_addressing_del: <dali_line> <address_to_delete>" << endl;
+        std::cout << "config_wago Usage:" << std::endl;
+        std::cout << "\t" << argv[0] << " host <ip address> action <action> [Action options]" << std::endl;
+        std::cout << std::endl;
+        std::cout << "\tWhere action:" << std::endl;
+        std::cout << "\t\tset_outtype: <address> <type> (type=NONE, TELERUPTEUR, DIRECT, VOLET, VOLET_IMPULSE, TELERUPTEUR_DALI, TELERUPTEUR_DALI_GROUP, TELERUPTEUR_KNX_OUTPUT, DIRECT_KNX_OUTPUT)" << std::endl;
+        std::cout << "\t\tget_outtype: <address>" << std::endl;
+        std::cout << "\t\tset_outaddr: <address> <out1> <out2> <SameAs>" << std::endl;
+        std::cout << "\t\tget_outaddr: <address>" << std::endl;
+        std::cout << "\t\tget_version" << std::endl;
+        std::cout << "\t\tget_info" << std::endl;
+        std::cout << "\t\tget_info_module: <module>" << std::endl;
+        std::cout << "\t\tget_volet_positions: <var_save>" << std::endl;
+        std::cout << "\t\tset_server_ip: <ip>" << std::endl;
+        std::cout << "\t\tset_output: <out> <boolean>" << std::endl;
+        std::cout << "\t\tset_knx_output: <out> <boolean>" << std::endl;
+        std::cout << "\t\theartbeat (send heartbeat to the PLC)" << std::endl;
+        std::cout << "\t\tset_dali: <dali_line> <group?> <address> <value> <fade_time>" << std::endl;
+        std::cout << "\t\tget_dali: <dali_line> <address>" << std::endl;
+        std::cout << "\t\tdali_search_devices: <dali_line>" << std::endl;
+        std::cout << "\t\tdali_get_device_info: <dali_line> <address>" << std::endl;
+        std::cout << "\t\tdali_get_device_group: <dali_line> <group>" << std::endl;
+        std::cout << "\t\tdali_device_add_group: <dali_line> <address> <group>" << std::endl;
+        std::cout << "\t\tdali_device_del_group: <dali_line> <address> <group>" << std::endl;
+        std::cout << "\t\tdali_central: <dali_line> <boolean> (switch on/off all DALI lamps)" << std::endl;
+        std::cout << "\t\tdali_blink: <dali_line> <address> <group?> <blink_time>" << std::endl;
+        std::cout << "\t\tdali_blink_stop: <dali_line>" << std::endl;
+        std::cout << "\t\tdali_set_device_config: <dali_line> <address> <fade_rate> <fade_time> <max_level> <min_level> <system_failure_level> <power_on_level>" << std::endl;
+        std::cout << "\t\tdali_addressing_new: <dali_line> <reset?>" << std::endl;
+        std::cout << "\t\tdali_addressing_add: <dali_line>" << std::endl;
+        std::cout << "\t\tdali_addressing_status: <dali_line>" << std::endl;
+        std::cout << "\t\tdali_addressing_change: <dali_line> <old_address> <new_address>" << std::endl;
+        std::cout << "\t\tdali_addressing_del: <dali_line> <address_to_delete>" << std::endl;
 
-        cout << endl;
-        cout << "\t\tsave_config: <file>" << endl;
-        cout << "\t\tload_config: <file>" << endl;
-        cout << endl;
+        std::cout << std::endl;
+        std::cout << "\t\tsave_config: <file>" << std::endl;
+        std::cout << "\t\tload_config: <file>" << std::endl;
+        std::cout << std::endl;
     }
     else
     {
         for (int i = 0;i < argc;i++)
         {
-            string arg = argv[i];
+            std::string arg = argv[i];
             if (arg == "host")
                 host = argv[i + 1];
             else if (arg == "action")
@@ -236,7 +234,7 @@ int main(int argc, char **argv)
                 }
                 else
                 {
-                    cout << "action not found: " << action << endl;
+                    std::cout << "action not found: " << action << std::endl;
                     exit(1);
                 }
             }
@@ -247,14 +245,14 @@ int main(int argc, char **argv)
     {
         s << "WAGO_SET_OUTADDR " << address << " " << addr1 << " " << addr2 << " " << sameas;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "heartbeat")
     {
         s << "WAGO_HEARTBEAT";
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "set_outtype")
@@ -271,144 +269,144 @@ int main(int argc, char **argv)
         if (type == "DIRECT_KNX_OUTPUT") t = 8;
         s << "WAGO_SET_OUTTYPE " << address << " " << t;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "get_outtype")
     {
         s << "WAGO_GET_OUTTYPE " << address;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
         Params p;
         p.Parse(cmd);
-        cout << "Type of input " << p["1"] << ":" << endl;
-        if (p["2"] == "0") cout << "\tNONE" << endl;
-        if (p["2"] == "1") cout << "\tTELERUPTEUR" << endl;
-        if (p["2"] == "2") cout << "\tDIRECT" << endl;
-        if (p["2"] == "3") cout << "\tVOLET" << endl;
-        if (p["2"] == "4") cout << "\tVOLET_IMPULSE" << endl;
+        std::cout << "Type of input " << p["1"] << ":" << std::endl;
+        if (p["2"] == "0") std::cout << "\tNONE" << std::endl;
+        if (p["2"] == "1") std::cout << "\tTELERUPTEUR" << std::endl;
+        if (p["2"] == "2") std::cout << "\tDIRECT" << std::endl;
+        if (p["2"] == "3") std::cout << "\tVOLET" << std::endl;
+        if (p["2"] == "4") std::cout << "\tVOLET_IMPULSE" << std::endl;
     }
     else if (action == "get_outaddr")
     {
         s << "WAGO_GET_OUTADDR " << address;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
         Params p;
         p.Parse(cmd);
-        cout << "Address for input " << p["1"] << ":" << endl;
-        cout << "\tAddress 1: " << p["2"] << endl;
-        cout << "\tAddress 2: " << p["3"] << endl;
-        cout << "\tSameAs: " << p["4"] << endl;
+        std::cout << "Address for input " << p["1"] << ":" << std::endl;
+        std::cout << "\tAddress 1: " << p["2"] << std::endl;
+        std::cout << "\tAddress 2: " << p["3"] << std::endl;
+        std::cout << "\tSameAs: " << p["4"] << std::endl;
     }
     else if (action == "get_info")
     {
         s << "WAGO_GET_INFO";
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
         Params p;
         p.Parse(cmd);
-        cout << "WAGO Infos :" << endl;
-        cout << "\tTotal nb modules: " << p["1"] << endl;
-        cout << "\tnb input modules: " << p["2"] << endl;
-        cout << "\tnb output modules: " << p["3"] << endl;
-        cout << "\tnb input digital: " << p["4"] << endl;
-        cout << "\tnb output digital: " << p["5"] << endl;
-        cout << "\tnb input analog: " << p["6"] << endl;
-        cout << "\tnb output analog: " << p["7"] << endl;
+        std::cout << "WAGO Infos :" << std::endl;
+        std::cout << "\tTotal nb modules: " << p["1"] << std::endl;
+        std::cout << "\tnb input modules: " << p["2"] << std::endl;
+        std::cout << "\tnb output modules: " << p["3"] << std::endl;
+        std::cout << "\tnb input digital: " << p["4"] << std::endl;
+        std::cout << "\tnb output digital: " << p["5"] << std::endl;
+        std::cout << "\tnb input analog: " << p["6"] << std::endl;
+        std::cout << "\tnb output analog: " << p["7"] << std::endl;
     }
     else if (action == "get_version")
     {
         s << "WAGO_GET_VERSION";
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
         Params p;
         p.Parse(cmd);
-        cout << "WAGO type: " << p["2"] << endl << "Calaos version: " << p["1"] << endl;
+        std::cout << "WAGO type: " << p["2"] << std::endl << "Calaos version: " << p["1"] << std::endl;
     }
     else if (action == "get_volet_positions")
     {
         s << "WAGO_INFO_VOLET_GET " << address;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
         Params p;
         p.Parse(cmd);
-        cout << "WAGO volet " << p["1"] << " position: " << p["2"] << endl;
+        std::cout << "WAGO volet " << p["1"] << " position: " << p["2"] << std::endl;
     }
     else if (action == "get_info_module")
     {
         s << "WAGO_GET_INFO_MODULE " << address;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
         Params p;
         p.Parse(cmd);
-        cout << "WAGO module " << p["1"] << " :" << endl;
-        cout << "\tmodule type: " << p["2"] << endl;
-        cout << "\tphysical position: " << p["3"] << endl;
-        cout << "\tinput size: " << p["4"] << endl;
-        cout << "\toutput size: " << p["5"] << endl;
+        std::cout << "WAGO module " << p["1"] << " :" << std::endl;
+        std::cout << "\tmodule type: " << p["2"] << std::endl;
+        std::cout << "\tphysical position: " << p["3"] << std::endl;
+        std::cout << "\tinput size: " << p["4"] << std::endl;
+        std::cout << "\toutput size: " << p["5"] << std::endl;
     }
     else if (action == "save_config")
     {
-        ofstream f(file.c_str());
+        std::ofstream f(file.c_str());
         for (int i = 0;i < 256;i++)
         {
             {
-                stringstream sstr;
+                std::stringstream sstr;
                 sstr << "WAGO_GET_OUTTYPE " << i;
                 cmd = sstr.str();
-                cout << "Sending \"" << cmd << "\"..." << endl;
+                std::cout << "Sending \"" << cmd << "\"..." << std::endl;
                 socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
                 socket->RecvFrom(buffer, 256);
                 cmd = buffer;
-                cout << "Receiving \"" << cmd << "\"..." << endl;
+                std::cout << "Receiving \"" << cmd << "\"..." << std::endl;
 
                 Params p;
                 p.Parse(cmd);
-                f << "WAGO_SET_OUTTYPE " << i << " " << p["2"] << endl;
+                f << "WAGO_SET_OUTTYPE " << i << " " << p["2"] << std::endl;
             }
 
             {
-                stringstream sstr;
+                std::stringstream sstr;
                 sstr << "WAGO_GET_OUTADDR " << i;
                 cmd = sstr.str();
-                cout << "Sending \"" << cmd << "\"..." << endl;
+                std::cout << "Sending \"" << cmd << "\"..." << std::endl;
                 socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
                 socket->RecvFrom(buffer, 256);
                 cmd = buffer;
-                cout << "Receiving \"" << cmd << "\"..." << endl;
+                std::cout << "Receiving \"" << cmd << "\"..." << std::endl;
 
                 Params p;
                 p.Parse(cmd);
-                f << "WAGO_SET_OUTADDR " << i << " " << p["2"] << " " << p["3"] << " " << p["4"] << endl;
+                f << "WAGO_SET_OUTADDR " << i << " " << p["2"] << " " << p["3"] << " " << p["4"] << std::endl;
             }
         }
         f.close();
     }
     else if (action == "load_config")
     {
-        ifstream f(file.c_str());
+        std::ifstream f(file.c_str());
         while (!f.eof())
         {
             getline (f, cmd);
-            cout << "Sending \"" << cmd << "\"..." << endl;
+            std::cout << "Sending \"" << cmd << "\"..." << std::endl;
             socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
 
             //little pause
@@ -423,7 +421,7 @@ int main(int argc, char **argv)
     {
         s << "WAGO_SET_SERVER_IP " << ip;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "set_output")
@@ -431,7 +429,7 @@ int main(int argc, char **argv)
         s << "WAGO_SET_OUTPUT " << addr1 << " ";
         if (boolean == "true") s << "1"; else s << "0";
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "set_knx_output")
@@ -439,7 +437,7 @@ int main(int argc, char **argv)
         s << "WAGO_SET_KNX_OUTPUT " << addr1 << " ";
         if (boolean == "true") s << "1"; else s << "0";
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "set_dali")
@@ -451,115 +449,115 @@ int main(int argc, char **argv)
         s << dali_value << " ";
         s << dali_fade << " ";
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "get_dali")
     {
         s << "WAGO_DALI_GET " << dali_line << " " << dali_addr;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
         Params p;
         p.Parse(cmd);
-        cout << "DALI slave, short address: " << dali_addr << " :" << endl;
-        cout << "\tlight is on: " << p["1"] << endl;
-        cout << "\tdimm value: " << p["2"] << endl;
+        std::cout << "DALI slave, short address: " << dali_addr << " :" << std::endl;
+        std::cout << "\tlight is on: " << p["1"] << std::endl;
+        std::cout << "\tdimm value: " << p["2"] << std::endl;
     }
     else if (action == "dali_search_devices")
     {
         s << "WAGO_DALI_GET_ADDR";
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
 
-        cout << cmd << endl;
+        std::cout << cmd << std::endl;
         /*Params p;
                 p.Parse(cmd);
-                cout << "DALI slave, short address: " << dali_addr << " :" << endl;
-                cout << "\tlight is on: " << p["1"] << endl;
-                cout << "\tdimm value: " << p["2"] << endl;*/
+                std::cout << "DALI slave, short address: " << dali_addr << " :" << std::endl;
+                std::cout << "\tlight is on: " << p["1"] << std::endl;
+                std::cout << "\tdimm value: " << p["2"] << std::endl;*/
     }
     else if (action == "dali_get_device_info")
     {
         s << "WAGO_DALI_GET_DEVICE_INFO " << dali_line << " " << dali_addr;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
 
-        cout << cmd << endl;
+        std::cout << cmd << std::endl;
         /*Params p;
                 p.Parse(cmd);
-                cout << "DALI slave, short address: " << dali_addr << " :" << endl;
-                cout << "\tlight is on: " << p["1"] << endl;
-                cout << "\tdimm value: " << p["2"] << endl;*/
+                std::cout << "DALI slave, short address: " << dali_addr << " :" << std::endl;
+                std::cout << "\tlight is on: " << p["1"] << std::endl;
+                std::cout << "\tdimm value: " << p["2"] << std::endl;*/
     }
     else if (action == "dali_get_device_group")
     {
         s << "WAGO_DALI_GET_DEVICE_GROUP " << dali_line << " " << dali_addr;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
 
-        cout << cmd << endl;
+        std::cout << cmd << std::endl;
         /*Params p;
                 p.Parse(cmd);
-                cout << "DALI slave, short address: " << dali_addr << " :" << endl;
-                cout << "\tlight is on: " << p["1"] << endl;
-                cout << "\tdimm value: " << p["2"] << endl;*/
+                std::cout << "DALI slave, short address: " << dali_addr << " :" << std::endl;
+                std::cout << "\tlight is on: " << p["1"] << std::endl;
+                std::cout << "\tdimm value: " << p["2"] << std::endl;*/
     }
     else if (action == "dali_central")
     {
         s << "WAGO_DALI_CENTRAL " << dali_line << " " << ((boolean == "true")?"1":"0");
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "dali_blink")
     {
         s << "WAGO_DALI_BLINK " << dali_line << " " << dali_addr << " " << dali_group << " " << dali_time;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "dali_blink_stop")
     {
         s << "WAGO_DALI_BLINK_STOP " << dali_line;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "dali_device_add_group")
     {
         s << "WAGO_DALI_DEVICE_ADD_GROUP " << dali_line << " " << dali_addr << " " << dali_group;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
 
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
 
-        cout << cmd << endl;
+        std::cout << cmd << std::endl;
     }
     else if (action == "dali_device_del_group")
     {
         s << "WAGO_DALI_DEVICE_DEL_GROUP " << dali_line << " " << dali_addr << " " << dali_group;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
 
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
 
-        cout << cmd << endl;
+        std::cout << cmd << std::endl;
     }
     else if (action == "dali_set_device_config")
     {
@@ -568,46 +566,46 @@ int main(int argc, char **argv)
           << dali_maxlevel << " " << dali_minlevel << " "
           << dali_systemfailurelevel << " " << dali_poweronlevel;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "dali_addressing_new")
     {
         s << "WAGO_DALI_ADDRESSING_NEW " << dali_line << " " << dali_addr;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "dali_addressing_add")
     {
         s << "WAGO_DALI_ADDRESSING_ADD " << dali_line;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "dali_addressing_status")
     {
         s << "WAGO_DALI_ADDRESSING_STATUS " << dali_line;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
         socket->RecvFrom(buffer, 256);
         cmd = buffer;
 
-        cout << cmd << endl;
+        std::cout << cmd << std::endl;
     }
     else if (action == "dali_addressing_change")
     {
         s << "WAGO_DALI_ADDRESSING_CHANGE " << dali_line << " " << dali_addr << " " << dali_value;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
     else if (action == "dali_addressing_del")
     {
         s << "WAGO_DALI_ADDRESSING_DEL " << dali_line << " " << dali_addr;
         cmd = s.str();
-        cout << "Sending \"" << cmd << "\"..." << endl;
+        std::cout << "Sending \"" << cmd << "\"..." << std::endl;
         socket->SendTo(cmd.c_str(), cmd.size(), WAGO_LISTEN_PORT, host);
     }
 

--- a/src/lib/CalaosModule.h
+++ b/src/lib/CalaosModule.h
@@ -36,11 +36,11 @@ class CalaosModuleBase
 {
 protected:
     Evas *evas;
-    string id;
-    string module_path;
+    std::string id;
+    std::string module_path;
 
 public:
-    CalaosModuleBase(Evas *_evas, string _id, string _module_path):
+    CalaosModuleBase(Evas *_evas, std::string _id, std::string _module_path):
         evas(_evas), id(_id), module_path(_module_path)
     { }
 
@@ -50,7 +50,7 @@ public:
     /* Return a string that represent the current module instance
                    It's used to display a list of active module
                 */
-    virtual string getStringInfo() { return ""; }
+    virtual std::string getStringInfo() { return ""; }
 
     virtual void getSizeMin(int &w, int &h) { }
     virtual void getSizeMax(int &w, int &h) { }

--- a/src/lib/CalaosNetwork.cpp
+++ b/src/lib/CalaosNetwork.cpp
@@ -22,7 +22,7 @@
 #include <jansson.h>
 #include <Jansson_Addition.h>
 
-CalaosNetwork::CalaosNetwork(string _username, string _password):
+CalaosNetwork::CalaosNetwork(std::string _username, std::string _password):
     username(_username),
     password(_password),
     download_in_progress(false)
@@ -37,7 +37,7 @@ CalaosNetwork::~CalaosNetwork()
 {
 }
 
-void CalaosNetwork::Register(string cn_user, string cn_pass)
+void CalaosNetwork::Register(std::string cn_user, std::string cn_pass)
 {
     if (download_in_progress)
     {
@@ -49,7 +49,7 @@ void CalaosNetwork::Register(string cn_user, string cn_pass)
 
     download_in_progress = true;
 
-    string jdata = "{";
+    std::string jdata = "{";
     jdata += "\"cn_user\":\"" + cn_user + "\",";
     jdata += "\"cn_pass\":\"" + cn_pass + "\",";
     jdata += "\"action\":\"register\",";
@@ -57,7 +57,7 @@ void CalaosNetwork::Register(string cn_user, string cn_pass)
     //------------------------------------------------------
     //Used to update calaos_id to hwid
     //To be removed in the future when everyone has updated
-    string calaos_id = Utils::get_config_option("calaos_id");
+    std::string calaos_id = Utils::get_config_option("calaos_id");
     if (calaos_id != "")
         jdata += "\"calaos_id\":\"" + calaos_id + "\",";
     //------------------------------------------------------
@@ -70,14 +70,14 @@ void CalaosNetwork::Register(string cn_user, string cn_pass)
     fdownloader->Start();
 }
 
-void CalaosNetwork::register_cb(string result, void *data)
+void CalaosNetwork::register_cb(std::string result, void *data)
 {
     if (result == "done")
     {
         download_in_progress = false;
 
         Buffer_CURL *buff = reinterpret_cast<Buffer_CURL *>(data);
-        string res((const char *)buff->buffer, buff->bufsize);
+        std::string res((const char *)buff->buffer, buff->bufsize);
 
         fdownloader = NULL;
 
@@ -137,7 +137,7 @@ void CalaosNetwork::register_cb(string result, void *data)
     }
 }
 
-void CalaosNetwork::updateIP(string priv_ip)
+void CalaosNetwork::updateIP(std::string priv_ip)
 {
     if (download_in_progress)
     {
@@ -149,7 +149,7 @@ void CalaosNetwork::updateIP(string priv_ip)
 
     download_in_progress = true;
 
-    string jdata = "{";
+    std::string jdata = "{";
     jdata += "\"cn_user\":\"" + username + "\",";
     jdata += "\"cn_pass\":\"" + password + "\",";
     jdata += "\"action\":\"update_ip\",";
@@ -166,14 +166,14 @@ void CalaosNetwork::updateIP(string priv_ip)
     fdownloader->Start();
 }
 
-void CalaosNetwork::update_ip_cb(string result, void *data)
+void CalaosNetwork::update_ip_cb(std::string result, void *data)
 {
     if (result == "done")
     {
         download_in_progress = false;
 
         Buffer_CURL *buff = reinterpret_cast<Buffer_CURL *>(data);
-        string res((const char *)buff->buffer, buff->bufsize);
+        std::string res((const char *)buff->buffer, buff->bufsize);
 
         fdownloader = NULL;
 
@@ -229,7 +229,7 @@ void CalaosNetwork::getIP()
 
     download_in_progress = true;
 
-    string jdata = "{";
+    std::string jdata = "{";
     jdata += "\"cn_user\":\"" + username + "\",";
     jdata += "\"cn_pass\":\"" + password + "\",";
     jdata += "\"action\":\"get_ip\"";
@@ -240,14 +240,14 @@ void CalaosNetwork::getIP()
     fdownloader->Start();
 }
 
-void CalaosNetwork::get_ip_cb(string result, void *data)
+void CalaosNetwork::get_ip_cb(std::string result, void *data)
 {
     if (result == "done")
     {
         download_in_progress = false;
 
         Buffer_CURL *buff = reinterpret_cast<Buffer_CURL *>(data);
-        string res((const char *)buff->buffer, buff->bufsize);
+        std::string res((const char *)buff->buffer, buff->bufsize);
 
         fdownloader = NULL;
 
@@ -271,8 +271,8 @@ void CalaosNetwork::get_ip_cb(string result, void *data)
             return;
         }
 
-        string public_ip;
-        string private_ip;
+        std::string public_ip;
+        std::string private_ip;
         bool at_home;
 
         public_ip = jansson_string_get(json, "public_ip", "bad_value");

--- a/src/lib/CalaosNetwork.h
+++ b/src/lib/CalaosNetwork.h
@@ -27,30 +27,30 @@
 class CalaosNetwork: public sigc::trackable
 {
 private:
-    string username;
-    string password;
+    std::string username;
+    std::string password;
 
     FileDownloader *fdownloader;
 
     bool download_in_progress;
 
-    void register_cb(string result, void *data);
-    void update_ip_cb(string result, void *data);
-    void get_ip_cb(string result, void *data);
+    void register_cb(std::string result, void *data);
+    void update_ip_cb(std::string result, void *data);
+    void get_ip_cb(std::string result, void *data);
 
 public:
-    CalaosNetwork(string username = "", string password = "");
+    CalaosNetwork(std::string username = "", std::string password = "");
     ~CalaosNetwork();
 
     /**
                   * Registers the user with the machine on calaos network
                   */
-    void Register(string username, string password);
+    void Register(std::string username, std::string password);
 
     /**
                   * Update Calaos Network DNS IP
                   */
-    void updateIP(string private_ip);
+    void updateIP(std::string private_ip);
 
     /**
                   * Query Calaos Network account for private/public IP
@@ -58,9 +58,9 @@ public:
     void getIP();
 
     /* Signals */
-    sigc::signal<void, string> registered;
-    sigc::signal<void, string> ip_updated;
-    sigc::signal<void, string, string /* public_ip */, string /* private_ip */, bool /* at_home */> ip_retrieved;
+    sigc::signal<void, std::string> registered;
+    sigc::signal<void, std::string> ip_updated;
+    sigc::signal<void, std::string, std::string /* public_ip */, std::string /* private_ip */, bool /* at_home */> ip_retrieved;
 
 };
 

--- a/src/lib/Calendar.cpp
+++ b/src/lib/Calendar.cpp
@@ -46,8 +46,8 @@ TimeZone::TimeZone()
             {
                 if (f_info2->type == EINA_FILE_REG)
                 {
-                    string tz;
-                    tz = string(ecore_file_file_get(f_info->path)) + "/" + string(f_info2->path + f_info2->name_start);
+                    std::string tz;
+                    tz = std::string(ecore_file_file_get(f_info->path)) + "/" + std::string(f_info2->path + f_info2->name_start);
                     timeZone.push_back(TimeZoneElt(tz.c_str(), "Europe / Royaume Unis / Londre", "GMT+00:00", 0, "gb"));
                 }
             }
@@ -88,7 +88,7 @@ int TimeZone::loadCurrentTimeZone()
     return -1;
 }
 
-TimeZoneElt::TimeZoneElt(string k, string c, string dstr, int d, string id)
+TimeZoneElt::TimeZoneElt(std::string k, std::string c, std::string dstr, int d, std::string id)
 {
     key = k;
     country = c;
@@ -137,7 +137,7 @@ void Calendar::initDate()
 /*
  * Retourne le jour sous forme de string (lundi, mardi ...)
  */
-const string Calendar::getDayFromDate()
+const std::string Calendar::getDayFromDate()
 {
     updateDay();
     if(dayId<0 || dayId>7)
@@ -157,7 +157,7 @@ int Calendar::getDayIdFromDate()
 /*
  * Retourne le mois sous forme de string (janvier, février ...)
  */
-const string Calendar::getMonthFromDate()
+const std::string Calendar::getMonthFromDate()
 {
     if(month<1 || month>12)
         return M[0];
@@ -338,9 +338,9 @@ void Calendar::setDay(int d)
 /*
  * Retourne l'heure sous forme de chaine de caractère (01 02 03 ... 10 ...)
  */
-string Calendar::hoursToString()
+std::string Calendar::hoursToString()
 {
-    string res = Utils::to_string(hours);
+    std::string res = Utils::to_string(hours);
     if (hours < 10)
         res = "0" + res;
     return res;
@@ -350,9 +350,9 @@ string Calendar::hoursToString()
 /*
  * Retourne les minutes sous forme de chaine de caractère (01 02 03 ... 10 ...)
  */
-string Calendar::minutesToString()
+std::string Calendar::minutesToString()
 {
-    string res = Utils::to_string(minutes);
+    std::string res = Utils::to_string(minutes);
     if (minutes < 10)
         res = "0" + res;
     return res;
@@ -362,9 +362,9 @@ string Calendar::minutesToString()
 /*
  * Retourne les secondes sous forme de chaine de caractère (01 02 03 ... 10 ...)
  */
-string Calendar::secondesToString()
+std::string Calendar::secondesToString()
 {
-    string res = Utils::to_string(secondes);
+    std::string res = Utils::to_string(secondes);
     if (secondes < 10)
         res = "0" + res;
     return res;
@@ -399,7 +399,7 @@ void Calendar::applyTimezone()
 
     ecore_file_mv(TMP_CURRENT_ZONE, CURRENT_ZONE);
 
-    string new_ltime = ZONEPATH;
+    std::string new_ltime = ZONEPATH;
     new_ltime += timeZone.timeZone[timeZone.current].key;
 
     //copy the new zone info
@@ -424,7 +424,7 @@ Eina_Bool _CalendarHandle1(void *data, int type, void *event)
 
     ecore_event_handler_del(calendar->handler);
     //ecore_exe_free(calendar->exe);
-    string cmd = "/sbin/hwclock --systohc";
+    std::string cmd = "/sbin/hwclock --systohc";
 
     calendar->handler = ecore_event_handler_add(ECORE_EXE_EVENT_DEL, _CalendarHandle2, calendar);
     calendar->exe = ecore_exe_run(cmd.c_str(), NULL);

--- a/src/lib/Calendar.h
+++ b/src/lib/Calendar.h
@@ -34,17 +34,17 @@ class TimeZoneElt
 {
 public:
     /* la cl du pays  mettre dans /etc/timezone */
-    string key;
+    std::string key;
     /* le chemin complet du pays (continent / pays / ville) */
-    string country;
+    std::string country;
     /* le dcalage horaire sous forme de chaine de caractre */
-    string decalageStr;
+    std::string decalageStr;
     /* le dcalage horaire  sous forme d'entier (non utilis) */
     int decalage;
     /* le code du pays (fr, de ...) */
-    string code;
+    std::string code;
 
-    TimeZoneElt(string k, string c, string dstr, int d, string id);
+    TimeZoneElt(std::string k, std::string c, std::string dstr, int d, std::string id);
 };
 
 class TimeZone
@@ -55,7 +55,7 @@ public:
     int current;
 
     /* la liste des fuseaux horaires */
-    vector<TimeZoneElt> timeZone;
+    std::vector<TimeZoneElt> timeZone;
 
     TimeZone();
     int loadCurrentTimeZone();
@@ -110,9 +110,9 @@ public:
     void setNtp(bool b);
     void timezoneSelect(int id);
 
-    string hoursToString();
-    string minutesToString();
-    string secondesToString();
+    std::string hoursToString();
+    std::string minutesToString();
+    std::string secondesToString();
 
     void monthUp();
     void monthDown();
@@ -126,10 +126,10 @@ public:
     void yearDown();
     void setYear(int m);
 
-    const string getDayFromDate();
+    const std::string getDayFromDate();
     int getDayIdFromDate();
     void initDate();
-    const string getMonthFromDate();
+    const std::string getMonthFromDate();
     int getNbDaysInMonth();
 
     void apply();

--- a/src/lib/ColorUtils.cpp
+++ b/src/lib/ColorUtils.cpp
@@ -21,7 +21,6 @@
 #include "ColorUtils.h"
 #include "Calaos.h"
 
-using namespace Calaos;
 
 #define OUT_OF_RANGE(val, min, max) \
     ((val < min) || (val > max))
@@ -40,14 +39,14 @@ ColorValue::ColorValue(int r, int g, int b)
     setRgb(r, g, b);
 }
 
-ColorValue::ColorValue(string str_color)
+ColorValue::ColorValue(std::string str_color)
 {
     setString(str_color);
 }
 
-string ColorValue::toString() const
+std::string ColorValue::toString() const
 {
-    stringstream s;
+    std::stringstream s;
     if (!isValid()) return "#000000";
 
     if (type == ColorRGB)
@@ -78,9 +77,9 @@ string ColorValue::toString() const
     return s.str();
 }
 
-void ColorValue::setString(const string &str)
+void ColorValue::setString(const std::string &str)
 {
-    string s = Utils::str_to_lower(Utils::trim(str));
+    std::string s = Utils::str_to_lower(Utils::trim(str));
 
     /* Color format supported:
      * 1234   decimal value for the color with 3 RGB components
@@ -133,7 +132,7 @@ void ColorValue::setString(const string &str)
         s.erase(s.find_last_of(')'));
         Utils::replace_str(s, " ", ""); //remove any spaces
 
-        vector<string> values;
+        std::vector<std::string> values;
         Utils::split(s, values, ",");
 
         if (values.size() == 3 ||
@@ -164,7 +163,7 @@ void ColorValue::setString(const string &str)
         Utils::replace_str(s, " ", ""); //remove any spaces
         Utils::replace_str(s, "%", ""); //remove any %
 
-        vector<string> values;
+        std::vector<std::string> values;
         Utils::split(s, values, ",");
 
         if (values.size() == 3 ||
@@ -195,7 +194,7 @@ void ColorValue::setString(const string &str)
         Utils::replace_str(s, " ", ""); //remove any spaces
         Utils::replace_str(s, "%", ""); //remove any %
 
-        vector<string> values;
+        std::vector<std::string> values;
         Utils::split(s, values, ",");
 
         if (values.size() == 3 ||

--- a/src/lib/ColorUtils.h
+++ b/src/lib/ColorUtils.h
@@ -23,19 +23,18 @@
 
 #include <iostream>
 
-using namespace std;
 
 class ColorValue
 {
 public:
     ColorValue();
     ColorValue(int r, int g, int b);
-    ColorValue(string str_color);
+    ColorValue(std::string str_color);
 
     bool isValid() const { return type != ColorInvalid; }
 
-    string toString() const;
-    void setString(const string &str);
+    std::string toString() const;
+    void setString(const std::string &str);
 
     int getAlpha() const { return alpha; }
     void setAlpha(int a);

--- a/src/lib/DownloadManager.cpp
+++ b/src/lib/DownloadManager.cpp
@@ -31,13 +31,13 @@ DownloadManager::~DownloadManager()
     clear();
 }
 
-void DownloadManager::add(string source, string destination,
-                          sigc::slot<void, string, string, void*> sig,
-                          sigc::slot<void, string, string, double, double, void*> sig_progress,
+void DownloadManager::add(std::string source, std::string destination,
+                          sigc::slot<void, std::string, std::string, void*> sig,
+                          sigc::slot<void, std::string, std::string, double, double, void*> sig_progress,
                           void *userData)
 {
     //check if download isn't already running
-    list<DownloadManagerData *>::iterator it;
+    std::list<DownloadManagerData *>::iterator it;
     for (it = lDownloads.begin();it != lDownloads.end();it++)
     {
         if (source == (*it)->source &&
@@ -59,10 +59,10 @@ void DownloadManager::add(string source, string destination,
     downloadFirst();
 }
 
-void DownloadManager::add(string source, string destination)
+void DownloadManager::add(std::string source, std::string destination)
 {
     //check if download isn't already running
-    list<DownloadManagerData *>::iterator it;
+    std::list<DownloadManagerData *>::iterator it;
     for (it = lDownloads.begin();it != lDownloads.end();it++)
     {
         if (source == (*it)->source &&
@@ -83,10 +83,10 @@ void DownloadManager::add(string source, string destination)
 
 void DownloadManager::clear()
 {
-    for_each(l.begin(),l.end(),Delete());
+    for_each(l.begin(),l.end(),Utils::Delete());
     l.clear();
 
-    list<DownloadManagerData *>::iterator it;
+    std::list<DownloadManagerData *>::iterator it;
     for(it = lDownloads.begin();it != lDownloads.end();it++)
     {
         DownloadManagerData *data = *it;
@@ -104,10 +104,10 @@ void DownloadManager::clear()
     lDownloads.clear();
 }
 
-void DownloadManager::del(string source, string destination, void *userData)
+void DownloadManager::del(std::string source, std::string destination, void *userData)
 {
     DownloadManagerData *item = NULL;
-    list<DownloadManagerData *>::iterator it;
+    std::list<DownloadManagerData *>::iterator it;
     for(it = lDownloads.begin();it != lDownloads.end();it++)
     {
         if ((*it)->source == source &&
@@ -172,7 +172,7 @@ void DownloadManager::downloadFirst()
     if(lDownloads.size() >= (uint)nbDownloadsMax || l.size() <= 0)
         return ;
 
-    list<DownloadManagerData *>::iterator it = l.begin();
+    std::list<DownloadManagerData *>::iterator it = l.begin();
     DownloadManagerData *download = *it;
     l.erase(it);
     lDownloads.push_back(download);
@@ -188,11 +188,11 @@ void DownloadManager::downloadFirst()
 }
 
 
-void DownloadManager::IPCDownloadDone(string source, string signal,
+void DownloadManager::IPCDownloadDone(std::string source, std::string signal,
                                       void* listener_data, void* sender_data)
 {
     DownloadManagerData *data = reinterpret_cast<DownloadManagerData*>(listener_data);
-    list<DownloadManagerData *>::iterator it;
+    std::list<DownloadManagerData *>::iterator it;
 
     if((signal == "done" || signal == "failed" || signal == "aborted")
        && data->hasDeleted)

--- a/src/lib/DownloadManager.h
+++ b/src/lib/DownloadManager.h
@@ -26,14 +26,14 @@
 class DownloadManagerData
 {
 public:
-    string source;
-    string destination;
-    sigc::signal<void, string, string, void*, void*> sigDownload;
+    std::string source;
+    std::string destination;
+    sigc::signal<void, std::string, std::string, void*, void*> sigDownload;
     int downloadTimes;
 
     void *userData;
-    sigc::signal<void, string, string, void*> sigUser;
-    sigc::signal<void, string, string, double, double, void*> sigProgressUpdate;
+    sigc::signal<void, std::string, std::string, void*> sigUser;
+    sigc::signal<void, std::string, std::string, double, double, void*> sigProgressUpdate;
 
     FileDownloader* downloader;
 
@@ -56,12 +56,12 @@ private:
     /**
                  * The list of files to download
                  */
-    list<DownloadManagerData *> l;
+    std::list<DownloadManagerData *> l;
 
     /**
                  * List of downloads
                  */
-    list<DownloadManagerData *> lDownloads;
+    std::list<DownloadManagerData *> lDownloads;
 
     /**
                  * The maximum of downloads at the same time
@@ -73,7 +73,7 @@ private:
     int nbTry;
 
     void downloadFirst();
-    void IPCDownloadDone(string source, string signal,
+    void IPCDownloadDone(std::string source, std::string signal,
                          void* listener_data, void* sender_data);
 
 
@@ -93,12 +93,12 @@ public:
                  * @param sig_progress, the signal called when download progress updates (url, destination_file, dl_now, dl_total, data)
                  * @param userData, user data
                  */
-    void add(string source, string destination,
-             sigc::slot<void, string, string, void*> sig,
-             sigc::slot<void, string, string, double, double, void*> sig_progress,
+    void add(std::string source, std::string destination,
+             sigc::slot<void, std::string, std::string, void*> sig,
+             sigc::slot<void, std::string, std::string, double, double, void*> sig_progress,
              void *userData);
 
-    void add(string source, string destination);
+    void add(std::string source, std::string destination);
 
 
 
@@ -108,7 +108,7 @@ public:
                  * @param destination, the local destination (/tmp...)
                  * @param userData, user data
                  */
-    void del(string source, string destination, void *userData);
+    void del(std::string source, std::string destination, void *userData);
 
     /**
                  * Clear the list

--- a/src/lib/EcoreFdHandler.h
+++ b/src/lib/EcoreFdHandler.h
@@ -25,7 +25,6 @@
 #include <sigc++/sigc++.h>
 #include <Ecore.h>
 
-using namespace Utils;
 
 class CalaosEcoreFdHandler
 {

--- a/src/lib/EcoreTimer.h
+++ b/src/lib/EcoreTimer.h
@@ -25,7 +25,6 @@
 #include <sigc++/sigc++.h>
 #include <Ecore.h>
 
-using namespace Utils;
 
 class EcoreTimer
 {

--- a/src/lib/EinaLog.h
+++ b/src/lib/EinaLog.h
@@ -25,7 +25,6 @@
 #include <sstream>
 #include <Eina.h>
 
-using namespace std;
 
 #define EinaLogDebug(a)         a->EinaDebug(__FILE__, __PRETTY_FUNCTION__, __LINE__)
 #define EinaLogInfo(a)          a->EinaInfo(__FILE__, __PRETTY_FUNCTION__, __LINE__)
@@ -45,7 +44,7 @@ class LogStream
 private:
     struct LogData
     {
-        LogData(int d, string f, string fn, int ln, Eina_Log_Level l):
+        LogData(int d, std::string f, std::string fn, int ln, Eina_Log_Level l):
             domain(d),
             file(f),
             function(fn),
@@ -53,10 +52,10 @@ private:
             level(l)
         {}
         int domain;
-        string file, function;
+        std::string file, function;
         int line;
         Eina_Log_Level level;
-        ostringstream stream;
+        std::ostringstream stream;
     } *logData;
 
 public:
@@ -66,7 +65,7 @@ public:
         logData->stream << obj;
         return *this;
     }
-    LogStream(int d, string f, string fn, int ln, Eina_Log_Level l):
+    LogStream(int d, std::string f, std::string fn, int ln, Eina_Log_Level l):
         logData(new LogData(d, f, fn, ln, l))
     {}
 
@@ -95,11 +94,11 @@ class EinaLog
 {
 private:
     int domain;
-    string domainName;
+    std::string domainName;
     bool coutOutput = false;
 
 public:
-    EinaLog(string dname="EinaLog"):
+    EinaLog(std::string dname="EinaLog"):
         domain(-1),
         domainName(dname)
     {
@@ -124,27 +123,27 @@ public:
         }
     }
 
-    LogStream EinaDebug(string file, string function, int line) const
+    LogStream EinaDebug(std::string file, std::string function, int line) const
     {
         if (coutOutput) return LogStream(-1, file, function, line, EINA_LOG_LEVEL_UNKNOWN);
         return LogStream(domain, file, function, line, EINA_LOG_LEVEL_DBG);
     }
-    LogStream EinaInfo(string file, string function, int line) const
+    LogStream EinaInfo(std::string file, std::string function, int line) const
     {
         if (coutOutput) return LogStream(-1, file, function, line, EINA_LOG_LEVEL_UNKNOWN);
         return LogStream(domain, file, function, line, EINA_LOG_LEVEL_INFO);
     }
-    LogStream EinaCritical(string file, string function, int line) const
+    LogStream EinaCritical(std::string file, std::string function, int line) const
     {
         if (coutOutput) return LogStream(-1, file, function, line, EINA_LOG_LEVEL_UNKNOWN);
         return LogStream(domain, file, function, line, EINA_LOG_LEVEL_CRITICAL);
     }
-    LogStream EinaError(string file, string function, int line) const
+    LogStream EinaError(std::string file, std::string function, int line) const
     {
         if (coutOutput) return LogStream(-1, file, function, line, EINA_LOG_LEVEL_UNKNOWN);
         return LogStream(domain, file, function, line, EINA_LOG_LEVEL_ERR);
     }
-    LogStream EinaWarning(string file, string function, int line) const
+    LogStream EinaWarning(std::string file, std::string function, int line) const
     {
         if (coutOutput) return LogStream(-1, file, function, line, EINA_LOG_LEVEL_UNKNOWN);
         return LogStream(domain, file, function, line, EINA_LOG_LEVEL_WARN);

--- a/src/lib/FileDownloader.cpp
+++ b/src/lib/FileDownloader.cpp
@@ -46,7 +46,7 @@ static Eina_Bool _progress_cb(void *data, int type, void *event)
     return ECORE_CALLBACK_RENEW;
 }
 
-FileDownloader::FileDownloader(string _url, string _dest, bool auto_del):
+FileDownloader::FileDownloader(std::string _url, std::string _dest, bool auto_del):
     url_con(NULL),
     dl_file(NULL),
     auto_destroy(auto_del),
@@ -61,7 +61,7 @@ FileDownloader::FileDownloader(string _url, string _dest, bool auto_del):
     progress_handler = ecore_event_handler_add(ECORE_CON_EVENT_URL_PROGRESS, _progress_cb, this);
 }
 
-FileDownloader::FileDownloader(string _url, string _dest, string _postData, string _postContentType, bool auto_del):
+FileDownloader::FileDownloader(std::string _url, std::string _dest, std::string _postData, std::string _postContentType, bool auto_del):
     url_con(NULL),
     dl_file(NULL),
     auto_destroy(auto_del),
@@ -78,7 +78,7 @@ FileDownloader::FileDownloader(string _url, string _dest, string _postData, stri
     progress_handler = ecore_event_handler_add(ECORE_CON_EVENT_URL_PROGRESS, _progress_cb, this);
 }
 
-FileDownloader::FileDownloader(string _url, string _postData, string _postContentType, bool auto_del):
+FileDownloader::FileDownloader(std::string _url, std::string _postData, std::string _postContentType, bool auto_del):
     url_con(NULL),
     dl_file(NULL),
     auto_destroy(auto_del),
@@ -138,11 +138,11 @@ bool FileDownloader::Start()
     url_con = ecore_con_url_new(url.c_str());
     if (!url_con)
     {
-        string err = "Failed to create Ecore_Con_Url";
+        std::string err = "Failed to create Ecore_Con_Url";
 
         IPC::Instance().SendEvent("downloader::" + Utils::to_string(this),
                                   "failed",
-                                  IPCData(new string(err), new DeletorT<string *>()),
+                                  IPCData(new std::string(err), new Utils::DeletorT<std::string *>()),
                                   true);
 
         cb_signal.emit("failed", &err);
@@ -176,11 +176,11 @@ bool FileDownloader::Start()
 
     if (!dl_file)
     {
-        string err = "Failed to open file";
+        std::string err = "Failed to open file";
 
         IPC::Instance().SendEvent("downloader::" + Utils::to_string(this),
                                   "failed",
-                                  IPCData(new string(err), new DeletorT<string *>()),
+                                  IPCData(new std::string(err), new Utils::DeletorT<std::string *>()),
                                   true);
 
         cb_signal.emit("failed", &err);
@@ -210,11 +210,11 @@ bool FileDownloader::Start()
 
     if (!ret)
     {
-        string err = "Failed to call GET/POST";
+        std::string err = "Failed to call GET/POST";
 
         IPC::Instance().SendEvent("downloader::" + Utils::to_string(this),
                                   "failed",
-                                  IPCData(new string(err), new DeletorT<string *>()),
+                                  IPCData(new std::string(err), new Utils::DeletorT<std::string *>()),
                                   true);
 
         cb_signal.emit("failed", &err);
@@ -251,7 +251,7 @@ void FileDownloader::Cancel()
 
     IPC::Instance().SendEvent("downloader::" + Utils::to_string(this),
                               "aborted",
-                              IPCData(new string(url), new DeletorT<string *>()),
+                              IPCData(new std::string(url), new Utils::DeletorT<std::string *>()),
                               true);
 
     cb_signal.emit("aborted", &url);
@@ -267,7 +267,7 @@ void FileDownloader::progressCb(double dlnow, double dltotal)
 {
     IPC::Instance().SendEvent("downloader::" + Utils::to_string(this),
                               "progress,update",
-                              IPCData(new FileProgress(dlnow, dltotal), new DeletorT<FileProgress *>()),
+                              IPCData(new FileProgress(dlnow, dltotal), new Utils::DeletorT<FileProgress *>()),
                               true);
 
     FileProgress fp(dlnow, dltotal);
@@ -284,11 +284,11 @@ void FileDownloader::completeCb(int status)
 
     if (status >= 400 || status < 100)
     {
-        string err = "Error code : " + Utils::to_string(status);
+        std::string err = "Error code : " + Utils::to_string(status);
 
         IPC::Instance().SendEvent("downloader::" + Utils::to_string(this),
                                   "failed",
-                                  IPCData(new string(err), new DeletorT<string *>()),
+                                  IPCData(new std::string(err), new Utils::DeletorT<std::string *>()),
                                   true);
 
         cb_signal.emit("failed", &err);
@@ -308,7 +308,7 @@ void FileDownloader::completeCb(int status)
     {
         IPC::Instance().SendEvent("downloader::" + Utils::to_string(this),
                                   "done",
-                                  IPCData(new string(dest), new DeletorT<string *>()),
+                                  IPCData(new std::string(dest), new Utils::DeletorT<std::string *>()),
                                   true);
 
         cb_signal.emit("done", &dest);
@@ -316,7 +316,7 @@ void FileDownloader::completeCb(int status)
     }
     else
     {
-        Buffer_CURL buff;
+        Utils::Buffer_CURL buff;
 
         dl_file = fopen(tmpFile.c_str(), "rb");
         fseek(dl_file, 0, SEEK_END);
@@ -331,7 +331,7 @@ void FileDownloader::completeCb(int status)
 
         IPC::Instance().SendEvent("downloader::" + Utils::to_string(this),
                                   "done",
-                                  IPCData(new Buffer_CURL(buff), new DeletorT<Buffer_CURL *>()),
+                                  IPCData(new Utils::Buffer_CURL(buff), new Utils::DeletorT<Utils::Buffer_CURL *>()),
                                   true);
 
         cb_signal.emit("done", &buff);

--- a/src/lib/FileDownloader.h
+++ b/src/lib/FileDownloader.h
@@ -28,7 +28,6 @@
 #include <Ecore_Con.h>
 #include <Ecore_File.h>
 
-using namespace Utils;
 
 class FileProgress
 {
@@ -57,26 +56,26 @@ protected:
     bool auto_destroy;
     Ecore_Idler *idler;
 
-    string url;
-    string dest;
-    string tmpFile;
-    string postData;
-    string postContentType;
+    std::string url;
+    std::string dest;
+    std::string tmpFile;
+    std::string postData;
+    std::string postContentType;
 
-    sigc::signal<void, string, void *> cb_signal;
+    sigc::signal<void, std::string, void *> cb_signal;
     sigc::connection cb_connection;
 
-    sigc::signal<void, string, void *, void *> cb_signal_user;
+    sigc::signal<void, std::string, void *, void *> cb_signal_user;
     sigc::connection cb_connection_user;
     void *user_data;
 
 public:
     /* Simple file download */
-    FileDownloader(string url, string destFile, bool auto_destroy = false);
+    FileDownloader(std::string url, std::string destFile, bool auto_destroy = false);
     /* POST data with content type, and return data in a buffer */
-    FileDownloader(string url, string postData, string postContentType, bool auto_destroy = false);
+    FileDownloader(std::string url, std::string postData, std::string postContentType, bool auto_destroy = false);
     /* POST data with content type, and return data in a file */
-    FileDownloader(string url, string destFile, string postData, string postContentType, bool auto_destroy = false);
+    FileDownloader(std::string url, std::string destFile, std::string postData, std::string postContentType, bool auto_destroy = false);
 
     ~FileDownloader();
 
@@ -86,13 +85,13 @@ public:
                    aborted : download is aborted
                    progress,update : progress update message
                  */
-    void addCallback(sigc::slot<void, string, void *> slot)
+    void addCallback(sigc::slot<void, std::string, void *> slot)
     {
         cb_connection.disconnect();
         cb_connection = cb_signal.connect(slot);
     }
 
-    void addCallback(sigc::slot<void, string, void *, void *> slot, void *_user_data)
+    void addCallback(sigc::slot<void, std::string, void *, void *> slot, void *_user_data)
     {
         user_data = _user_data;
         cb_connection_user.disconnect();

--- a/src/lib/Firmwares.cpp
+++ b/src/lib/Firmwares.cpp
@@ -22,7 +22,7 @@
 #include <jansson.h>
 #include <Jansson_Addition.h>
 
-Firmwares::Firmwares(string _cn_user, string _cn_pass, string _fw_version):
+Firmwares::Firmwares(std::string _cn_user, std::string _cn_pass, std::string _fw_version):
     fdownloader(NULL),
     cn_user(_cn_user),
     cn_pass(_cn_pass),
@@ -47,7 +47,7 @@ Firmwares::~Firmwares()
     cb_con_install.disconnect();
 }
 
-void Firmwares::checkUpdate(sigc::slot<void, string> callback)
+void Firmwares::checkUpdate(sigc::slot<void, std::string> callback)
 {
     if (download_in_progress)
     {
@@ -62,7 +62,7 @@ void Firmwares::checkUpdate(sigc::slot<void, string> callback)
     cb_con_check.disconnect();
     cb_con_check = cb_signal_check.connect(callback);
 
-    string jdata = "{";
+    std::string jdata = "{";
     jdata += "\"cn_user\":\"" + cn_user + "\",";
     jdata += "\"cn_pass\":\"" + cn_pass + "\",";
     jdata += "\"action\":\"firmware\",";
@@ -77,14 +77,14 @@ void Firmwares::checkUpdate(sigc::slot<void, string> callback)
     fdownloader->Start();
 }
 
-void Firmwares::check_cb(string result, void *data)
+void Firmwares::check_cb(std::string result, void *data)
 {
     if (result == "done")
     {
         download_in_progress = false;
 
         Buffer_CURL *buff = reinterpret_cast<Buffer_CURL *>(data);
-        string res((const char *)buff->buffer, buff->bufsize);
+        std::string res((const char *)buff->buffer, buff->bufsize);
 
         fdownloader = NULL;
 
@@ -116,7 +116,7 @@ void Firmwares::check_cb(string result, void *data)
 
             if (jansson_bool_get(json, "need_update"))
             {
-                string new_version = jansson_string_get(json, "new_version");
+                std::string new_version = jansson_string_get(json, "new_version");
 
                 if (new_version != "")
                 {
@@ -153,7 +153,7 @@ void Firmwares::check_cb(string result, void *data)
     }
 }
 
-void Firmwares::downloadFirmware(sigc::slot<void, string, FileProgress *> callback)
+void Firmwares::downloadFirmware(sigc::slot<void, std::string, FileProgress *> callback)
 {
     if (download_in_progress)
     {
@@ -168,7 +168,7 @@ void Firmwares::downloadFirmware(sigc::slot<void, string, FileProgress *> callba
     cb_con_download.disconnect();
     cb_con_download = cb_signal_download.connect(callback);
 
-    string jdata = "{";
+    std::string jdata = "{";
     jdata += "\"cn_user\":\"" + cn_user + "\",";
     jdata += "\"cn_pass\":\"" + cn_pass + "\",";
     jdata += "\"action\":\"firmware\",";
@@ -183,7 +183,7 @@ void Firmwares::downloadFirmware(sigc::slot<void, string, FileProgress *> callba
     fdownloader->Start();
 }
 
-void Firmwares::download_cb(string result, void *data)
+void Firmwares::download_cb(std::string result, void *data)
 {
     if (result == "failed" || result == "aborted")
     {
@@ -217,14 +217,14 @@ static Eina_Bool exe_exit(void *data, int type, void *event)
     return EINA_TRUE;
 }
 
-bool Firmwares::installFirmware(sigc::slot<void, string> callback)
+bool Firmwares::installFirmware(sigc::slot<void, std::string> callback)
 {
     exehandler = ecore_event_handler_add(ECORE_EXE_EVENT_DEL, exe_exit, this);
 
     cb_con_install.disconnect();
     cb_con_install = cb_signal_install.connect(callback);
 
-    string cmd = "/sbin/fw_update.sh";
+    std::string cmd = "/sbin/fw_update.sh";
 
     fwupdate_exe = ecore_exe_run(cmd.c_str(), NULL);
     if(!fwupdate_exe)

--- a/src/lib/Firmwares.h
+++ b/src/lib/Firmwares.h
@@ -28,27 +28,27 @@ class Firmwares
 {
 private:
     FileDownloader *fdownloader;
-    string cn_user, cn_pass;
-    string fw_version;
+    std::string cn_user, cn_pass;
+    std::string fw_version;
 
     bool download_in_progress;
 
     Ecore_Exe *fwupdate_exe;
     Ecore_Event_Handler *exehandler;
 
-    sigc::signal<void, string> cb_signal_check;
-    sigc::signal<void, string, FileProgress *> cb_signal_download;
-    sigc::signal<void, string> cb_signal_install;
+    sigc::signal<void, std::string> cb_signal_check;
+    sigc::signal<void, std::string, FileProgress *> cb_signal_download;
+    sigc::signal<void, std::string> cb_signal_install;
 
     sigc::connection cb_con_check;
     sigc::connection cb_con_download;
     sigc::connection cb_con_install;
 
-    void check_cb(string result, void *data);
-    void download_cb(string result, void *data);
+    void check_cb(std::string result, void *data);
+    void download_cb(std::string result, void *data);
 
 public:
-    Firmwares(string cn_user = "", string cn_pass = "", string fw_version = "");
+    Firmwares(std::string cn_user = "", std::string cn_pass = "", std::string fw_version = "");
     ~Firmwares();
 
     /* Check for an update for current user
@@ -57,19 +57,19 @@ public:
                  * no_update : system is up to date
                  * <version number> : system should be updated to <version number>
                  */
-    void checkUpdate(sigc::slot<void, string> callback);
+    void checkUpdate(sigc::slot<void, std::string> callback);
 
     /* download new firmware if a new one is available
                    callback will be called with progress info as in FileDownloader
                    return false if error (no new firmware available)
                 */
-    void downloadFirmware(sigc::slot<void, string, FileProgress *> callback);
+    void downloadFirmware(sigc::slot<void, std::string, FileProgress *> callback);
 
     /* install the new downloaded firmware
                    return false if error (firmware not downloaded)
                    callback will be called with progress info (if available)
                 */
-    bool installFirmware(sigc::slot<void, string> callback);
+    bool installFirmware(sigc::slot<void, std::string> callback);
 
     /* private don't use */
     void ExecutableEnded(Ecore_Exe_Event_Del *ev);

--- a/src/lib/IPC.cpp
+++ b/src/lib/IPC.cpp
@@ -57,7 +57,7 @@ IPC::~IPC()
     close(fd_write);
 }
 
-void IPC::AddHandler(string source, string emission, sigc::signal<void, std::string, std::string, void*, void*> &signal, void *data)
+void IPC::AddHandler(std::string source, std::string emission, sigc::signal<void, std::string, std::string, void*, void*> &signal, void *data)
 {
     IPCSignal s;
     s.source = source;
@@ -70,7 +70,7 @@ void IPC::AddHandler(string source, string emission, sigc::signal<void, std::str
 
 void IPC::DeleteHandler(sigc::signal<void, std::string, std::string, void*, void*> &signal)
 {
-    list<IPCSignal>::iterator it;
+    std::list<IPCSignal>::iterator it;
 
     for(it = signals.begin();it != signals.end();it++)
     {
@@ -82,7 +82,7 @@ void IPC::DeleteHandler(sigc::signal<void, std::string, std::string, void*, void
     }
 }
 
-void IPC::SendEvent(string source, string emission, void* data)
+void IPC::SendEvent(std::string source, std::string emission, void* data)
 {
     IPCMsg msg;
     msg.source = source;
@@ -102,7 +102,7 @@ void IPC::SendEvent(string source, string emission, void* data)
     //                 mutex2.unlock();
 
     //wake up the listener
-    string s = "wake_up";
+    std::string s = "wake_up";
     if (write(fd_write, s.c_str(), s.length()) < 0)
     {
         cErrorDom("ipc") << "Error writing to pipe !";
@@ -110,7 +110,7 @@ void IPC::SendEvent(string source, string emission, void* data)
     //         }
 }
 
-void IPC::SendEvent(string source, string emission, IPCData data, bool auto_delete_data)
+void IPC::SendEvent(std::string source, std::string emission, IPCData data, bool auto_delete_data)
 {
     IPCMsg msg;
     msg.source = source;
@@ -129,7 +129,7 @@ void IPC::SendEvent(string source, string emission, IPCData data, bool auto_dele
     //                 mutex2.unlock();
 
     //wake up the listener
-    string s = "wake_up";
+    std::string s = "wake_up";
     if (write(fd_write, s.c_str(), s.length()) < 0)
     {
         cErrorDom("ipc") << "Error writing to pipe !";
@@ -155,7 +155,7 @@ void IPC::BroadcastEvent()
                            Otherwise the events.begin iterator can become invalid
                            (if there is no element in the list)
                         */
-            list<IPCMsg>::iterator itd = events.begin();
+            std::list<IPCMsg>::iterator itd = events.begin();
             if(itd == events.end())
                 break;
             IPCMsg msg = (*itd);
@@ -164,7 +164,7 @@ void IPC::BroadcastEvent()
             cDebugDom("ipc") << "(\"" <<
                                 msg.source<<"\"  ,  \""<<msg.emission<< "\" , " << Utils::to_string(msg.data) << ")";
 
-            list<IPCSignal>::iterator it;
+            std::list<IPCSignal>::iterator it;
 
             mutex.unlock();
 
@@ -172,7 +172,7 @@ void IPC::BroadcastEvent()
             //sometimes the method call by signal->emit
             //   call deleteHandler on the current handler
             mutex.lock();
-            list<IPCSignal> signalsCopy = signals;
+            std::list<IPCSignal> signalsCopy = signals;
             mutex.unlock();
             for(it=signalsCopy.begin();it!=signalsCopy.end();it++)
             {

--- a/src/lib/IPC.h
+++ b/src/lib/IPC.h
@@ -26,7 +26,6 @@
 #include <sigc++/sigc++.h>
 #include <Ecore.h>
 
-using namespace Utils;
 
 //maximum string length for an event name
 #define MAX_EVENT_NAME          512
@@ -35,19 +34,19 @@ class IPCData
 {
 public:
     void *data;
-    DeletorBase *destroy;   //Delete fonction that know how to free data
+    Utils::DeletorBase *destroy;   //Delete fonction that know how to free data
 
     IPCData(): data(NULL), destroy(NULL)
     { }
-    IPCData(void *d, DeletorBase *del): data(d), destroy(del)
+    IPCData(void *d, Utils::DeletorBase *del): data(d), destroy(del)
     { }
 };
 
 class IPCMsg
 {
 public:
-    string source;
-    string emission;
+    std::string source;
+    std::string emission;
     void *data;
     bool auto_delete;       //If set, data will be auto deleted after use
     IPCData del_data;
@@ -59,10 +58,10 @@ public:
 class IPCSignal
 {
 public:
-    string source;
-    string emission;
+    std::string source;
+    std::string emission;
     void *data;
-    sigc::signal<void, string, string, void*, void* > *signal;
+    sigc::signal<void, std::string, std::string, void*, void* > *signal;
 };
 
 /**
@@ -77,8 +76,8 @@ private:
     Ecore_Fd_Handler *fd_handler;
     Mutex mutex;
 
-    list<IPCMsg> events;
-    list<IPCSignal> signals;
+    std::list<IPCMsg> events;
+    std::list<IPCSignal> signals;
 
     //ctor
     IPC();
@@ -101,16 +100,16 @@ public:
                  *  - void*: the data of the listener (you)
                  *  - void*: the data of the signal sender
                  */
-    void AddHandler(string source, string emission,
-                    sigc::signal<void, string, string, void*, void*> &signal,
+    void AddHandler(std::string source, std::string emission,
+                    sigc::signal<void, std::string, std::string, void*, void*> &signal,
                     void* data = NULL);
-    void DeleteHandler(sigc::signal<void, string, string, void*, void*> &signal);
+    void DeleteHandler(sigc::signal<void, std::string, std::string, void*, void*> &signal);
 
     //used by threads.
-    void SendEvent(string source, string emission, void *data = NULL);
+    void SendEvent(std::string source, std::string emission, void *data = NULL);
 
     //auto_delete_data flag is used to delete void *data automatically after use
-    void SendEvent(string source, string emission, IPCData data, bool auto_delete_data = false);
+    void SendEvent(std::string source, std::string emission, IPCData data, bool auto_delete_data = false);
 
     //called by _calaos_ipc_event()
     void BroadcastEvent();

--- a/src/lib/Jansson_Addition.h
+++ b/src/lib/Jansson_Addition.h
@@ -97,7 +97,7 @@ inline void jansson_decode_object(json_t *jroot, Params &params)
 
     json_object_foreach(jroot, key, value)
     {
-        string svalue;
+        std::string svalue;
 
         if (json_is_string(value))
             svalue = json_string_value(value);
@@ -110,18 +110,18 @@ inline void jansson_decode_object(json_t *jroot, Params &params)
     }
 }
 
-inline string jansson_to_string(json_t *jroot)
+inline std::string jansson_to_string(json_t *jroot)
 {
     char *d = json_dumps(jroot, JSON_COMPACT | JSON_ENSURE_ASCII /*| JSON_ESCAPE_SLASH*/);
     if (!d)
     {
         cError() << "json_dumps failed!";
         json_decref(jroot);
-        return string();
+        return std::string();
     }
 
     json_decref(jroot);
-    string res(d);
+    std::string res(d);
     free(d);
 
     return res;

--- a/src/lib/NTPClock.cpp
+++ b/src/lib/NTPClock.cpp
@@ -21,7 +21,6 @@
 
 #include <NTPClock.h>
 
-using namespace std;
 
 static Eina_Bool _NTPHandle1(void *data, int type, void *event)
 {
@@ -75,7 +74,7 @@ void NTPClock::updateClock()
         handler = ecore_event_handler_add(ECORE_EXE_EVENT_DEL, _NTPHandle1, this);
         cInfo() <<  "NTPClock::updateClock() Updating clock...";
 
-        string cmd = "/usr/sbin/ntpdate calaos.fr";
+        std::string cmd = "/usr/sbin/ntpdate calaos.fr";
 
         exe = ecore_exe_run(cmd.c_str(), NULL);
     }
@@ -110,7 +109,7 @@ void NTPClock::TimerTick()
     timer = new EcoreTimer(60 * 60 * 12, (sigc::slot<void>)sigc::mem_fun(*this, &NTPClock::TimerTick));
 }
 
-void NTPClock::applyCalendarFromServer(string source, string s,
+void NTPClock::applyCalendarFromServer(std::string source, std::string s,
                                        void *listener_data, void* sender_data)
 {
     if (networkCmdCalendarApply[2] == "ntp_on")
@@ -119,7 +118,7 @@ void NTPClock::applyCalendarFromServer(string source, string s,
         enable(true);
 
         int timeZone;
-        istringstream iss(networkCmdCalendarApply[3]);
+        std::istringstream iss(networkCmdCalendarApply[3]);
         iss >> timeZone;
 
         cApply.timeZone.current = timeZone;
@@ -134,41 +133,41 @@ void NTPClock::applyCalendarFromServer(string source, string s,
 
         {
             int i;
-            istringstream iss(networkCmdCalendarApply[3]);
+            std::istringstream iss(networkCmdCalendarApply[3]);
             iss >> i;
             cApply.setHours(i);
         }
 
         {
             int i;
-            istringstream iss(networkCmdCalendarApply[4]);
+            std::istringstream iss(networkCmdCalendarApply[4]);
             iss >> i;
             cApply.setMinutes(i);
         }
 
         {
             int i;
-            istringstream iss(networkCmdCalendarApply[5]);
+            std::istringstream iss(networkCmdCalendarApply[5]);
             iss >> i;
             cApply.setSecondes(i);
         }
         {
             int i;
-            istringstream iss(networkCmdCalendarApply[6]);
+            std::istringstream iss(networkCmdCalendarApply[6]);
             iss >> i;
             cApply.setDay(i);
         }
 
         {
             int i;
-            istringstream iss(networkCmdCalendarApply[7]);
+            std::istringstream iss(networkCmdCalendarApply[7]);
             iss >> i;
             cApply.setMonth(i);
         }
 
         {
             int i;
-            istringstream iss(networkCmdCalendarApply[8]);
+            std::istringstream iss(networkCmdCalendarApply[8]);
             iss >> i;
             cApply.setYear(i);
         }
@@ -176,14 +175,14 @@ void NTPClock::applyCalendarFromServer(string source, string s,
     }
 }
 
-void NTPClock::setNetworkCmdCalendarApply(vector < string > s)
+void NTPClock::setNetworkCmdCalendarApply(std::vector<std::string> s)
 {
     networkCmdCalendarApply = s;
 }
 
 void NTPClock::Handle1()
 {
-    string cmd = "/sbin/hwclock --systohc";
+    std::string cmd = "/sbin/hwclock --systohc";
 
     ecore_event_handler_del(handler);
     handler = ecore_event_handler_add(ECORE_EXE_EVENT_DEL, _NTPHandle2, this);

--- a/src/lib/NTPClock.h
+++ b/src/lib/NTPClock.h
@@ -47,11 +47,11 @@ private:
     /**
                  * signal called by the signal 'applyDate'
                  */
-    sigc::signal<void, string, string, void*, void*> sig_applyCalendar;
+    sigc::signal<void, std::string, std::string, void*, void*> sig_applyCalendar;
     /** the command from the server
                  * something as "system date ntp_on"
                  */
-    vector<string> networkCmdCalendarApply;
+    std::vector<std::string> networkCmdCalendarApply;
     /**
                  * Calendar use to apply a manual date (no ntp)
                  */
@@ -91,12 +91,12 @@ public:
                  *   from the main thread instead of the udp server thread
                  *   ( we use some ecore_* methods to apply the date )
                  */
-    void applyCalendarFromServer(string source,string emission,
+    void applyCalendarFromServer(std::string source,std::string emission,
                                  void* listener_data, void* sender_data);
     /**
                  * See applyCalendarFromServer()
                  */
-    void setNetworkCmdCalendarApply(vector<string> s);
+    void setNetworkCmdCalendarApply(std::vector<std::string> s);
 
     void setRestartWhenApply(bool s);
     bool isRestartWhenApply();

--- a/src/lib/Params.cpp
+++ b/src/lib/Params.cpp
@@ -21,45 +21,44 @@
 #include <Params.h>
 #include <sstream>
 
-using namespace std;
 
-void Params::Add(string key, string value)
+void Params::Add(std::string key, std::string value)
 {
     params[key] = value;
 }
 
-bool Params::Exists(string key) const
+bool Params::Exists(std::string key) const
 {
-    map<string, string>::const_iterator fter = params.find(key);
+    std::map<std::string, std::string>::const_iterator fter = params.find(key);
     if (fter != params.cend())
         return true;
     return false;
 }
 
-string Params::get_param(string key)
+std::string Params::get_param(std::string key)
 {
     if (Exists(key))
         return params[key];
     return "";
 }
 
-string Params::get_param_const(const string key) const
+std::string Params::get_param_const(const std::string key) const
 {
-    map<string, string>::const_iterator fter = params.find(key);
+    std::map<std::string, std::string>::const_iterator fter = params.find(key);
     if (fter != params.cend())
         return fter->second;
 
     return "";
 }
 
-string Params::operator[] (string key) const
+std::string Params::operator[] (std::string key) const
 {
     return get_param_const(key);
 }
 
-void Params::get_item(int i, string &key, string &value) const
+void Params::get_item(int i, std::string &key, std::string &value) const
 {
-    map<string, string>::const_iterator iter;
+    std::map<std::string, std::string>::const_iterator iter;
     for (iter = params.cbegin();iter != params.cend();iter++,i--)
     {
         if (i == 0)
@@ -71,7 +70,7 @@ void Params::get_item(int i, string &key, string &value) const
     }
 }
 
-void Params::Parse(string str)
+void Params::Parse(std::string str)
 {
     int count = 0;
     unsigned int i = 0;
@@ -80,8 +79,8 @@ void Params::Parse(string str)
     {
         if (isspace(str[i]))
         {
-            string sid, val = str.substr(0, i);
-            stringstream id;
+            std::string sid, val = str.substr(0, i);
+            std::stringstream id;
             id << count;
             sid = id.str();
             Add(sid, val);
@@ -103,8 +102,8 @@ void Params::Parse(string str)
             i++;
             if (i >= str.length())
             {
-                stringstream id;
-                string sid;
+                std::stringstream id;
+                std::string sid;
                 id << count;
                 sid = id.str();
                 Add(sid, str);
@@ -114,11 +113,11 @@ void Params::Parse(string str)
     }
 }
 
-string Params::toString() const
+std::string Params::toString() const
 {
-    string ret, key, value;
+    std::string ret, key, value;
 
-    map<string, string>::const_iterator iter;
+    std::map<std::string, std::string>::const_iterator iter;
     ret = "Params::toString():\n";
     for (iter = params.cbegin();iter != params.cend();iter++)
     {

--- a/src/lib/Params.h
+++ b/src/lib/Params.h
@@ -25,12 +25,10 @@
 #include <map>
 #include <jansson.h>
 
-using namespace std;
-
 class Params
 {
 protected:
-    std::map<string, string> params;
+    std::map<std::string, std::string> params;
 
 public:
     Params()
@@ -39,7 +37,7 @@ public:
     /* C++11 initializer_list constructor. This allows to do:
      * Params p = { {"key", "val"}, {"key2", "val2"} };
      */
-    typedef std::pair<const string, string> param_value_type;
+    typedef std::pair<const std::string, std::string> param_value_type;
     Params(std::initializer_list<param_value_type> il)
     {
         clear();
@@ -49,19 +47,19 @@ public:
     ~Params()
     { }
 
-    void Add(string key, string value);
+    void Add(std::string key, std::string value);
     int size() const { return params.size(); }
-    bool Exists(string key) const;
-    string get_param(string key);
-    string get_param_const(const string key) const;
-    void get_item(int i, string &key, string &value) const;
+    bool Exists(std::string key) const;
+    std::string get_param(std::string key);
+    std::string get_param_const(const std::string key) const;
+    void get_item(int i, std::string &key, std::string &value) const;
     void Delete(std::string key) { params.erase(key); }
 
-    string operator[] (string key) const;
+    std::string operator[] (std::string key) const;
 
-    void Parse(string str);
+    void Parse(std::string str);
 
-    string toString() const;
+    std::string toString() const;
     json_t *toJson() const;
 
     void clear() { params.clear(); }

--- a/src/lib/Prefix.cpp
+++ b/src/lib/Prefix.cpp
@@ -44,7 +44,7 @@ Prefix::~Prefix()
         eina_prefix_free(pfx);
 }
 
-string Prefix::binDirectoryGet()
+std::string Prefix::binDirectoryGet()
 { 
     const char *str = eina_prefix_bin_get(pfx); 
     // test returned string to avoir exception
@@ -53,7 +53,7 @@ string Prefix::binDirectoryGet()
     else return "";
 }
 
-string Prefix::libDirectoryGet()
+std::string Prefix::libDirectoryGet()
 {
     const char *str = eina_prefix_lib_get(pfx); 
     // test returned string to avoir exception
@@ -62,7 +62,7 @@ string Prefix::libDirectoryGet()
     else return "";
 }
 
-string Prefix::dataDirectoryGet()
+std::string Prefix::dataDirectoryGet()
 {
     const char *str = eina_prefix_data_get(pfx); 
     // test returned string to avoir exception
@@ -71,7 +71,7 @@ string Prefix::dataDirectoryGet()
     else return "";
 }
 
-string Prefix::localeDirectoryGet()
+std::string Prefix::localeDirectoryGet()
 {
     const char *str = eina_prefix_locale_get(pfx); 
     // test returned string to avoir exception

--- a/src/lib/Prefix.h
+++ b/src/lib/Prefix.h
@@ -49,10 +49,10 @@ public:
 
     ~Prefix();
 
-    string binDirectoryGet();
-    string libDirectoryGet();
-    string dataDirectoryGet();
-    string localeDirectoryGet();
+    std::string binDirectoryGet();
+    std::string libDirectoryGet();
+    std::string dataDirectoryGet();
+    std::string localeDirectoryGet();
 
 private:
     Eina_Prefix *pfx;

--- a/src/lib/TimeRange.cpp
+++ b/src/lib/TimeRange.cpp
@@ -29,26 +29,26 @@ TimeRange::TimeRange():
 {
 }
 
-TimeRange::TimeRange(string proto):
+TimeRange::TimeRange(std::string proto):
     shour("0"), smin("0"), ssec("0"),
     ehour("0"), emin("0"), esec("0")
 {
-    vector<string> tokens;
-    split(proto, tokens, ":", 11);
+    std::vector<std::string> tokens;
+    Utils::split(proto, tokens, ":", 11);
 
     shour = tokens[1];
     smin = tokens[2];
     ssec = tokens[3];
-    from_string(tokens[4], start_type);
-    from_string(tokens[5], start_offset);
+    Utils::from_string(tokens[4], start_type);
+    Utils::from_string(tokens[5], start_offset);
     if (start_offset < 0) start_offset = -1;
     if (start_offset >= 0) start_offset = 1;
 
     ehour = tokens[6];
     emin = tokens[7];
     esec = tokens[8];
-    from_string(tokens[9], end_type);
-    from_string(tokens[10], end_offset);
+    Utils::from_string(tokens[9], end_type);
+    Utils::from_string(tokens[10], end_offset);
     if (end_offset < 0) end_offset = -1;
     if (end_offset >= 0) end_offset = 1;
 }
@@ -58,16 +58,16 @@ TimeRange::TimeRange(const Params &p)
     shour = p["start_hour"];
     smin = p["start_min"];
     ssec = p["start_sec"];
-    from_string(p["start_type"], start_type);
-    from_string(p["start_offset"], start_offset);
+    Utils::from_string(p["start_type"], start_type);
+    Utils::from_string(p["start_offset"], start_offset);
     if (start_offset < 0) start_offset = -1;
     if (start_offset >= 0) start_offset = 1;
 
     ehour = p["end_hour"];
     emin = p["end_min"];
     esec = p["end_sec"];
-    from_string(p["end_type"], end_type);
-    from_string(p["end_offset"], end_offset);
+    Utils::from_string(p["end_type"], end_type);
+    Utils::from_string(p["end_offset"], end_offset);
     if (end_offset < 0) end_offset = -1;
     if (end_offset >= 0) end_offset = 1;
 }
@@ -98,9 +98,9 @@ long TimeRange::getStartTimeSec(int year, int month, int day)
     if (start_type == HTYPE_NORMAL)
     {
         int h, m, s;
-        from_string(shour, h);
-        from_string(smin, m);
-        from_string(ssec, s);
+        Utils::from_string(shour, h);
+        Utils::from_string(smin, m);
+        Utils::from_string(ssec, s);
         v = h * 3600 + m * 60 + s;
     }
     else if (start_type == HTYPE_SUNRISE ||
@@ -123,9 +123,9 @@ long TimeRange::getStartTimeSec(int year, int month, int day)
         {
             //there is an offset
             int h, m, s;
-            from_string(shour, h);
-            from_string(smin, m);
-            from_string(ssec, s);
+            Utils::from_string(shour, h);
+            Utils::from_string(smin, m);
+            Utils::from_string(ssec, s);
             v = v + start_offset * (h * 3600 + m * 60 + s);
         }
     }
@@ -140,9 +140,9 @@ long TimeRange::getEndTimeSec(int year, int month, int day)
     if (end_type == HTYPE_NORMAL)
     {
         int h, m, s;
-        from_string(ehour, h);
-        from_string(emin, m);
-        from_string(esec, s);
+        Utils::from_string(ehour, h);
+        Utils::from_string(emin, m);
+        Utils::from_string(esec, s);
         v = h * 3600 + m * 60 + s;
     }
     else if (end_type == HTYPE_SUNRISE ||
@@ -165,9 +165,9 @@ long TimeRange::getEndTimeSec(int year, int month, int day)
         {
             //there is an offset
             int h, m, s;
-            from_string(ehour, h);
-            from_string(emin, m);
-            from_string(esec, s);
+            Utils::from_string(ehour, h);
+            Utils::from_string(emin, m);
+            Utils::from_string(esec, s);
             v = v + end_offset * (h * 3600 + m * 60 + s);
         }
     }
@@ -245,7 +245,7 @@ void TimeRange::computeSunSetRise(int year, int month, int day,
     double latitude;
     Params opt;
 
-    get_config_options(opt);
+    Utils::get_config_options(opt);
     if (!opt.Exists("longitude") || !opt.Exists("latitude"))
     {
         longitude = 2.548828;
@@ -256,8 +256,8 @@ void TimeRange::computeSunSetRise(int year, int month, int day,
     }
     else
     {
-        from_string(get_config_option("longitude"), longitude);
-        from_string(get_config_option("latitude"), latitude);
+        Utils::from_string(Utils::get_config_option("longitude"), longitude);
+        Utils::from_string(Utils::get_config_option("latitude"), latitude);
     }
 
     double rise, set;
@@ -333,9 +333,9 @@ bool TimeRange::isSameStartEnd()
     return start == end;
 }
 
-string TimeRange::toProtoCommand(int day) const
+std::string TimeRange::toProtoCommand(int day) const
 {
-    string s = Utils::to_string(day + 1) + ":";
+    std::string s = Utils::to_string(day + 1) + ":";
     s += shour + ":" + smin + ":" + ssec;
     s += ":" + Utils::to_string(start_type);
     s += ":" + Utils::to_string(start_offset); //1 or -1
@@ -366,9 +366,9 @@ Params TimeRange::toParams(int day) const
     return p;
 }
 
-string TimeRange::toString()
+std::string TimeRange::toString()
 {
-    stringstream str;
+    std::stringstream str;
 
     struct tm *ctime = NULL;
     tzset(); //Force reload of timezone data
@@ -380,7 +380,7 @@ string TimeRange::toString()
 
     if (start_type == HTYPE_NORMAL)
     {
-        str << "[Start: normal] (" << time2string_digit(start) << ") ===> ";
+        str << "[Start: normal] (" << Utils::time2string_digit(start) << ") ===> ";
     }
     else
     {
@@ -388,7 +388,7 @@ string TimeRange::toString()
         if (start_type == HTYPE_SUNSET) str << "[Start: sunset] ";
         if (start_type == HTYPE_NOON) str << "[Start: noon] ";
 
-        str << "(" << time2string_digit(start) << ") ";
+        str << "(" << Utils::time2string_digit(start) << ") ";
 
         if (shour != "0" || smin != "0" || ssec != "0")
         {
@@ -404,7 +404,7 @@ string TimeRange::toString()
 
     if (end_type == HTYPE_NORMAL)
     {
-        str << "[End: normal] (" << time2string_digit(end) << ")";
+        str << "[End: normal] (" << Utils::time2string_digit(end) << ")";
     }
     else
     {
@@ -412,7 +412,7 @@ string TimeRange::toString()
         if (end_type == HTYPE_SUNSET) str << "[End: sunset] ";
         if (end_type == HTYPE_NOON) str << "[End: noon] ";
 
-        str << "(" << time2string_digit(end) << ") ";
+        str << "(" << Utils::time2string_digit(end) << ") ";
 
         if (ehour != "0" || emin != "0" || esec != "0")
         {

--- a/src/lib/TimeRange.h
+++ b/src/lib/TimeRange.h
@@ -21,7 +21,6 @@
 
 #include <Utils.h>
 
-using namespace Utils;
 
 class TimeRange
 {
@@ -56,11 +55,11 @@ public:
     int start_offset = 1; //should be 1 or -1
     int end_offset = 1; //should be 1 or -1
 
-    string shour, smin, ssec;
-    string ehour, emin, esec;
+    std::string shour, smin, ssec;
+    std::string ehour, emin, esec;
 
     TimeRange();
-    TimeRange(string proto);
+    TimeRange(std::string proto);
     TimeRange(const Params &p);
 
     long getStartTimeSec(int year, int month, int day);
@@ -72,10 +71,10 @@ public:
 
     bool isSameStartEnd();
 
-    string toProtoCommand(int day) const;
+    std::string toProtoCommand(int day) const;
     Params toParams(int day) const;
-    string toString();
+    std::string toString();
 
     //flag to ease the loading in UI
-    bitset<7> dayOfWeek;
+    std::bitset<7> dayOfWeek;
 };

--- a/src/lib/UrlDownloader.cpp
+++ b/src/lib/UrlDownloader.cpp
@@ -62,7 +62,7 @@ Eina_Bool _progress_cb(void *data, int type, void *event)
     return ECORE_CALLBACK_RENEW;
 }
 
-UrlDownloader::UrlDownloader(string url, bool autodelete) :
+UrlDownloader::UrlDownloader(std::string url, bool autodelete) :
     m_url(url),
     m_autodelete(autodelete)
 {
@@ -183,7 +183,7 @@ bool UrlDownloader::start()
     return true;
 }
 
-bool UrlDownloader::httpPost(string destination, string bodyData)
+bool UrlDownloader::httpPost(std::string destination, std::string bodyData)
 {
     if (!destination.empty())
         destinationSet(destination);
@@ -193,7 +193,7 @@ bool UrlDownloader::httpPost(string destination, string bodyData)
     return start();
 }
 
-bool UrlDownloader::httpGet(string destination, string bodyData)
+bool UrlDownloader::httpGet(std::string destination, std::string bodyData)
 {
     if (!destination.empty())
         destinationSet(destination);
@@ -203,7 +203,7 @@ bool UrlDownloader::httpGet(string destination, string bodyData)
     return start();
 }
 
-bool UrlDownloader::httpPut(string destination, string bodyData)
+bool UrlDownloader::httpPut(std::string destination, std::string bodyData)
 {
     if (!destination.empty())
         destinationSet(destination);
@@ -213,7 +213,7 @@ bool UrlDownloader::httpPut(string destination, string bodyData)
     return start();
 }
 
-bool UrlDownloader::httpDelete(string destination, string bodyData)
+bool UrlDownloader::httpDelete(std::string destination, std::string bodyData)
 {
     if (!destination.empty())
         destinationSet(destination);
@@ -267,7 +267,7 @@ Params UrlDownloader::getResponseHeaders()
     EINA_LIST_FOREACH(h, l, d)
     {
         str = (char *)d;
-        vector<string> t;
+        std::vector<std::string> t;
         Utils::split(str, t, ":", 2);
         if (Utils::trim(t[0]) != "" &&
             !Utils::strStartsWith(Utils::trim(t[0]), "HTTP/"))

--- a/src/lib/UrlDownloader.h
+++ b/src/lib/UrlDownloader.h
@@ -37,8 +37,8 @@ private:
     RequestType m_requestType = HTTP_POST;
 
     bool m_auth = false;
-    string m_user;
-    string m_password;
+    std::string m_user;
+    std::string m_password;
 
     // EcoreCon events handlers
     Ecore_Event_Handler *m_completeHandler;
@@ -53,13 +53,13 @@ private:
     // fd of the file when a fd is given
     int m_fd = -1;
     // Url to contact
-    string m_url = "";
+    std::string m_url = "";
     // Destination where to store the result
-    string m_destination = "";
+    std::string m_destination = "";
     // Message Body
-    string m_bodyData = "";
+    std::string m_bodyData = "";
     // Content type to be send
-    string m_postContentType = "";
+    std::string m_postContentType = "";
 
     //Common function for starting download of url
     bool start();
@@ -79,22 +79,22 @@ public:
     Eina_Binbuf *m_downloadedData = NULL;
 
     // Constructor
-    UrlDownloader(string url, bool autodelete = false);
+    UrlDownloader(std::string url, bool autodelete = false);
 
     // Setter for private members
-    void bodyDataSet(string bodyData) {m_bodyData = bodyData;}
-    void postContentTypeSet(string postContentType) {m_postContentType = postContentType;}
-    void destinationSet(string destination) {m_destination = destination;}
-    void authSet(string user, string password) {m_user = user; m_password = password; m_auth = true;}
+    void bodyDataSet(std::string bodyData) {m_bodyData = bodyData;}
+    void postContentTypeSet(std::string postContentType) {m_postContentType = postContentType;}
+    void destinationSet(std::string destination) {m_destination = destination;}
+    void authSet(std::string user, std::string password) {m_user = user; m_password = password; m_auth = true;}
     void authUnSet() {m_auth = false;}
     void fdSet(int fd) {m_fd = fd;}
 
     Params getResponseHeaders();
 
-    bool httpDelete(string destination = "", string bodyData = "");
-    bool httpGet(string destination = "", string bodyData = "");
-    bool httpPost(string destination = "", string bodyData = "");
-    bool httpPut(string destination = "", string bodyData = "");
+    bool httpDelete(std::string destination = "", std::string bodyData = "");
+    bool httpGet(std::string destination = "", std::string bodyData = "");
+    bool httpPost(std::string destination = "", std::string bodyData = "");
+    bool httpPut(std::string destination = "", std::string bodyData = "");
 
     ~UrlDownloader();
 

--- a/src/lib/Utils.cpp
+++ b/src/lib/Utils.cpp
@@ -23,7 +23,6 @@
 #include <Ecore_File.h>
 #include <tcpsocket.h>
 
-using namespace Utils;
 
 bool Utils::file_copy(std::string source, std::string dest)
 {
@@ -67,9 +66,9 @@ bool Utils::fileExists(std::string filename)
     return false;
 }
 
-string Utils::url_encode(string str)
+std::string Utils::url_encode(std::string str)
 {
-    string ret = "";
+    std::string ret = "";
     char tmp[10];
 
     for (uint i = 0;i < str.length();i++)
@@ -90,9 +89,9 @@ string Utils::url_encode(string str)
     return ret;
 }
 
-string Utils::url_decode(string str)
+std::string Utils::url_decode(std::string str)
 {
-    string ret = "";
+    std::string ret = "";
 
     for (uint i = 0;i < str.length();i++)
     {
@@ -123,7 +122,7 @@ std::string Utils::Base64_decode(std::string &str)
 
 std::string Utils::Base64_decode_data(std::string &str)
 {
-    string ret = base64_decode(str);
+    std::string ret = base64_decode(str);
 
     return ret;
 }
@@ -162,7 +161,7 @@ int Utils::htoi(char *s)
     return (value);
 }
 
-string Utils::time2string(long s, long ms)
+std::string Utils::time2string(long s, long ms)
 {
     double sec = s;
     int hours = (int)(sec / 3600.0);
@@ -170,7 +169,7 @@ string Utils::time2string(long s, long ms)
     int min = (int)(sec / 60.0);
     sec -= min * 60;
 
-    stringstream str;
+    std::stringstream str;
 
     if (hours == 1)
         str << hours << " " << "heure" << " ";
@@ -196,7 +195,7 @@ string Utils::time2string(long s, long ms)
     return str.str();
 }
 
-string Utils::time2string_digit(long s, long ms)
+std::string Utils::time2string_digit(long s, long ms)
 {
     double sec = s;
     int hours = (int)(sec / 3600.0);
@@ -204,34 +203,34 @@ string Utils::time2string_digit(long s, long ms)
     int min = (int)(sec / 60.0);
     sec -= min * 60;
 
-    stringstream str;
+    std::stringstream str;
 
     if (hours > 0)
-        str << setw(2) << setfill('0') << hours << ":";
+        str << std::setw(2) << std::setfill('0') << hours << ":";
 
-    str << setw(2) << setfill('0') << min << ":";
-    str << setw(2) << setfill('0') << sec;
+    str << std::setw(2) << std::setfill('0') << min << ":";
+    str << std::setw(2) << std::setfill('0') << sec;
 
     if (ms > 0)
-        str << "." << setw(4) << setfill('0') << ms;
+        str << "." << std::setw(4) << std::setfill('0') << ms;
 
     return str.str();
 }
 
-void Utils::split(const string &str, vector<string> &tokens, const string &delimiters, int max /* = 0 */)
+void Utils::split(const std::string &str, std::vector<std::string> &tokens, const std::string &delimiters, int max /* = 0 */)
 {
     // Skip delimiters at beginning.
-    string::size_type lastPos = str.find_first_not_of(delimiters, 0);
+    std::string::size_type lastPos = str.find_first_not_of(delimiters, 0);
     // Find first "non-delimiter".
-    string::size_type pos     = str.find_first_of(delimiters, lastPos);
+    std::string::size_type pos     = str.find_first_of(delimiters, lastPos);
 
     int counter = 0;
 
-    while (string::npos != pos || string::npos != lastPos)
+    while (std::string::npos != pos || std::string::npos != lastPos)
     {
         if (counter + 1 >= max && max > 0)
         {
-            tokens.push_back(str.substr(lastPos, string::npos));
+            tokens.push_back(str.substr(lastPos, std::string::npos));
             break;
         }
 
@@ -248,14 +247,14 @@ void Utils::split(const string &str, vector<string> &tokens, const string &delim
     while (tokens.size() < (uint)max) tokens.push_back("");
 }
 
-void Utils::remove_tag(string &html, const string begin_tag, const string end_tag)
+void Utils::remove_tag(std::string &html, const std::string begin_tag, const std::string end_tag)
 {
-    string::size_type start_pos = html.find(begin_tag, 0);
+    std::string::size_type start_pos = html.find(begin_tag, 0);
 
-    while (start_pos != string::npos)
+    while (start_pos != std::string::npos)
     {
-        string::size_type end_pos = html.find(end_tag, start_pos);
-        if (end_pos == string::npos)
+        std::string::size_type end_pos = html.find(end_tag, start_pos);
+        if (end_pos == std::string::npos)
         {
             break;
         }
@@ -268,10 +267,10 @@ void Utils::remove_tag(string &html, const string begin_tag, const string end_ta
     }
 }
 
-void Utils::replace_str(string &source, const string searchstr, const string replacestr)
+void Utils::replace_str(std::string &source, const std::string searchstr, const std::string replacestr)
 {
-    string::size_type pos = 0;
-    while((pos = source.find(searchstr, pos)) != string::npos)
+    std::string::size_type pos = 0;
+    while((pos = source.find(searchstr, pos)) != std::string::npos)
     {
         source.erase(pos, searchstr.length());
         source.insert(pos, replacestr);
@@ -295,7 +294,7 @@ double Utils::roundValue(double value, int precision)
     return (double)round(value * tmp) / tmp;
 }
 
-bool Utils::strContains(const string &str, const string &needle, CaseSensitivity cs)
+bool Utils::strContains(const std::string &str, const std::string &needle, CaseSensitivity cs)
 {
     if (needle.empty())
         return true;
@@ -306,11 +305,11 @@ bool Utils::strContains(const string &str, const string &needle, CaseSensitivity
     if (cs == Utils::CaseSensitive)
         return str.find(needle) != std::string::npos;
 
-    string s = str;
+    std::string s = str;
     return str_to_lower(s).find(str_to_lower(needle)) != std::string::npos;
 }
 
-bool Utils::strStartsWith(const string &str, const string &needle, Utils::CaseSensitivity cs)
+bool Utils::strStartsWith(const std::string &str, const std::string &needle, Utils::CaseSensitivity cs)
 {
     if (needle.empty())
         return true;
@@ -330,16 +329,16 @@ bool Utils::strStartsWith(const string &str, const string &needle, Utils::CaseSe
     return true;
 }
 
-void Utils::parseParamsItemList(string l, vector<Params> &res, int start_at)
+void Utils::parseParamsItemList(std::string l, std::vector<Params> &res, int start_at)
 {
-    vector<string> tokens;
+    std::vector<std::string> tokens;
     split(l, tokens);
     Params item;
 
     for (unsigned int i = start_at;i < tokens.size();i++)
     {
-        string tmp = tokens[i];
-        vector<string> tk;
+        std::string tmp = tokens[i];
+        std::vector<std::string> tk;
         split(tmp, tk, ":", 2);
 
         if (tk.size() != 2) continue;
@@ -359,7 +358,7 @@ void Utils::parseParamsItemList(string l, vector<Params> &res, int start_at)
 
 int CURL_write_callback(void *buffer, size_t size, size_t nmemb, void *stream)
 {
-    File_CURL *out = (File_CURL *)stream;
+    Utils::File_CURL *out = (Utils::File_CURL *)stream;
 
     if(out && !out->fp)
     {
@@ -374,7 +373,7 @@ int CURL_write_callback(void *buffer, size_t size, size_t nmemb, void *stream)
 
 int CURL_writebuf_callback(void *buffer, size_t size, size_t nmemb, void *stream)
 {
-    Buffer_CURL *cbuffer = (Buffer_CURL *)stream;
+    Utils::Buffer_CURL *cbuffer = (Utils::Buffer_CURL *)stream;
 
     cbuffer->buffer = realloc(cbuffer->buffer, cbuffer->bufsize + size * nmemb);
     memcpy((char *)cbuffer->buffer + cbuffer->bufsize, buffer, size * nmemb);
@@ -384,17 +383,21 @@ int CURL_writebuf_callback(void *buffer, size_t size, size_t nmemb, void *stream
     return nmemb;
 }
 
-static bool einaLogShuttingDown = false;
-static string default_domain;
-static std::unordered_map<std::string, EinaLog *> logger_hash;
-static EinaLog defaultCoutLogger(true);
+namespace {
 
-EinaLog *Utils::einaLogger(const char *domain)
+bool einaLogShuttingDown = false;
+std::string default_domain;
+std::unordered_map<std::string, efl::eina::log::EinaLog *> logger_hash;
+efl::eina::log::EinaLog defaultCoutLogger(true);
+
+}
+
+efl::eina::log::EinaLog *Utils::einaLogger(const char *domain)
 {
     if (einaLogShuttingDown)
         return &defaultCoutLogger;
 
-    string d = default_domain;
+    std::string d = default_domain;
     
     if (domain)
       d = domain;
@@ -406,11 +409,11 @@ EinaLog *Utils::einaLogger(const char *domain)
     if (!Utils::strStartsWith(d, "calaos_"))
         d.insert(0, "calaos_");
 
-    EinaLog *logger = nullptr;
+    efl::eina::log::EinaLog *logger = nullptr;
     auto it = logger_hash.find(d);
     if (it == logger_hash.end())
     {
-        logger = new EinaLog(d);
+        logger = new efl::eina::log::EinaLog(d);
         logger_hash[d] = logger;
     }
     else
@@ -432,7 +435,7 @@ void Utils::InitEinaLog(const char *d)
 
     eina_init();
     default_domain = d;
-    logger_hash[default_domain] = new EinaLog(default_domain);
+    logger_hash[default_domain] = new efl::eina::log::EinaLog(default_domain);
 }
 
 void Utils::FreeEinaLogs()
@@ -448,14 +451,18 @@ void Utils::FreeEinaLogs()
     einaLogShuttingDown = true;
 }
 
-static string _configBase;
-static string _cacheBase;
+namespace {
 
-string Utils::getConfigFile(const char *configType)
+std::string _configBase;
+std::string _cacheBase;
+
+}
+
+std::string Utils::getConfigFile(const char *configType)
 {
     if (_configBase.empty())
     {
-        string home;
+        std::string home;
         if (getenv("HOME"))
         {
             home = getenv("HOME");
@@ -466,7 +473,7 @@ string Utils::getConfigFile(const char *configType)
             home = pw->pw_dir;
         }
 
-        list<string> confDirs;
+        std::list<std::string> confDirs;
         confDirs.push_back(home + "/" + HOME_CONFIG_PATH);
         confDirs.push_back(ETC_CONFIG_PATH);
         confDirs.push_back(PREFIX_CONFIG_PATH);
@@ -477,10 +484,10 @@ string Utils::getConfigFile(const char *configType)
         // - pkg_prefix/etc/calaos
         // - create $HOME/.config/calaos/ if nothing found
 
-        list<string>::iterator it = confDirs.begin();
+        std::list<std::string>::iterator it = confDirs.begin();
         for (;it != confDirs.end();it++)
         {
-            string conf = *it;
+            std::string conf = *it;
             conf += "/" IO_CONFIG;
             if (ecore_file_exists(conf.c_str()))
             {
@@ -492,8 +499,8 @@ string Utils::getConfigFile(const char *configType)
         if (_configBase.empty())
         {
             //no config dir found, create $HOME/.config/calaos
-            ecore_file_mkdir(string(home + "/.config").c_str());
-            ecore_file_mkdir(string(home + "/.config/calaos").c_str());
+            ecore_file_mkdir(std::string(home + "/.config").c_str());
+            ecore_file_mkdir(std::string(home + "/.config/calaos").c_str());
             _configBase = home + "/" + HOME_CONFIG_PATH;
         }
     }
@@ -501,11 +508,11 @@ string Utils::getConfigFile(const char *configType)
     return _configBase + "/" + configType;
 }
 
-string Utils::getCacheFile(const char *cacheFile)
+std::string Utils::getCacheFile(const char *cacheFile)
 {
     if (_cacheBase.empty())
     {
-        string home;
+        std::string home;
         if (getenv("HOME"))
         {
             home = getenv("HOME");
@@ -517,8 +524,8 @@ string Utils::getCacheFile(const char *cacheFile)
         }
 
         //force the creation of .cache/calaos
-        ecore_file_mkdir(string(home + "/.cache").c_str());
-        ecore_file_mkdir(string(home + "/.cache/calaos").c_str());
+        ecore_file_mkdir(std::string(home + "/.cache").c_str());
+        ecore_file_mkdir(std::string(home + "/.cache/calaos").c_str());
 
         _cacheBase = home + "/.cache/calaos";
     }
@@ -531,7 +538,7 @@ void Utils::initConfigOptions(char *configdir, char *cachedir, bool quiet)
     if (configdir) _configBase = configdir;
     if (cachedir) _cacheBase = cachedir;
 
-    string file = getConfigFile(LOCAL_CONFIG);
+    std::string file = getConfigFile(LOCAL_CONFIG);
 
     if (!quiet)
     {
@@ -540,18 +547,18 @@ void Utils::initConfigOptions(char *configdir, char *cachedir, bool quiet)
     }
 
     if (!ecore_file_can_write(getConfigFile("").c_str()))
-        throw (runtime_error("config path is not writable"));
+        throw (std::runtime_error("config path is not writable"));
     if (!ecore_file_can_write(getCacheFile("").c_str()))
-        throw (runtime_error("cache path is not writable"));
+        throw (std::runtime_error("cache path is not writable"));
 
     if (!fileExists(file))
     {
         //create a defaut config
         std::ofstream conf(file.c_str(), std::ofstream::out);
-        conf << "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>" << endl;
-        conf << "<calaos:config xmlns:calaos=\"http://www.calaos.fr\">" << endl;
-        conf << "<calaos:option name=\"fw_version\" value=\"0\" />" << endl;
-        conf << "</calaos:config>" << endl;
+        conf << "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>" << std::endl;
+        conf << "<calaos:config xmlns:calaos=\"http://www.calaos.fr\">" << std::endl;
+        conf << "<calaos:option name=\"fw_version\" value=\"0\" />" << std::endl;
+        conf << "</calaos:config>" << std::endl;
         conf.close();
 
         set_config_option("fw_target", "calaos_tss");
@@ -567,13 +574,13 @@ void Utils::initConfigOptions(char *configdir, char *cachedir, bool quiet)
         set_config_option("latitude", "48.864715");
 
         if (!quiet)
-            cout << "WARNING: no local_config.xml found, generating default config with username: \"user\" and password: \"pass\"" << endl;
+            std::cout << "WARNING: no local_config.xml found, generating default config with username: \"user\" and password: \"pass\"" << std::endl;
     }
 }
 
-string Utils::get_config_option(string _key)
+std::string Utils::get_config_option(std::string _key)
 {
-    string value = "";
+    std::string value = "";
     TiXmlDocument document(getConfigFile(LOCAL_CONFIG).c_str());
 
     if (!document.LoadFile())
@@ -606,7 +613,7 @@ string Utils::get_config_option(string _key)
     return value;
 }
 
-bool Utils::set_config_option(string key, string value)
+bool Utils::set_config_option(std::string key, std::string value)
 {
     TiXmlDocument document(getConfigFile(LOCAL_CONFIG).c_str());
 
@@ -652,7 +659,7 @@ bool Utils::set_config_option(string key, string value)
     return true;
 }
 
-bool Utils::del_config_option(string key)
+bool Utils::del_config_option(std::string key)
 {
     TiXmlDocument document(getConfigFile(LOCAL_CONFIG).c_str());
 
@@ -752,14 +759,14 @@ char *Utils::argvOptionParam(char **begin, char **end, const std::string &option
 #define HWETH1 "eth0"
 #define HWETH2 "eth1"
 
-string Utils::getHardwareID()
+std::string Utils::getHardwareID()
 {
-    static string hwID;
+    static std::string hwID;
 
     if (!hwID.empty())
         return hwID;
 
-    stringstream ss;
+    std::stringstream ss;
 
     unsigned char hwmac1[6], hwmac2[6];
     if (!TCPSocket::GetMacAddr(HWETH1, hwmac1))
@@ -770,39 +777,39 @@ string Utils::getHardwareID()
 
     for (int i = 0;i < 6;i++)
     {
-        ss << setiosflags(ios_base::uppercase) << setfill('0')
-           << setw(2) << hex << (unsigned int)hwmac1[i];
-        ss << setiosflags(ios_base::uppercase) << setfill('0')
-           << setw(2) << hex << (unsigned int)hwmac2[i];
+        ss << setiosflags(std::ios_base::uppercase) << std::setfill('0')
+           << std::setw(2) << std::hex << (unsigned int)hwmac1[i];
+        ss << setiosflags(std::ios_base::uppercase) << std::setfill('0')
+           << std::setw(2) << std::hex << (unsigned int)hwmac2[i];
     }
     hwID = ss.str();
 
     return hwID;
 }
 
-string Utils::getFileContent(const char *filename)
+std::string Utils::getFileContent(const char *filename)
 {
-    ifstream ifs(filename, ios::in | ios::binary | ios::ate);
+    std::ifstream ifs(filename, std::ios::in | std::ios::binary | std::ios::ate);
     if (!ifs) return "";
 
-    ifstream::pos_type filesize = ifs.tellg();
-    ifs.seekg(0, ios::beg);
+    std::ifstream::pos_type filesize = ifs.tellg();
+    ifs.seekg(0, std::ios::beg);
 
-    vector<char> buff(filesize);
+    std::vector<char> buff(filesize);
     ifs.read(&buff[0], filesize);
 
-    return string(&buff[0], filesize);
+    return std::string(&buff[0], filesize);
 }
 
-string Utils::getFileContentBase64(const char *filename)
+std::string Utils::getFileContentBase64(const char *filename)
 {
-    ifstream ifs(filename, ios::in | ios::binary | ios::ate);
+    std::ifstream ifs(filename, std::ios::in | std::ios::binary | std::ios::ate);
     if (!ifs) return "";
 
-    ifstream::pos_type filesize = ifs.tellg();
-    ifs.seekg(0, ios::beg);
+    std::ifstream::pos_type filesize = ifs.tellg();
+    ifs.seekg(0, std::ios::beg);
 
-    vector<char> buff(filesize);
+    std::vector<char> buff(filesize);
     ifs.read(&buff[0], filesize);
 
     return Utils::Base64_encode(&buff[0], filesize);
@@ -832,12 +839,12 @@ unsigned int Utils::getUptime()
 #endif
 }
 
-string Utils::createRandomUuid()
+std::string Utils::createRandomUuid()
 {
     struct timeval t1;
     gettimeofday(&t1, NULL);
     srand(t1.tv_usec * t1.tv_sec); //use a more accurate seed for srand.
-    stringstream ssUuid;
+    std::stringstream ssUuid;
 
     ssUuid << std::hex << std::setfill('0') ;
     ssUuid << std::setw(4) << (rand() & 0xffff) << std::setw(4) << (rand() & 0xffff) << "-";
@@ -849,19 +856,19 @@ string Utils::createRandomUuid()
     return ssUuid.str();
 }
 
-string Utils::str_to_lower(std::string s)
+std::string Utils::str_to_lower(std::string s)
 {
      std::transform(s.begin(), s.end(), s.begin(), Utils::to_lower());
      return s;
 }
 
-string Utils::str_to_upper(std::string s)
+std::string Utils::str_to_upper(std::string s)
 {
      std::transform(s.begin(), s.end(), s.begin(), Utils::to_upper());
      return s;
 }
 
-string Utils::trim(const string &str)
+std::string Utils::trim(const std::string &str)
 {
     if (str.size() == 0)
         return str;
@@ -883,17 +890,17 @@ string Utils::trim(const string &str)
 
     len = end - start + 1;
     if (len <= 0)
-        return string();
+        return std::string();
 
-    return string(str, start, len);
+    return std::string(str, start, len);
 }
 
-string Utils::escape_quotes(const string &s)
+std::string Utils::escape_quotes(const std::string &s)
 {
-    string after;
+    std::string after;
     after.reserve(s.length() + 4);
 
-    for (string::size_type i = 0; i < s.length(); i++)
+    for (std::string::size_type i = 0; i < s.length(); i++)
     {
         switch (s[i])
         {

--- a/src/lib/Utils.h
+++ b/src/lib/Utils.h
@@ -84,8 +84,6 @@ using Json = nlohmann::json;
 #include <time.h>
 #endif
 
-using namespace efl::eina::log;
-
 #ifdef EAPI
 # undef EAPI
 #endif /* ifdef EAPI */
@@ -123,7 +121,6 @@ using namespace efl::eina::log;
 #endif
 
 //-----------------------------------------------------------------------------
-using namespace std;
 
 #ifndef uint
 typedef unsigned int uint;
@@ -208,51 +205,51 @@ namespace Utils
 {
 void InitEinaLog(const char *default_domain);
 void FreeEinaLogs();
-EinaLog *einaLogger(const char *domain = nullptr);
+efl::eina::log::EinaLog *einaLogger(const char *domain = nullptr);
 
 bool file_copy(std::string source, std::string dest);
 
 bool fileExists(std::string filename);
 
-string url_encode(string str);
-string url_decode(string str);
+std::string url_encode(std::string str);
+std::string url_decode(std::string str);
 std::string url_decode2(std::string str); //decode 2 times
 int htoi(char *s);
-string time2string(long s, long ms = 0);
-string time2string_digit(long s, long ms = 0);
+std::string time2string(long s, long ms = 0);
+std::string time2string_digit(long s, long ms = 0);
 
 /* usefull string utilities */
-void split(const string &str, vector<string> &tokens, const string &delimiters = " ", int max = 0);
-void remove_tag(string &source, const string begin_tag, const string end_tag);
-void replace_str(string &source, const string searchstr, const string replacestr);
+void split(const std::string &str, std::vector<std::string> &tokens, const std::string &delimiters = " ", int max = 0);
+void remove_tag(std::string &source, const std::string begin_tag, const std::string end_tag);
+void replace_str(std::string &source, const std::string searchstr, const std::string replacestr);
 void trim_right(std::string &source, const std::string &t);
 void trim_left(std::string &source, const std::string &t);
-string trim(const string &str);
-string escape_quotes(const string &s);
+std::string trim(const std::string &str);
+std::string escape_quotes(const std::string &s);
 
 enum CaseSensitivity { CaseInsensitive, CaseSensitive };
-bool strContains(const string &str, const string &needle, Utils::CaseSensitivity cs = Utils::CaseSensitive);
-bool strStartsWith(const string &str, const string &needle, Utils::CaseSensitivity cs = Utils::CaseSensitive);
+bool strContains(const std::string &str, const std::string &needle, Utils::CaseSensitivity cs = Utils::CaseSensitive);
+bool strStartsWith(const std::string &str, const std::string &needle, Utils::CaseSensitivity cs = Utils::CaseSensitive);
 
 // Return a value rounded to precision decimal after the dot
 double roundValue(double value, int precision);
 
 //Parse a result string into an array of Params.
-void parseParamsItemList(string l, vector<Params> &res, int start_at = 0);
+void parseParamsItemList(std::string l, std::vector<Params> &res, int start_at = 0);
 
 void initConfigOptions(char *configdir = NULL, char *cachedir = NULL, bool quiet = false);
 
-string getConfigFile(const char *configFile);
-string getCacheFile(const char *cacheFile);
+std::string getConfigFile(const char *configFile);
+std::string getCacheFile(const char *cacheFile);
 
-string get_config_option(string key);
-bool set_config_option(string key, string value);
-bool del_config_option(string key);
+std::string get_config_option(std::string key);
+bool set_config_option(std::string key, std::string value);
+bool del_config_option(std::string key);
 bool get_config_options(Params &options);
 void Watchdog(std::string fname);
-string getHardwareID();
+std::string getHardwareID();
 
-string createRandomUuid();
+std::string createRandomUuid();
 
 //Parse command line options
 bool argvOptionCheck(char **begin, char **end, const std::string &option);
@@ -265,8 +262,8 @@ std::string Base64_decode_data(std::string &str);
 std::string Base64_encode(std::string &str);
 std::string Base64_encode(void *data, int size);
 
-string getFileContent(const char *filename);
-string getFileContentBase64(const char *filename);
+std::string getFileContent(const char *filename);
+std::string getFileContentBase64(const char *filename);
 unsigned int getUptime();
 
 //-----------------------------------------------------------------------------

--- a/src/lib/WebSocketFrame.cpp
+++ b/src/lib/WebSocketFrame.cpp
@@ -82,7 +82,7 @@ void WebSocketFrame::checkValid()
         isvalid = true;
 }
 
-bool WebSocketFrame::processFrameData(string &data)
+bool WebSocketFrame::processFrameData(std::string &data)
 {
     bool finished = false;
 
@@ -277,11 +277,11 @@ void WebSocketFrame::processMask(char *p, uint64_t size, uint32_t maskingKey)
         *p++ ^= m[i++ % 4];
 }
 
-string WebSocketFrame::toString()
+std::string WebSocketFrame::toString()
 {
     if (!isValid()) return "Invalid frame";
 
-    stringstream s;
+    std::stringstream s;
     s << "Final:" << (isFinalFrame()?'1':'0')
       << " Control:" << (isControlFrame()?'1':'0')
       << " Continue:" << (isContinuationFrame()?'1':'0')
@@ -293,7 +293,7 @@ string WebSocketFrame::toString()
     return s.str();
 }
 
-void WebSocketFrame::parseCloseCodeReason(uint16_t &code, string &reason)
+void WebSocketFrame::parseCloseCodeReason(uint16_t &code, std::string &reason)
 {
     if (payload.size() == 1)
     {
@@ -306,9 +306,9 @@ void WebSocketFrame::parseCloseCodeReason(uint16_t &code, string &reason)
         reason = payload.substr(2);
 }
 
-string WebSocketFrame::makeFrame(int _opcode, const string &_payload, bool _lastframe, uint32_t maskingKey)
+std::string WebSocketFrame::makeFrame(int _opcode, const std::string &_payload, bool _lastframe, uint32_t maskingKey)
 {
-    string frame;
+    std::string frame;
 
     if (_payload.size() > 0x7FFFFFFFFFFFFFFFULL)
     {
@@ -360,7 +360,7 @@ string WebSocketFrame::makeFrame(int _opcode, const string &_payload, bool _last
 
     if (maskingKey != 0)
     {
-        string maskedPayload = _payload;
+        std::string maskedPayload = _payload;
         processMask((char *)maskedPayload.c_str(), maskedPayload.size(), maskingKey);
         frame.append(maskedPayload);
     }

--- a/src/lib/WebSocketFrame.h
+++ b/src/lib/WebSocketFrame.h
@@ -29,7 +29,7 @@ public:
     WebSocketFrame();
 
     int getCloseCode() const { return closeCode; }
-    string getCloseReason() const { return closeReason; }
+    std::string getCloseReason() const { return closeReason; }
     bool isFinalFrame() const { return finalFrame; }
     bool isControlFrame() const { return (opcode & 0x08) == 0x08; }
     bool isDataFrame() const { return !isControlFrame(); }
@@ -45,7 +45,7 @@ public:
     int getRsv2() const { return rsv2; }
     int getRsv3() const { return rsv3; }
     int getOpcode() const { return opcode; }
-    string getPayload() const { return payload; }
+    std::string getPayload() const { return payload; }
     bool isOpCodeReserved() { return ((opcode > OpCodeBinary) && (opcode < OpCodeClose)) || (opcode > OpCodePong); }
 
     void clear();
@@ -54,13 +54,13 @@ public:
 
     bool hasError() const { return haserror; }
 
-    bool processFrameData(string &data);
+    bool processFrameData(std::string &data);
 
-    string toString();
+    std::string toString();
 
-    void parseCloseCodeReason(uint16_t &code, string &reason);
+    void parseCloseCodeReason(uint16_t &code, std::string &reason);
 
-    static string makeFrame(int opcode, const string &payload, bool lastframe, uint32_t maskingKey = 0);
+    static std::string makeFrame(int opcode, const std::string &payload, bool lastframe, uint32_t maskingKey = 0);
 
     enum OpCode
     {
@@ -113,7 +113,7 @@ private:
     int state;
 
     int closeCode;
-    string closeReason;
+    std::string closeReason;
     bool finalFrame;
     uint32_t mask;
     int rsv1;
@@ -123,7 +123,7 @@ private:
     bool maskbit;
 
     uint64_t payload_length;
-    string payload;
+    std::string payload;
 
     bool isvalid;
     bool haserror;

--- a/src/lib/sigc_fix_functor.h
+++ b/src/lib/sigc_fix_functor.h
@@ -13,7 +13,7 @@ namespace sigc
 {
 
 template <typename Functor>
-struct functor_trait<Functor, false>
+struct functor_trait<Functor, false, false>
 {
     typedef decltype (::sigc::mem_fun (std::declval<Functor&> (),
                                        &Functor::operator())) _intermediate;

--- a/src/lib/tcpsocket.cpp
+++ b/src/lib/tcpsocket.cpp
@@ -293,7 +293,7 @@ int TCPSocket::Recv(void *Buffer, int nLength, bool block)
     return Bytes_Recv;
 }
 
-bool TCPSocket::Recv(string & Message, int timeout, int fdpipe)
+bool TCPSocket::Recv(std::string & Message, int timeout, int fdpipe)
 {
     char buf[4096];
     int ret;
@@ -573,9 +573,9 @@ std::string TCPSocket::GetLocalIP(std::string intf)
 }
 
 #define SYSCLASSNET     "/sys/class/net"
-vector<string> TCPSocket::getAllInterfaces()
+std::vector<std::string> TCPSocket::getAllInterfaces()
 {
-    vector<string> ret;
+    std::vector<std::string> ret;
     Eina_Iterator *it = eina_file_ls(SYSCLASSNET);
 
     const char *f_name;
@@ -591,7 +591,7 @@ vector<string> TCPSocket::getAllInterfaces()
 
 std::string TCPSocket::GetLocalIPFor(std::string ip_search)
 {
-    string ip;
+    std::string ip;
 
     //check if the string is a correct ip address
     struct sockaddr_in sa;
@@ -600,7 +600,7 @@ std::string TCPSocket::GetLocalIPFor(std::string ip_search)
     {
         cWarningDom("network") << ip_search << " is not a valid ip address";
         //Get the first interface ip address
-        vector<string> intf = TCPSocket::getAllInterfaces();
+        std::vector<std::string> intf = TCPSocket::getAllInterfaces();
         if (intf.size() > 0)
         {
             ip = TCPSocket::GetLocalIP(intf[0]);

--- a/src/lib/tcpsocket.h
+++ b/src/lib/tcpsocket.h
@@ -94,7 +94,7 @@ public:
     void SetReuse();
 
     static std::string GetLocalIP(std::string intf = "eth0");
-    static vector<string> getAllInterfaces();
+    static std::vector<std::string> getAllInterfaces();
     static std::string GetLocalIPFor(std::string ip);
     static bool GetMacAddr(std::string intf, unsigned char *mac);
 

--- a/src/lib/threadManager.cpp
+++ b/src/lib/threadManager.cpp
@@ -30,9 +30,9 @@ ThreadManager::~ThreadManager()
 {
     if(threads.size()!=0)
     {
-        string s;
+        std::string s;
 
-        vector<CThread* >::iterator iter;
+        std::vector<CThread* >::iterator iter;
         for (iter = threads.begin();iter!=threads.end();iter++)
             s+=Utils::to_string(*iter)+", ";
 
@@ -55,11 +55,11 @@ void ThreadManager::add(CThread* t)
     cInfoDom("threads") << "Add new thread : " << t;
 }
 
-void ThreadManager::deleteThread(string source, string s, void* listener_data, void* t)
+void ThreadManager::deleteThread(std::string source, std::string s, void* listener_data, void* t)
 {
     CThread* c = (CThread*) t;
 
-    vector<CThread* >::iterator iter;
+    std::vector<CThread* >::iterator iter;
     for (iter = threads.begin();iter!=threads.end();iter++)
     {
         if (*iter == t) break;

--- a/src/lib/threadManager.h
+++ b/src/lib/threadManager.h
@@ -25,19 +25,18 @@
 #include <CThread.h>
 #include <IPC.h>
 
-using namespace std;
 
 class ThreadManager
 {
 private:
-    vector<CThread*> threads;
-    sigc::signal<void, string, string, void*, void*> signal;
+    std::vector<CThread*> threads;
+    sigc::signal<void, std::string, std::string, void*, void*> signal;
     sigc::connection conn;
 
 public:
     static ThreadManager& Instance();
     ThreadManager();
-    void deleteThread(string source, string s, void*, void*);
+    void deleteThread(std::string source, std::string s, void*, void*);
     ~ThreadManager();
     void add(CThread *c);
 

--- a/src/widgets/clock/module.cpp
+++ b/src/widgets/clock/module.cpp
@@ -36,10 +36,10 @@ EAPI CalaosModuleApi calaos_modapi =
     constructor
 };
 
-ModuleClock::ModuleClock(Evas *_e, string _id, string _path):
+ModuleClock::ModuleClock(Evas *_e, std::string _id, std::string _path):
     CalaosModuleBase(_e, _id, _path)
 {
-    string theme = module_path + "/default.edj";
+    std::string theme = module_path + "/default.edj";
     edje_clock = new EdjeObject(theme, evas);
     edje_clock->LoadEdje("widget/clock");
 }
@@ -49,20 +49,20 @@ ModuleClock::~ModuleClock()
     delete edje_clock;
 }
 
-string ModuleClock::getStringInfo()
+std::string ModuleClock::getStringInfo()
 {
     Calendar c;
 
     //hour
-    string heure = c.hoursToString() + ":" + c.minutesToString() + ":" + c.secondesToString();
+    std::string heure = c.hoursToString() + ":" + c.minutesToString() + ":" + c.secondesToString();
 
     //date
-    string date = c.getDayFromDate() + " " + Utils::to_string(c.day) + " " +
+    std::string date = c.getDayFromDate() + " " + Utils::to_string(c.day) + " " +
                   c.getMonthFromDate() + " " + Utils::to_string(c.year);
 
     //timezone
     int tid = c.timeZone.loadCurrentTimeZone();
-    string tzone;
+    std::string tzone;
     if (tid > 0)
     {
         tzone = c.timeZone.timeZone[tid].decalageStr;

--- a/src/widgets/clock/module.h
+++ b/src/widgets/clock/module.h
@@ -21,12 +21,12 @@
 #ifndef CALAOS_MODULE_H
 #define CALAOS_MODULE_H
 
+#include "ApplicationMain.h"
 #include "CalaosModule.h"
 #include "Utils.h"
 #include "EdjeObject.h"
 #include "Calendar.h"
 #include <Ecore_File.h>
-#include "ApplicationMain.h"
 
 class ModuleClock: public CalaosModuleBase
 {
@@ -35,11 +35,11 @@ private:
     Calendar *calendar;
 
 public:
-    ModuleClock(Evas *evas, string id, string module_path);
+    ModuleClock(Evas *evas, std::string id, std::string module_path);
 
     virtual ~ModuleClock();
 
-    virtual string getStringInfo();
+    virtual std::string getStringInfo();
 
     virtual void getSizeMin(int &w, int &h);
     virtual void getSizeMax(int &w, int &h);

--- a/src/widgets/note/module.cpp
+++ b/src/widgets/note/module.cpp
@@ -36,14 +36,14 @@ EAPI CalaosModuleApi calaos_modapi =
     constructor
 };
 
-ModuleNote::ModuleNote(Evas *_e, string _id, string _path):
+ModuleNote::ModuleNote(Evas *_e, std::string _id, std::string _path):
     CalaosModuleBase(_e, _id, _path)
 {
-    string theme = module_path + "/default.edj";
+    std::string theme = module_path + "/default.edj";
     edje = new EdjeObject(theme, evas);
     edje->LoadEdje("widget/note");
 
-    string path = MODULE_CONFIG_PATH;
+    std::string path = MODULE_CONFIG_PATH;
     path += "widget_note/";
     ecore_file_mkpath(path.c_str());
 
@@ -55,7 +55,7 @@ ModuleNote::ModuleNote(Evas *_e, string _id, string _path):
 
         if (file)
         {
-            stringstream buf;
+            std::stringstream buf;
             buf << file.rdbuf();
             file.close();
             text = buf.str();
@@ -72,7 +72,7 @@ ModuleNote::~ModuleNote()
     delete edje;
 }
 
-void ModuleNote::EdjeCallback(void *data, Evas_Object *edje_object, string emission, string source)
+void ModuleNote::EdjeCallback(void *data, Evas_Object *edje_object, std::string emission, std::string source)
 {
     cDebug() << "Show keyboard";
     ApplicationMain::Instance().ShowKeyboard(_("You can now write the new note to display."),
@@ -82,12 +82,12 @@ void ModuleNote::EdjeCallback(void *data, Evas_Object *edje_object, string emiss
                                              1);
 }
 
-void ModuleNote::KeyboardCb(string t)
+void ModuleNote::KeyboardCb(std::string t)
 {
     text = t;
     edje->setPartText("note.text", text);
 
-    string path = MODULE_CONFIG_PATH;
+    std::string path = MODULE_CONFIG_PATH;
     path += "widget_note/";
     path += id;
     std::ofstream file(path.c_str());
@@ -99,7 +99,7 @@ void ModuleNote::KeyboardCb(string t)
     }
 }
 
-string ModuleNote::getStringInfo()
+std::string ModuleNote::getStringInfo()
 {
     return text;
 }

--- a/src/widgets/note/module.h
+++ b/src/widgets/note/module.h
@@ -21,26 +21,26 @@
 #ifndef CALAOS_MODULE_H
 #define CALAOS_MODULE_H
 
+#include <ApplicationMain.h>
 #include <CalaosModule.h>
 #include <Utils.h>
 #include <EdjeObject.h>
 #include <Ecore_File.h>
-#include <ApplicationMain.h>
 
 class ModuleNote: public CalaosModuleBase
 {
     private:
         EdjeObject *edje;
-        string text;
+        std::string text;
 
-        void KeyboardCb(string text);
+        void KeyboardCb(std::string text);
 
     public:
-        ModuleNote(Evas *evas, string id, string module_path);
+        ModuleNote(Evas *evas, std::string id, std::string module_path);
 
         virtual ~ModuleNote();
 
-        virtual string getStringInfo();
+        virtual std::string getStringInfo();
 
         virtual void getSizeMin(int &w, int &h);
         virtual void getSizeMax(int &w, int &h);


### PR DESCRIPTION
Removes all using namespace directives which are harmful for readability and are liable for name clashes.

Since the using namespace directives were in headers, this meant the using directives were leaking types to global namespace for all translation units.
