### PR TITLE
Dev/nae/charts

### DIFF
--- a/src/bin/calaos_server/DataLogger.cpp
+++ b/src/bin/calaos_server/DataLogger.cpp
@@ -44,8 +44,7 @@ DataLogger::DataLogger()
         if (m_influxdb_host == "")
             m_influxdb_host = "127.0.0.1";
 
-        uint16_t influxdb_port = 0;
-        Utils::from_string(Utils::get_config_option("influxdb_port"), influxdb_port);
+        Utils::from_string(Utils::get_config_option("influxdb_port"), m_influxdb_port);
         if (m_influxdb_port == 0)
             m_influxdb_port = 8086;
 

--- a/src/bin/calaos_server/DataLogger.h
+++ b/src/bin/calaos_server/DataLogger.h
@@ -48,6 +48,11 @@ public:
     }
     ~DataLogger();
 
+    bool isEnabled() {return m_enable;};
+    string getHost() {return m_influxdb_host;};
+    uint16_t getPort() {return m_influxdb_port;};
+    string getDatabase() {return m_influxdb_database;};
+
     void log(IOBase *io);
 };
 

--- a/src/bin/calaos_server/IO/Mqtt/MqttExternProc_main.cpp
+++ b/src/bin/calaos_server/IO/Mqtt/MqttExternProc_main.cpp
@@ -157,7 +157,6 @@ bool MqttProcess::setup(int &argc, char **&argv)
     string password = "";
     int keepalive = 120;
 
-    cout << "test stdout" << endl;
     cDebugDom("mqtt") << "Mqtt external process";
 
     if (!connectSocket())

--- a/src/bin/calaos_server/JsonApiHandlerHttp.h
+++ b/src/bin/calaos_server/JsonApiHandlerHttp.h
@@ -80,6 +80,8 @@ private:
     void processEventLog();
     void processEventPicture();
     void processRegisterPush();
+    
+    void processDataLogger(json_t *jroot);
 
     void processAudio(json_t *jroot);
     void processAudioDb(json_t *jroot);


### PR DESCRIPTION
Fix bug and bad log + add new HTTP API for charts/datalogger points retrieval.

This api act as a proxy for influxdb database. If datalooger is disable, this api return "success" : "false" otherwise, the content of the `q` key of the json request is send to influxdb.
Influxdb output is then returned as json payload.

Example of json payload (get 1hour of points for  Calaos IO named "Outside Temperature")
```
{ "cn_user": "USERNAME", "cn_pass": "PASSWORD", "action": "datalogger", "q": "SELECT  \"value\" from \"Outside Temperature\" WHERE time >= now() - 1h" }
```

Example of json returned :
```json
{
    "results": [
        {
            "statement_id": 0,
            "series": [
                {
                    "name": "Outside Temperature",
                    "columns": [
                        "time",
                        "value"
                    ],
                    "values": [
                        [
                            "2020-09-19T14:25:30.148879183Z",
                            29.2
                        ],
                        [
                            "2020-09-19T14:30:30.148224696Z",
                            29.2
                        ],
                        [
                            "2020-09-19T14:35:30.146235282Z",
                            29.2
                        ],
                        [
                            "2020-09-19T14:40:30.147027598Z",
                            29.2
                        ],
                        [
                            "2020-09-19T14:45:30.149729178Z",
                            29.2
                        ],
                        [
                            "2020-09-19T14:48:32.524887511Z",
                            29
                        ],
                        [
                            "2020-09-19T14:50:30.147821093Z",
                            29
                        ],
                        [
                            "2020-09-19T14:55:30.148496147Z",
                            29
                        ],
                        [
                            "2020-09-19T15:00:30.150516343Z",
                            29
                        ],
                        [
                            "2020-09-19T15:05:30.150021941Z",
                            29
                        ],
                        [
                            "2020-09-19T15:10:30.150139142Z",
                            29
                        ],
                        [
                            "2020-09-19T15:15:30.152617019Z",
                            29
                        ],
                        [
                            "2020-09-19T15:20:30.153415413Z",
                            29
                        ]
                    ]
                }
            ]
        }
    ]
}
```