### PR TITLE
Dev/naguirre/influxdb

### DIFF
--- a/src/bin/calaos_server/DataLogger.cpp
+++ b/src/bin/calaos_server/DataLogger.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- **  Copyright (c) 2006-2018, Calaos. All Rights Reserved.
+ **  Copyright (c) 2006-2019, Calaos. All Rights Reserved.
  **
  **  This file is part of Calaos.
  **
@@ -18,159 +18,81 @@
  **  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  **
  ******************************************************************************/
+#include <chrono>
 #include <DataLogger.h>
 #include <IOBase.h>
+#include <Utils.h>
+#include "UrlDownloader.h"
 
 using namespace Calaos;
-
-typedef struct _Calaos_DataLogger_Mean Calaos_DataLogger_Mean;
-typedef struct _Calaos_DataLogger_Values Calaos_DataLogger_Values;
-typedef struct _Calaos_DataLogger_List Calaos_DataLogger_List;
-
-struct _Calaos_DataLogger_Mean
-{
-    double mean;
-
-};
-
-struct _Calaos_DataLogger_Values
-{
-    time_t timestamp;
-    double value;
-
-};
-
-struct _Calaos_DataLogger_List
-{
-//    Eina_List *list;
-};
-
-//Eet_Data_Descriptor *calaos_datalogger_values_eed;
-//Eet_Data_Descriptor *calaos_datalogger_list_edd;
-//Eet_Data_Descriptor *calaos_datalogger_mean_edd;
-
-#define CALAOS_EET_DATALOGGER_FILE "datalogger.eet"
-
-//static void
-//_hash_values_free_cb(void *data)
-//{
-//    free(data);
-//}
 
 
 DataLogger::DataLogger()
 {
-//    string db_file = getCacheFile(CALAOS_EET_DATALOGGER_FILE);
+    if (Utils::get_config_option("influxdb_enabled") == "true")
+        m_enable = true;
+    else
+        m_enable = false;
+    
+    cInfoDom("datalogger") << "DataLogger is " << (m_enable ? "enabled" : "disabled");
 
-//    eet_init();
-//    initEetDescriptors();
+    if (m_enable)
+    { 
+        m_influxdb_host = Utils::get_config_option("influxdb_host");
+        if (m_influxdb_host == "")
+            m_influxdb_host = "127.0.0.1";
 
-//    ef = eet_open(db_file.c_str(), EET_FILE_MODE_READ_WRITE);
+        uint16_t influxdb_port = 0;
+        Utils::from_string(Utils::get_config_option("influxdb_port"), influxdb_port);
+        if (m_influxdb_port == 0)
+            m_influxdb_port = 8086;
 
-//    hash_values = eina_hash_string_superfast_new(_hash_values_free_cb);
+        m_influxdb_database = Utils::get_config_option("influxdb_database");
+        if (m_influxdb_database == "")
+            m_influxdb_database = "calaos";
+
+
+        cInfoDom("datalogger") << "Create database  " << m_influxdb_database << " on host " << m_influxdb_host;
+
+        string url = "http://" + m_influxdb_host + ":" + Utils::to_string(m_influxdb_port) + "/query";
+        UrlDownloader *query = new UrlDownloader(url, true);
+        string postData = "q=CREATE DATABASE " + m_influxdb_database;
+        query->httpPost(string(), postData);
+
+        m_influxdb_log_timeout = 0;
+    
+        Utils::from_string(Utils::get_config_option("influxdb_log_timeout"), m_influxdb_log_timeout);
+        if (!m_influxdb_log_timeout)
+            m_influxdb_log_timeout = 300; // log if nothing happend in last 5 minutes
+        
+    }
 }
 
 DataLogger::~DataLogger()
