### PR TITLE
set MqttOutputLight brightness between 0 and 254.

### DIFF
--- a/src/bin/calaos_server/IO/Mqtt/MqttOutputLightDimmer.cpp
+++ b/src/bin/calaos_server/IO/Mqtt/MqttOutputLightDimmer.cpp
@@ -55,7 +55,7 @@ MqttOutputLightDimmer::MqttOutputLightDimmer(Params &p):
 void MqttOutputLightDimmer::readValue()
 {
     bool err;
-    auto newValue = ctrl->getValueDouble(get_params(), err) / 2.55;
+    auto newValue = ctrl->getValueDouble(get_params(), err) / 2.54;
 
     if (!err)
     {
@@ -70,6 +70,6 @@ void MqttOutputLightDimmer::readValue()
 bool MqttOutputLightDimmer::set_value_real(int val)
 {
     cDebugDom("mqtt") << "Set value to " << val;
-    ctrl->setValueInt(get_params(), val * 2.55);
+    ctrl->setValueInt(get_params(), val * 2.54);
     return true;
 }

--- a/src/bin/calaos_server/IO/Mqtt/MqttOutputLightDimmer.cpp
+++ b/src/bin/calaos_server/IO/Mqtt/MqttOutputLightDimmer.cpp
@@ -21,7 +21,6 @@
 #include "MqttOutputLightDimmer.h"
 #include "MqttBrokersList.h"
 #include "IOFactory.h"
-#include <AnalogIO.h>
 #include <ExpressionEvaluator.h>
 
 using namespace Calaos;

--- a/src/bin/calaos_server/IO/Mqtt/MqttOutputLightDimmer.cpp
+++ b/src/bin/calaos_server/IO/Mqtt/MqttOutputLightDimmer.cpp
@@ -55,7 +55,7 @@ MqttOutputLightDimmer::MqttOutputLightDimmer(Params &p):
 void MqttOutputLightDimmer::readValue()
 {
     bool err;
-    auto newValue = ctrl->getValueDouble(get_params(), err);
+    auto newValue = ctrl->getValueDouble(get_params(), err) / 2.55;
 
     if (!err)
     {
@@ -70,6 +70,6 @@ void MqttOutputLightDimmer::readValue()
 bool MqttOutputLightDimmer::set_value_real(int val)
 {
     cDebugDom("mqtt") << "Set value to " << val;
-    ctrl->setValueInt(get_params(), val);
+    ctrl->setValueInt(get_params(), val * 2.55);
     return true;
 }

--- a/src/bin/calaos_server/IO/Mqtt/MqttOutputLightDimmer.h
+++ b/src/bin/calaos_server/IO/Mqtt/MqttOutputLightDimmer.h
@@ -38,6 +38,7 @@ protected:
 
 public:
     MqttOutputLightDimmer(Params &p);
+    double convertValue(const Params &params, string direction, double dvalue);
 };
 
 }


### PR DESCRIPTION
In zigbee2mqtt the brightness of a light bulb is between 0 and 254. Here, for example: https://www.zigbee2mqtt.io/devices/LED1623G12.html#light
This PR transforms the value coming from Calaos, which is in percent, into a brightness. 