### PR TITLE
Adding quotes to the URL so that the request is correctly processed

### DIFF
--- a/src/lib/UrlDownloader.cpp
+++ b/src/lib/UrlDownloader.cpp
@@ -78,7 +78,7 @@ bool UrlDownloader::start()
 
     vector<string> req;
     req.push_back("curl");
-    req.push_back(m_url);
+    req.push_back("\"" + m_url + "\"");
     req.push_back("--silent");
     req.push_back("--insecure");
     req.push_back("--location");
@@ -347,7 +347,6 @@ x-beluga-response-time-x: 0.002 sec
     statusCode = 0;
     std::ifstream infile(tmpHeader);
     string line;
-    bool first = true;
     while (std::getline(infile, line))
     {
         if (Utils::strStartsWith(line, "HTTP/"))


### PR DESCRIPTION
![Capture](https://user-images.githubusercontent.com/60903143/130886186-9676a5f1-8ac2-4a50-a35d-e341c100b343.png)
La requete GET ne passe pas correctement s'il n'y a pas des guillemets à l'URL avec Curl, que ce soit pour le mouvement de la caméra Foscam ou pour openweather