-{
-//    eet_close(ef);
-//    releaseEetDescriptors();
-//    eet_shutdown();
-}
-
-void DataLogger::initEetDescriptors()
-{
-//    Eet_Data_Descriptor_Class eddc;
-//    Eet_Data_Descriptor *edd;
-
-
-//    /* Data Descriptor for mean values */
-//    EET_EINA_FILE_DATA_DESCRIPTOR_CLASS_SET(&eddc, Calaos_DataLogger_Mean);
-//    edd = eet_data_descriptor_stream_new(&eddc);
-
-//    EET_DATA_DESCRIPTOR_ADD_BASIC(edd, Calaos_DataLogger_Mean, "mean", mean, EET_T_DOUBLE);
-
-//    calaos_datalogger_mean_edd = edd;
-
-//    /* Data Descriptor for time/value */
-//    EET_EINA_FILE_DATA_DESCRIPTOR_CLASS_SET(&eddc, Calaos_DataLogger_Values);
-//    edd = eet_data_descriptor_stream_new(&eddc);
-
-//    EET_DATA_DESCRIPTOR_ADD_BASIC(edd, Calaos_DataLogger_Values, "timestamp", timestamp, EET_T_INT);
-//    EET_DATA_DESCRIPTOR_ADD_BASIC(edd, Calaos_DataLogger_Values, "value", value, EET_T_DOUBLE);
-
-//    calaos_datalogger_values_eed = edd;
-
-//    /* Data Descriptor for list of values */
-//    EET_EINA_FILE_DATA_DESCRIPTOR_CLASS_SET(&eddc, Calaos_DataLogger_List);
-//    edd = eet_data_descriptor_stream_new(&eddc);
-
-//    EET_DATA_DESCRIPTOR_ADD_LIST(edd, Calaos_DataLogger_List, "list", list, calaos_datalogger_values_eed);
-
-//    calaos_datalogger_list_edd = edd;
-}
-
-void DataLogger::releaseEetDescriptors()
 {
 
 }
 
 void DataLogger::log(IOBase *io)
 {
-//    char section[1024];
-//    Calaos_DataLogger_List *list;
-//    Calaos_DataLogger_Values *value;
-//    Calaos_DataLogger_Mean *mean;
-//    struct tm *ctime = NULL;
+    if (!m_enable)
+        return;
 
-//    tzset(); //Force reload of timezone data
-//    time_t t = time(NULL);
-//    ctime = localtime(&t);
+    if (io->get_param("logged") != "true")
+       return;
 
-//    // return immediatly if logged is not active for this IO
-//    if (io->get_param("logged") != "true")
-//        return;
-
-//    snprintf(section, sizeof(section), "calaos/sonde/%s/%d/%d/%d/%d/values", io->get_param("id").c_str(), ctime->tm_year + 1900, ctime->tm_mon + 1, ctime->tm_mday, ctime->tm_hour);
-
-//    //TODO if month or year changed since last write remove list from hash to save ram
-
-//    // Find the section in memory first
-//    list = (Calaos_DataLogger_List*)eina_hash_find(hash_values, section);
-//    // Then try to find it from disk
-//    if (!list)
-//    {
-//        list = (Calaos_DataLogger_List*)eet_data_read(ef, calaos_datalogger_values_eed, section);
-
-//        // And create an empty list if it's the first time we need it
-//        if (!list)
-//            list = (Calaos_DataLogger_List*)calloc(1, sizeof(Calaos_DataLogger_List));
-//        eina_hash_add(hash_values, section, list);
-//    }
-
-//    value = (Calaos_DataLogger_Values*)calloc(1, sizeof(Calaos_DataLogger_Values));
 //    value->timestamp = time(NULL);
-//    value->value = io->get_value_double();
+    double value = io->get_value_double();
+    cInfoDom("datalogger") << "Log value " << value;
 
-//    list->list = eina_list_append(list->list, value);
-//    eet_data_write(ef, calaos_datalogger_list_edd, section, list, EINA_TRUE);
+    string url = "http://" + m_influxdb_host + ":" + Utils::to_string(m_influxdb_port) + "/write?db=" + m_influxdb_database;
+    UrlDownloader *query = new UrlDownloader(url, true);
+    
+    stringstream postData;
+    uint64_t now = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    postData <<  "calaos " << Utils::escape_space(io->get_param("name")) << "=" << io->get_value_double()  << " " << now;
+    cInfoDom("datalogger") << "send value " << postData.str();
 
-//    // Mean Value for month
-//    snprintf(section, sizeof(section), "calaos/sonde/%s/%d/%d/mean", io->get_param("id").c_str(), ctime->tm_year + 1900, ctime->tm_mon + 1);
-//    mean = (Calaos_DataLogger_Mean*)eina_hash_find(hash_values, section);
-//    if (!mean)
-//    {
-//        mean = (Calaos_DataLogger_Mean*)calloc(1, sizeof(Calaos_DataLogger_Mean));
-//        eina_hash_add(hash_values, section, mean);
-//    }
+    query->httpPost(string(), postData.str());
 
-//    for (uint32_t i = 0; i < eina_list_count(list->list); i++)
-//    {
-//        Calaos_DataLogger_Values *v = (Calaos_DataLogger_Values*)eina_list_nth(list->list, i);
-//        mean->mean += v->value;
-//    }
-//    mean->mean /= eina_list_count(list->list);
-
-//    eet_data_write(ef, calaos_datalogger_mean_edd, section, mean, EINA_TRUE);
-
-//    eet_sync(ef);
 }

--- a/src/bin/calaos_server/DataLogger.cpp
+++ b/src/bin/calaos_server/DataLogger.cpp
@@ -67,12 +67,29 @@ DataLogger::DataLogger()
         if (!m_influxdb_log_timeout)
             m_influxdb_log_timeout = 300; // log if nothing happend in last 5 minutes
         
+        logAll();
+
+        timer = new Timer(m_influxdb_log_timeout, [=]() {
+            logAll();
+        });
     }
 }
 
 DataLogger::~DataLogger()
 {
+    delete timer;
+}
 
+void DataLogger::logAll()
+{
+    for (int i = 0; i < ListeRoom::Instance().size(); i++)
+    {
+        Room *room = ListeRoom::Instance().get_room(i);
+        for (int j = 0; j < room->get_size(); j++)
+        {
+            log(room->get_io(j));
+        }
+    }
 }
 
 void DataLogger::log(IOBase *io)

--- a/src/bin/calaos_server/DataLogger.h
+++ b/src/bin/calaos_server/DataLogger.h
@@ -22,8 +22,7 @@
 #define __DATA_LOGGER_H
 
 #include <IOBase.h>
-
-/* DISABLED, need to be rewritten once */
+#include "Timer.h"
 
 namespace Calaos
 {
@@ -37,6 +36,9 @@ private:
     uint16_t m_influxdb_port;
     string m_influxdb_database;
     int m_influxdb_log_timeout;
+    Timer *timer;
+
+    void logAll();
 
 public:
     static DataLogger &Instance()

--- a/src/bin/calaos_server/DataLogger.h
+++ b/src/bin/calaos_server/DataLogger.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- **  Copyright (c) 2006-2018, Calaos. All Rights Reserved.
+ **  Copyright (c) 2006-2019, Calaos. All Rights Reserved.
  **
  **  This file is part of Calaos.
  **
@@ -32,11 +32,12 @@ class DataLogger
 {
 private:
     DataLogger();
+    bool m_enable = false;
+    string m_influxdb_host;
+    uint16_t m_influxdb_port;
+    string m_influxdb_database;
+    int m_influxdb_log_timeout;
 
-    void initEetDescriptors();
-    void releaseEetDescriptors();
-//    Eet_File *ef;
-//    Eina_Hash *hash_values;
 public:
     static DataLogger &Instance()
     {

--- a/src/bin/calaos_server/IOBase.cpp
+++ b/src/bin/calaos_server/IOBase.cpp
@@ -38,6 +38,7 @@ IOBase::IOBase(Params &p, int iotype):
     ioDoc->paramAdd("gui_type", _("Internal graphical type for all calaos objects. Set automatically, read-only parameter."), IODoc::TYPE_STRING, false, string(), true);
     ioDoc->paramAdd("io_type", _("IO type, can be \"input\", \"output\", \"inout\""), IODoc::TYPE_STRING, true, string(), true);
     ioDoc->paramAdd("log_history", _("If enabled, write an entry in the history event log for this IO"), IODoc::TYPE_BOOL, false, "false");
+    ioDoc->paramAdd("logged", _("If enabled, and if influxdb is enabled in local_config send the value to influxdb for this IO"), IODoc::TYPE_BOOL, false, "false");
 
     if (!param.Exists("enabled"))
         param.Add("enabled", "true");

--- a/src/bin/calaos_server/main.cpp
+++ b/src/bin/calaos_server/main.cpp
@@ -32,7 +32,7 @@
 #include "Prefix.h"
 #include "Audio/AVRManager.h"
 #include "HistLogger.h"
-
+#include "DataLogger.h"
 #include "libuvw.h"
 
 using namespace Calaos;
@@ -126,6 +126,8 @@ int main (int argc, char **argv)
 
     Config::Instance().LoadConfigIO();
     Config::Instance().LoadConfigRule();
+
+    DataLogger::Instance();
 
     bool enable_udp = true;
     if (argvOptionCheck(argv, argv + argc, "-noudp"))

--- a/src/lib/Utils.cpp
+++ b/src/lib/Utils.cpp
@@ -864,6 +864,35 @@ string Utils::escape_quotes(const string &s)
     return after;
 }
 
+string Utils::escape_space(const string &s)
+{
+   
+    int count = 0;
+
+    for (string::size_type i = 0; i < s.length(); i++)
+    {
+        if (isspace(s[i]))
+            count ++;
+    }
+
+    string ret;
+    ret.reserve(s.length() + count);
+
+    for (string::size_type i = 0; i < s.length(); i++)
+    {
+        switch (s[i])
+        {
+            case ' ':
+                ret += '\\';
+                // Fall through.
+            default:
+                ret += s[i];
+        }
+    }
+
+    return ret;
+}
+
 CStrArray::CStrArray(const string &str_split)
 {
     Utils::split(str_split, m_strings, " ");

--- a/src/lib/Utils.h
+++ b/src/lib/Utils.h
@@ -222,6 +222,7 @@ void trim_right(std::string &source, const std::string &t);
 void trim_left(std::string &source, const std::string &t);
 string trim(const string &str);
 string escape_quotes(const string &s);
+string escape_space(const string &s);
 
 enum CaseSensitivity { CaseInsensitive, CaseSensitive };
 bool strContains(const string &str, const string &needle, Utils::CaseSensitivity cs = Utils::CaseSensitive);


### PR DESCRIPTION
This PR add support for influxdb data logging into calaos_server.
  
# What's needed 
One instance of Influxdb up and running at IP:PORT

# Configure Calaos_server
Configuration is located in local_config.xml

```sh
calaos_config set influxdb_host 127.0.0.1
calaos_config set influxdb_port 8086
calaos_config set influxdb_database calaos
calaos_config set influxdb_enabled true
calaos_config set influxdb_log_timeout 300
```

# Configure IO
Enabling IO logging is done in configuration per IO, by adding
```logged=true``` in io.xml file

Example of configuration : 
```xml
<calaos:input enabled="true" gui_type="temp"  id="io_3" io_type="input" logged="true" name="T°" visible="true"  ...../>
```
# Behaviour
At calaos_server startup, the database influxdb_database is created if it doesn't exists.
Each time an IO with logged=true configuration changed, value is send to influxdb host.
At startup and after a timeout of ``` influxdb_log_timeout```seconds expires, all data marked as logged_true are send to influxdb host.

Schema used for influxdb logging is the following :

```
IOName,room=ROOM value=XX TIMESTAMP
```
Once data are insterted in influxdb database, they can be retrieve by using requests : 
```
curl -G 'http://127.0.0.1:8086/query' --data-urlencode "db=calaos" --data-urlencode "q=SELECT \"value\" FROM \"T°\" WHERE \"room\"='livingroom'"
```
